### PR TITLE
ci(release): open Release PR with org App token, not GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,13 @@ name: Release
 # Publishes @toon-protocol/core and @toon-protocol/sdk to npm via changesets.
 # Auth comes from the org-level NPM_TOKEN secret (no local `npm login`).
 # changesets rewrites `workspace:*` -> the real version at publish time.
+#
+# The Release PR is opened with the org GitHub App token (APP_ID/APP_PRIVATE_KEY),
+# NOT the default GITHUB_TOKEN: the org forbids GitHub Actions from creating PRs
+# ("GitHub Actions is not permitted to create or approve pull requests"), and that
+# policy can't be overridden per-repo. An App is a distinct actor, so its PRs are
+# exempt. If the App isn't installed the token step is skipped and we fall back to
+# GITHUB_TOKEN (publish still works; only the Release-PR step would be blocked).
 
 on:
   push:
@@ -17,6 +24,14 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        continue-on-error: true # App not installed -> fall back to GITHUB_TOKEN
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -41,5 +56,5 @@ jobs:
           version: pnpm changeset version
           publish: pnpm changeset publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Problem

The `Release` workflow uses `changesets/action`, which opens a "Version Packages" PR with the default `GITHUB_TOKEN`. The org has **"Allow GitHub Actions to create and approve pull requests"** disabled, so this fails with:

> GitHub Actions is not permitted to create or approve pull requests.

The policy is enforced org-wide and cannot be overridden per-repo; the workflow's `pull-requests: write` grant is not sufficient. This already broke `toon`'s release (toon-protocol/toon#27); this repo has the identical workflow and will fail the same way on its next pending changeset.

## Fix

Mint the org **GitHub App token** (`APP_ID`/`APP_PRIVATE_KEY`) and pass it to `changesets/action` as `GITHUB_TOKEN` — the same pattern the org's decomposer/executor loops use. A GitHub App is a distinct actor, so its PRs are not subject to the Actions PR-creation policy.

`continue-on-error: true` on the token step preserves a `GITHUB_TOKEN` fallback so the publish path still works if the App is ever uninstalled.

No org-admin change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)