### PR TITLE
chore: clean stale relay-era root package.json metadata (#42)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,19 +2,16 @@
   "name": "swap",
   "version": "0.3.0",
   "private": true,
-  "description": "ILP-gated Nostr relay. Pay to write, free to read.",
+  "description": "TOON Protocol multi-chain swap node — EVM/Solana/Mina signed payment-channel claim issuer",
   "type": "module",
   "scripts": {
     "build": "pnpm -r run build",
     "test": "vitest run",
-    "test:jest": "pnpm --filter @toon-protocol/pet-dvm test",
-    "test:zk": "pnpm --filter @toon-protocol/pet-circuit test",
-    "test:all": "vitest run && pnpm test:jest",
+    "test:all": "vitest run",
     "test:coverage": "vitest --coverage",
     "lint": "eslint .",
     "format": "prettier --write \"packages/*/src/**/*.ts\"",
     "format:check": "prettier --check \"packages/*/src/**/*.ts\"",
-    "demo:ilp-gated-relay": "tsx packages/examples/src/ilp-gated-relay-demo/index.ts",
     "changeset": "changeset",
     "version": "changeset version",
     "release": "changeset publish"
@@ -25,9 +22,7 @@
     "ilp",
     "toon",
     "payment",
-    "agent",
-    "nip-02",
-    "social-graph"
+    "agent"
   ],
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Finishes the swap metadata cleanup begun in #26 (which fixed `packages/swap`). This handles the **root** `package.json`:

- `description` "ILP-gated Nostr relay" → swap-node description (#2)
- remove dead scripts `test:jest`/`test:zk` (reference non-existent `@toon-protocol/pet-dvm`/`pet-circuit`) and `demo:ilp-gated-relay` (missing `packages/examples`); simplify `test:all` → `vitest run` (#2)
- remove relay-social keywords `nip-02`/`social-graph` (#21)

No dependency or source changes. Closes #21 and #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)