### PR TITLE
chore(meta): scrub residual mill/town old names (#42)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,4 +25,4 @@ Canonical rules/decisions: `toon-meta` → `_bmad-output/project-context.md`.
 - Image-publish workflow (the `swap` Docker image) is a follow-up.
 
 ## Publishing
-CI publishes via **changesets + `pnpm`** using the org `NPM_TOKEN` secret. **Never run `npm publish`**. This will be `mill`'s first-ever npm publish.
+CI publishes via **changesets + `pnpm`** using the org `NPM_TOKEN` secret. **Never run `npm publish`**. This will be `swap`'s first-ever npm publish.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # swap
 
-TOON Protocol multi-chain swap node — @toon-protocol/swap (issues signed target-chain payment-channel claims; EVM/Solana/Mina). NB: npm package keeps the name @toon-protocol/swap this pass; mill->swap package rename is a follow-up.
+TOON Protocol multi-chain swap node — @toon-protocol/swap (issues signed target-chain payment-channel claims; EVM/Solana/Mina).
 
 > Extracted from the TOON monorepo with full git history preserved. npm publishing is done by CI (changesets + `pnpm`, authed by the org `NPM_TOKEN` secret). Docker image-publish workflows (where applicable) are a follow-up carved from the monorepo `publish-townhouse-images.yml`.

--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -1,6 +1,6 @@
 # @toon-protocol/swap
 
-TOON Mill — multi-chain payment-channel claim issuer for the Token Swap Primitive (Epic 12).
+TOON Swap — multi-chain payment-channel claim issuer for the Token Swap Primitive (Epic 12).
 
 ## Integration Tests
 

--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toon-protocol/swap",
   "version": "0.1.0",
-  "description": "TOON Mill — multi-chain payment-channel claim issuer for the Token Swap Primitive (Epic 12)",
+  "description": "TOON Swap — multi-chain payment-channel claim issuer for the Token Swap Primitive (Epic 12)",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -35,15 +35,14 @@
     "toon",
     "nostr",
     "ilp",
-    "mill",
     "swap",
     "payment-channel"
   ],
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/toon-protocol/town.git",
-    "directory": "packages/mill"
+    "url": "https://github.com/toon-protocol/swap.git",
+    "directory": "packages/swap"
   },
   "author": "ALLiDoizCode",
   "engines": {


### PR DESCRIPTION
Part of dependency-alignment epic toon-protocol/toon-meta#42.

The published package name is already correct (\`@toon-protocol/swap\`); this PR scrubs the residual pre-rename \`mill\`/\`town\` metadata.

## Changes
- **packages/swap/package.json**
  - \`description\`: "TOON Mill …" → "TOON Swap …"
  - \`keywords\`: removed stale \`"mill"\` (\`"swap"\` already present)
  - \`repository.url\`: \`github.com/toon-protocol/town.git\` → \`…/swap.git\`
  - \`repository.directory\`: \`packages/mill\` → \`packages/swap\`
- **README.md**: dropped the stale "mill->swap package rename is a follow-up" note (the rename is done)
- **CLAUDE.md**: "This will be \`mill\`'s first-ever npm publish" → "\`swap\`'s"

## Out of scope (intentionally untouched)
- **No dependency version ranges changed** (minimal-version policy for this epic).
- Internal \`Mill*\` code symbols (\`startMill\`, \`MillInventory\`, \`millSignerAddress\`), ILP addresses (\`g.toon.mill.*\`), logger event names, and test fixtures — CLAUDE.md flags these as optional further cleanup; changing them is behavioral, not metadata.
- \`pet-dvm\`/\`pet-circuit\` script refs (out of scope per epic).
- \`townhouse-*\` references (separate product name / historical monorepo workflow filenames, not the mill→swap rename).

JSON validity verified with \`node -e "require(...)"\`. Metadata-only; no build needed.