### PR TITLE
Rolling swap prereq: persist mill state (inventory, channel watermarks, replay reservations)

### DIFF
--- a/.changeset/pretty-moles-persist.md
+++ b/.changeset/pretty-moles-persist.md
@@ -1,0 +1,5 @@
+---
+'@toon-protocol/swap': minor
+---
+
+Persist swap node state across restarts (issue #46, rolling-swap prerequisite P2): inventory, channel nonce/cumulative watermarks, sticky sender→channel bindings, and replay reservations survive a crash or restart. New `SwapNodeConfig.statePath` / `stateStore` (CLI: `statePath`, env `SWAP_STATE_PATH`) enables a JSON-file snapshot written atomically (temp file + fsync + rename) with write-ahead ordering: the watermark is persisted BEFORE a signed claim can leave the process, so a handed-out claim is never ahead of the stored watermark. `startSwapNode` rehydrates the snapshot at boot (persisted values win over config notionals; corrupt snapshots fail boot loudly with `STATE_LOAD_FAILED` instead of silently resetting watermarks). Adds `JsonFileSwapStateStore`, `SwapStatePersister`, `PersistentSeenPacketIds`, `SwapChannelState.snapshot()`/binding rehydration, and `MultiChainClaimIssuer.persistState` (write-ahead failure → `PERSISTENCE_FAILED`, claim refused, state rolled back). Without `statePath`/`stateStore` the swap node runs in-memory exactly as before.

--- a/packages/swap/src/channel-state.ts
+++ b/packages/swap/src/channel-state.ts
@@ -15,7 +15,12 @@
  * senders with distinct pubkeys bind to distinct channels as long as
  * ≥2 channels were provisioned for that `(asset, chain)` (AC-7).
  *
- * In-memory only; persistence is Story 12.9's concern.
+ * State is held in memory for microtask-atomic `reserve`/`release`;
+ * durability is provided by `SwapStatePersister` (`state-store.ts`, issue
+ * #46): `snapshot()` exports channels + bindings, and the constructor's
+ * `init.channels` / `init.bindings` rehydrate them on restart so nonce and
+ * cumulativeAmount watermarks continue monotonically across process
+ * boundaries.
  */
 
 import { SwapWalletError } from './errors.js';
@@ -36,6 +41,15 @@ export interface SwapChannelStateInit {
   clock?: () => number;
   /** Optional logger — `release` emits `warn` when a no-op reversal would drive nonce/cumulative negative (AC-7). */
   logger?: ReleaseLogger;
+  /**
+   * Issue #46 — rehydrated sticky sender→channel bindings
+   * (`${assetCode}:${chain}:${senderPubkey}` → stored channel key), as
+   * previously exported by {@link SwapChannelState.snapshot}. Bindings whose
+   * target channel key is absent from `channels` are dropped (a dangling
+   * binding would otherwise pin its sender to a channel that no longer
+   * exists, failing every subsequent `reserve()`).
+   */
+  bindings?: Record<string, string>;
 }
 
 export interface ReserveParams {
@@ -83,6 +97,13 @@ export class SwapChannelState {
     if (init) {
       for (const [k, v] of Object.entries(init.channels)) {
         this.channels.set(k, { ...v });
+      }
+      if (init.bindings) {
+        for (const [bk, storedKey] of Object.entries(init.bindings)) {
+          if (!this.channels.has(storedKey)) continue; // drop dangling binding
+          this.senderBinding.set(bk, storedKey);
+          this.boundChannels.add(storedKey);
+        }
       }
     }
   }
@@ -218,6 +239,25 @@ export class SwapChannelState {
    */
   getBindings(): Record<string, string> {
     return Object.fromEntries(this.senderBinding);
+  }
+
+  /**
+   * Issue #46 — export the full channel + binding state for persistence.
+   * Returns deep copies keyed by the internal stored-map keys; feeding the
+   * result back through the constructor (`init.channels` / `init.bindings`)
+   * reproduces this instance's watermarks and sticky bindings exactly.
+   */
+  snapshot(): {
+    channels: Record<string, ChannelEntry>;
+    bindings: Record<string, string>;
+  } {
+    const channels: Record<string, ChannelEntry> = Object.create(
+      null
+    ) as Record<string, ChannelEntry>;
+    for (const [k, v] of this.channels) {
+      channels[k] = { ...v };
+    }
+    return { channels, bindings: this.getBindings() };
   }
 
   /**

--- a/packages/swap/src/claim-issuer.ts
+++ b/packages/swap/src/claim-issuer.ts
@@ -3,8 +3,16 @@
  *
  * Implements the `ClaimIssuer` interface from `@toon-protocol/sdk` (type-only
  * import — no runtime cycle). Flow: debit inventory → reserve channel state
- * → await signer.signBalanceProof → return { claim, claimId }. On signer
- * failure, both inventory and channel state are reversed.
+ * → write-ahead persist (issue #46) → await signer.signBalanceProof →
+ * return { claim, claimId }. On signer failure, both inventory and channel
+ * state are reversed (and the reversal re-persisted, best-effort).
+ *
+ * Issue #46 crash-consistency: when `persistState` is configured, the
+ * post-reserve watermark hits durable storage BEFORE the balance proof is
+ * signed — so no claim a counterparty can ever hold is AHEAD of the stored
+ * watermark. If the write-ahead persist throws, the debit + reservation are
+ * rolled back and the claim is refused (`PERSISTENCE_FAILED` → ILP T00).
+ * See `state-store.ts` for the full recovery rules.
  */
 
 import type {
@@ -85,6 +93,15 @@ export interface MultiChainClaimIssuerConfig {
    * Until then, callers must supply the map explicitly.
    */
   signerAddresses?: Record<string, string>;
+  /**
+   * Issue #46 — synchronous write-ahead persistence hook, wired by
+   * `startSwapNode()` to `SwapStatePersister.persist`. Called (a) after
+   * debit+reserve and BEFORE signing, so the stored watermark is always >=
+   * any handed-out claim, and (b) best-effort after a signer-failure
+   * rollback. When omitted, the issuer behaves exactly as before
+   * (in-memory only).
+   */
+  persistState?: () => void;
 }
 
 export class MultiChainClaimIssuer implements ClaimIssuer {
@@ -94,6 +111,7 @@ export class MultiChainClaimIssuer implements ClaimIssuer {
   private readonly logger?: SwapClaimIssuerLogger;
   private readonly newClaimId: () => string;
   private readonly signerAddresses: Record<string, string>;
+  private readonly persistState?: () => void;
 
   constructor(config: MultiChainClaimIssuerConfig) {
     // Constructor-time config validation uses INVALID_CONFIG so it does not
@@ -123,6 +141,7 @@ export class MultiChainClaimIssuer implements ClaimIssuer {
     this.channelState = config.channelState;
     this.logger = config.logger;
     this.signerAddresses = config.signerAddresses ?? {};
+    if (config.persistState) this.persistState = config.persistState;
     this.newClaimId =
       config.newClaimId ??
       (() => {
@@ -188,6 +207,37 @@ export class MultiChainClaimIssuer implements ClaimIssuer {
       throw err;
     }
 
+    // 3b. Issue #46 — WRITE-AHEAD persist. The reservation (nonce +
+    //     cumulative watermark + inventory debit) MUST be durable before the
+    //     signed claim can leave the process. Synchronous, so no other
+    //     issueClaim can interleave between reserve and persist. On failure:
+    //     roll back debit + reservation and refuse the claim — handing out a
+    //     claim ahead of the stored watermark is the exact desync this
+    //     hook exists to prevent.
+    if (this.persistState) {
+      try {
+        this.persistState();
+      } catch (err) {
+        this.inventory.credit(targetAsset, targetChain, targetAmount);
+        this.channelState.release({
+          assetCode: targetAsset,
+          chain: targetChain,
+          senderPubkey,
+          cumulativeDelta: targetAmount,
+        });
+        this.logger?.error?.('swap.issueClaim.persist_failed', {
+          err,
+          chain: targetChain,
+          asset: targetAsset,
+        });
+        throw new SwapWalletError(
+          'PERSISTENCE_FAILED',
+          'Write-ahead persist of channel watermark failed; claim not issued',
+          { cause: err }
+        );
+      }
+    }
+
     // 4. Sign the balance proof. On throw, reverse inventory + channel state.
     let claim: Uint8Array;
     try {
@@ -211,6 +261,22 @@ export class MultiChainClaimIssuer implements ClaimIssuer {
         senderPubkey,
         cumulativeDelta: targetAmount,
       });
+      // Issue #46 — re-persist the rolled-back state, best-effort. If THIS
+      // persist fails (or the process crashes before it runs), disk keeps
+      // the pre-rollback snapshot: an over-reservation, which is safe — the
+      // next boot's watermark is ahead of (never behind) any handed-out
+      // claim. See state-store.ts crash rule 3.
+      if (this.persistState) {
+        try {
+          this.persistState();
+        } catch (persistErr) {
+          this.logger?.error?.('swap.issueClaim.rollback_persist_failed', {
+            err: persistErr,
+            chain: targetChain,
+            asset: targetAsset,
+          });
+        }
+      }
       this.logger?.error?.('swap.issueClaim.signing_failed', {
         err,
         chain: targetChain,

--- a/packages/swap/src/cli.test.ts
+++ b/packages/swap/src/cli.test.ts
@@ -335,3 +335,36 @@ describe('Pass-3 CLI security: strict hex validation on config.secretKey', () =>
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #46 — SWAP_STATE_PATH env overlay (state persistence plumbing).
+// ---------------------------------------------------------------------------
+
+describe('issue #46 — SWAP_STATE_PATH env overlay', () => {
+  const fixturePath = resolve(__dirname, '..', 'fixtures', 'swap.config.json');
+
+  it('[P1] SWAP_STATE_PATH activates persistence: boot writes the snapshot file', async () => {
+    const { mkdtempSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const mod = (await import('./cli.js')) as {
+      main: (argv: string[]) => Promise<{ stop: () => Promise<void> }>;
+    };
+    const dir = mkdtempSync(join(tmpdir(), 'swap node-cli-state-'));
+    const statePath = join(dir, 'state.json');
+    const prev = process.env['SWAP_STATE_PATH'];
+    process.env['SWAP_STATE_PATH'] = statePath;
+    try {
+      const instance = await mod.main(['--config', fixturePath]);
+      try {
+        expect(existsSync(statePath)).toBe(true);
+      } finally {
+        await instance.stop();
+      }
+    } finally {
+      if (prev === undefined) delete process.env['SWAP_STATE_PATH'];
+      else process.env['SWAP_STATE_PATH'] = prev;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/swap/src/cli.ts
+++ b/packages/swap/src/cli.ts
@@ -14,6 +14,10 @@
  *   SWAP_SECRET_KEY_HEX    — 64-char hex-encoded 32-byte secret key
  *   SWAP_BLS_PORT          — numeric port for /health server
  *   SWAP_RELAYS            — comma-separated relay WebSocket URLs
+ *   SWAP_STATE_PATH        — durable state snapshot path (issue #46);
+ *                            enables persistence of inventory, channel
+ *                            watermarks, sticky bindings + replay
+ *                            reservations across restarts
  *   TOON_CONNECTOR_URL     — parent BTP URL; activates embedded-with-parent mode
  *   TOON_PARENT_PEER_ID    — peer id for the parent (default: "apex")
  *   TOON_PARENT_AUTH_TOKEN — BTP auth token for the parent peer (default: "")
@@ -47,6 +51,8 @@ interface CliRawConfig {
   relayUrls?: string[];
   blsPort?: number;
   btpServerPort?: number;
+  /** Durable swap-state snapshot path (issue #46). */
+  statePath?: string;
   passphrase?: string;
   knownPeers?: { ilpAddress: string; btpUrl?: string }[];
   // Story 12.7 Review Pass #1 additions — operator-surfaced kind:10032 fields.
@@ -147,6 +153,7 @@ function parseRawConfig(raw: CliRawConfig): SwapNodeConfig {
   }
   if (raw.blsPort !== undefined) cfg.blsPort = raw.blsPort;
   if (raw.btpServerPort !== undefined) cfg.btpServerPort = raw.btpServerPort;
+  if (raw.statePath) cfg.statePath = raw.statePath;
   if (raw.passphrase) cfg.passphrase = raw.passphrase;
   if (raw.knownPeers) cfg.knownPeers = raw.knownPeers;
   if (raw.ilpAddress) cfg.ilpAddress = raw.ilpAddress;
@@ -199,6 +206,7 @@ function applyEnvOverlay(cfg: SwapNodeConfig): SwapNodeConfig {
       .map((s) => s.trim())
       .filter(Boolean);
   }
+  if (env['SWAP_STATE_PATH']) out.statePath = env['SWAP_STATE_PATH'];
   // Embedded-with-parent connector wiring (TOON_* env vars). Setting
   // TOON_CONNECTOR_URL activates the embedded-with-parent path; the
   // remaining TOON_* vars are optional refinements.

--- a/packages/swap/src/errors.ts
+++ b/packages/swap/src/errors.ts
@@ -22,7 +22,14 @@ export type SwapWalletErrorCode =
   | 'UNSUPPORTED_CHAIN'
   | 'DERIVATION_FAILED'
   | 'SIGNING_FAILED'
-  | 'INVALID_CONFIG';
+  | 'INVALID_CONFIG'
+  /**
+   * Issue #46 — the write-ahead persist of the channel watermark failed, so
+   * the claim was NOT issued (debit + reservation rolled back). Flows
+   * through the swap handler as ILP `T00 Internal error` like every other
+   * non-inventory swap node failure.
+   */
+  | 'PERSISTENCE_FAILED';
 
 export class SwapInventoryError extends Error {
   public readonly code: SwapInventoryErrorCode;
@@ -68,6 +75,14 @@ export class SwapWalletError extends Error {
  *                            connector.
  * `HANDLER_REGISTRATION_FAILED` — registering the kind:1059 swap handler
  *                                  on the registry failed.
+ * `STATE_LOAD_FAILED`      — issue #46: a persisted swap-state snapshot
+ *                            exists but could not be read/validated. Boot
+ *                            fails LOUDLY instead of silently resetting
+ *                            channel watermarks (delete the state file to
+ *                            intentionally reset).
+ * `STATE_PERSIST_FAILED`   — issue #46: the initial boot-time snapshot
+ *                            write failed; persistence was requested but is
+ *                            non-functional, so the swap node refuses to start.
  */
 export type SwapNodeStartErrorCode =
   | 'INVALID_CONFIG'
@@ -75,7 +90,9 @@ export type SwapNodeStartErrorCode =
   | 'MISSING_KEY'
   | 'UNSUPPORTED_CHAIN_FAMILY'
   | 'CONNECTOR_INIT_FAILED'
-  | 'HANDLER_REGISTRATION_FAILED';
+  | 'HANDLER_REGISTRATION_FAILED'
+  | 'STATE_LOAD_FAILED'
+  | 'STATE_PERSIST_FAILED';
 
 export class SwapNodeStartError extends Error {
   public readonly code: SwapNodeStartErrorCode;

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -45,6 +45,23 @@ export type {
   SwapClaimIssuerLogger,
 } from './claim-issuer.js';
 
+// State persistence (issue #46 — rolling-swap prerequisite P2)
+export {
+  JsonFileSwapStateStore,
+  SwapStatePersister,
+  PersistentSeenPacketIds,
+  SwapStateStoreError,
+  DEFAULT_PERSISTED_SEEN_IDS_CAP,
+} from './state-store.js';
+export type {
+  SwapStateStore,
+  SwapStateStoreErrorCode,
+  SwapStatePersisterInit,
+  PersistedSwapState,
+  PersistedInventoryEntry,
+  PersistedChannelEntry,
+} from './state-store.js';
+
 // Errors (Story 12.4)
 export { SwapInventoryError, SwapWalletError } from './errors.js';
 export type { SwapInventoryErrorCode, SwapWalletErrorCode } from './errors.js';

--- a/packages/swap/src/inventory.ts
+++ b/packages/swap/src/inventory.ts
@@ -17,7 +17,11 @@ export interface SwapInventoryBalance {
 }
 
 export interface SwapInventoryInit {
-  balances: Record<string, { available: bigint; total: bigint }>;
+  balances: Record<
+    string,
+    /** `updatedAt` — issue #46: preserved on rehydration from a persisted snapshot; defaults to `clock()` when omitted. */
+    { available: bigint; total: bigint; updatedAt?: number }
+  >;
   clock?: () => number;
 }
 
@@ -51,7 +55,7 @@ export class SwapInventory {
       this.entries.set(k, {
         available: v.available,
         total: v.total,
-        updatedAt: now,
+        updatedAt: v.updatedAt ?? now,
       });
     }
   }

--- a/packages/swap/src/state-store.test.ts
+++ b/packages/swap/src/state-store.test.ts
@@ -1,0 +1,613 @@
+/**
+ * Issue #46 — swap-node state persistence tests.
+ *
+ * Covers:
+ *   - `JsonFileSwapStateStore` atomic save/load roundtrip + corruption policy
+ *   - `PersistentSeenPacketIds` bounding + persistence hook semantics
+ *   - `SwapStatePersister` snapshot fidelity
+ *   - Crash-recovery through `MultiChainClaimIssuer`:
+ *       - restart mid-stream → nonce/cumulative continue monotonically
+ *       - write-ahead ordering (persist BEFORE sign)
+ *       - write-ahead persist failure → claim refused + full rollback
+ *       - signer failure → rollback re-persisted
+ *       - crash between debit and FULFILL → recoverable (over-reserved) state
+ */
+import {
+  mkdtempSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { SwapPair } from '@toon-protocol/core';
+
+import {
+  JsonFileSwapStateStore,
+  SwapStatePersister,
+  SwapStateStoreError,
+  PersistentSeenPacketIds,
+  validatePersistedState,
+} from './state-store.js';
+import type { SwapStateStore, PersistedSwapState } from './state-store.js';
+import { MultiChainClaimIssuer } from './claim-issuer.js';
+import { SwapInventory } from './inventory.js';
+import { SwapChannelState } from './channel-state.js';
+import { SwapWalletError } from './errors.js';
+
+const SENDER_PUBKEY = 'b'.repeat(64);
+const OTHER_SENDER = 'c'.repeat(64);
+const FIXTURE_EVM_RECIPIENT = '0x' + '11'.repeat(20);
+
+const PAIR_USDC_TO_ETH: SwapPair = {
+  from: { assetCode: 'USDC', chain: 'evm:base:8453', assetScale: 6 },
+  to: { assetCode: 'ETH', chain: 'evm:base:8453', assetScale: 18 },
+  rate: '0.0005',
+};
+
+const tmpDirs: string[] = [];
+function makeTmpDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'swap-state-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+function sampleState(): PersistedSwapState {
+  return {
+    version: 1,
+    inventory: {
+      'ETH:evm:base:8453': {
+        available: '9007199254740993', // > MAX_SAFE_INTEGER (precision guard)
+        total: '9007199254740995',
+        updatedAt: 123,
+      },
+    },
+    channels: {
+      'ETH:evm:base:8453:0xchan': {
+        channelId: '0xchan',
+        cumulativeAmount: '18446744073709551617',
+        nonce: '42',
+        updatedAt: 456,
+      },
+    },
+    bindings: {
+      [`ETH:evm:base:8453:${SENDER_PUBKEY}`]: 'ETH:evm:base:8453:0xchan',
+    },
+    seenPacketIds: ['pkt-1', 'pkt-2'],
+  };
+}
+
+/** Fresh live state + persister wired to a store, for crash-recovery tests. */
+function makeLiveSwapNode(
+  store: SwapStateStore,
+  persisted?: PersistedSwapState | null
+) {
+  const inventory = new SwapInventory({
+    balances: persisted
+      ? Object.fromEntries(
+          Object.entries(persisted.inventory).map(([k, v]) => [
+            k,
+            {
+              available: BigInt(v.available),
+              total: BigInt(v.total),
+              updatedAt: v.updatedAt,
+            },
+          ])
+        )
+      : { 'ETH:evm:base:8453': { available: 1_000n, total: 1_000n } },
+  });
+  const channelState = new SwapChannelState({
+    channels: persisted
+      ? Object.fromEntries(
+          Object.entries(persisted.channels).map(([k, v]) => [
+            k,
+            {
+              channelId: v.channelId,
+              cumulativeAmount: BigInt(v.cumulativeAmount),
+              nonce: BigInt(v.nonce),
+              updatedAt: v.updatedAt,
+            },
+          ])
+        )
+      : {
+          'ETH:evm:base:8453:chan-a': {
+            channelId: 'chan-a',
+            cumulativeAmount: 0n,
+            nonce: 0n,
+            updatedAt: 0,
+          },
+          'ETH:evm:base:8453:chan-b': {
+            channelId: 'chan-b',
+            cumulativeAmount: 0n,
+            nonce: 0n,
+            updatedAt: 0,
+          },
+        },
+    ...(persisted && { bindings: persisted.bindings }),
+  });
+  const persister = new SwapStatePersister({ store, inventory, channelState });
+  const signer = {
+    chain: 'evm:base:8453',
+    chainKind: 'evm' as const,
+    signBalanceProof: vi.fn(async () => new Uint8Array([0x01])),
+  };
+  const issuer = new MultiChainClaimIssuer({
+    inventory,
+    signers: { 'evm:base:8453': signer },
+    channelState,
+    persistState: () => persister.persist(),
+  });
+  return { inventory, channelState, persister, signer, issuer };
+}
+
+function issueParams(senderPubkey = SENDER_PUBKEY, targetAmount = 50n) {
+  return {
+    sourceAmount: 100_000n,
+    targetAmount,
+    pair: PAIR_USDC_TO_ETH,
+    senderPubkey,
+    chainRecipient: FIXTURE_EVM_RECIPIENT,
+    rumor: {
+      pubkey: senderPubkey,
+      created_at: 1_700_000_000,
+      kind: 1,
+      tags: [],
+      content: '',
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// JsonFileSwapStateStore
+// ---------------------------------------------------------------------------
+
+describe('JsonFileSwapStateStore', () => {
+  it('[P0] save → load roundtrips the exact state (bigint-precision safe)', () => {
+    const path = join(makeTmpDir(), 'state.json');
+    const store = new JsonFileSwapStateStore(path);
+    const state = sampleState();
+    store.save(state);
+    expect(store.load()).toEqual(state);
+  });
+
+  it('[P1] load() returns null when no state file exists', () => {
+    const store = new JsonFileSwapStateStore(join(makeTmpDir(), 'absent.json'));
+    expect(store.load()).toBeNull();
+  });
+
+  it('[P1] save() creates missing parent directories and leaves no .tmp behind', () => {
+    const dir = makeTmpDir();
+    const path = join(dir, 'nested', 'deeper', 'state.json');
+    const store = new JsonFileSwapStateStore(path);
+    store.save(sampleState());
+    expect(existsSync(path)).toBe(true);
+    expect(existsSync(`${path}.tmp`)).toBe(false);
+  });
+
+  it('[P0] corrupt JSON fails load() loudly (LOAD_FAILED), never silently resets', () => {
+    const path = join(makeTmpDir(), 'state.json');
+    writeFileSync(path, '{ this is not json', 'utf-8');
+    const store = new JsonFileSwapStateStore(path);
+    expect(() => store.load()).toThrowError(SwapStateStoreError);
+    try {
+      store.load();
+    } catch (err) {
+      expect((err as SwapStateStoreError).code).toBe('LOAD_FAILED');
+    }
+  });
+
+  it('[P1] unsupported schema version fails load()', () => {
+    const path = join(makeTmpDir(), 'state.json');
+    writeFileSync(
+      path,
+      JSON.stringify({ ...sampleState(), version: 2 }),
+      'utf-8'
+    );
+    const store = new JsonFileSwapStateStore(path);
+    expect(() => store.load()).toThrowError(/version/);
+  });
+
+  it('[P1] malformed bigint strings fail load()', () => {
+    const path = join(makeTmpDir(), 'state.json');
+    const bad = sampleState();
+    bad.inventory['ETH:evm:base:8453'].available = 'not-a-bigint';
+    writeFileSync(path, JSON.stringify(bad), 'utf-8');
+    const store = new JsonFileSwapStateStore(path);
+    expect(() => store.load()).toThrowError(SwapStateStoreError);
+  });
+
+  it('[P2] prototype-polluting keys are rejected on load', () => {
+    expect(() =>
+      validatePersistedState({
+        ...sampleState(),
+        bindings: JSON.parse('{"__proto__": "x"}') as Record<string, string>,
+      })
+    ).toThrowError(/Unsafe key/);
+  });
+
+  it('[P1] save() over an existing snapshot replaces it atomically (last write wins)', () => {
+    const path = join(makeTmpDir(), 'state.json');
+    const store = new JsonFileSwapStateStore(path);
+    store.save(sampleState());
+    const next = sampleState();
+    next.channels['ETH:evm:base:8453:0xchan'].nonce = '43';
+    store.save(next);
+    const loaded = store.load()!;
+    expect(loaded.channels['ETH:evm:base:8453:0xchan'].nonce).toBe('43');
+    // File on disk is a single complete JSON document.
+    expect(() => JSON.parse(readFileSync(path, 'utf-8'))).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PersistentSeenPacketIds
+// ---------------------------------------------------------------------------
+
+describe('PersistentSeenPacketIds', () => {
+  it('[P1] behaves as a Set-like: has/add/delete/size', () => {
+    const set = new PersistentSeenPacketIds();
+    expect(set.has('a')).toBe(false);
+    set.add('a');
+    expect(set.has('a')).toBe(true);
+    expect(set.size).toBe(1);
+    expect(set.delete('a')).toBe(true);
+    expect(set.delete('a')).toBe(false);
+    expect(set.size).toBe(0);
+  });
+
+  it('[P1] evicts oldest entries beyond the cap (bounded replay window)', () => {
+    const set = new PersistentSeenPacketIds([], 3);
+    set.add('a').add('b').add('c').add('d');
+    expect(set.size).toBe(3);
+    expect(set.has('a')).toBe(false); // oldest evicted
+    expect(set.has('d')).toBe(true);
+    expect(set.values()).toEqual(['b', 'c', 'd']);
+  });
+
+  it('[P0] onMutate fires synchronously on add and delete, not on duplicate add', () => {
+    const set = new PersistentSeenPacketIds();
+    const persists: string[][] = [];
+    set.setOnMutate(() => persists.push(set.values()));
+    set.add('pkt-1');
+    set.add('pkt-1'); // duplicate — no persist
+    set.delete('pkt-1');
+    expect(persists).toEqual([['pkt-1'], []]);
+  });
+
+  it('[P1] rehydrates from a persisted list, preserving order', () => {
+    const set = new PersistentSeenPacketIds(['x', 'y']);
+    expect(set.has('x')).toBe(true);
+    expect(set.values()).toEqual(['x', 'y']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SwapStatePersister — snapshot fidelity
+// ---------------------------------------------------------------------------
+
+describe('SwapStatePersister', () => {
+  it('[P0] persists live inventory + channel watermarks + bindings + replay set', () => {
+    const path = join(makeTmpDir(), 'state.json');
+    const store = new JsonFileSwapStateStore(path);
+    const { inventory, channelState, persister } = makeLiveSwapNode(store);
+    // Drive some state: a reservation binds the sender and advances watermark.
+    channelState.reserve({
+      assetCode: 'ETH',
+      chain: 'evm:base:8453',
+      senderPubkey: SENDER_PUBKEY,
+      cumulativeDelta: 7n,
+    });
+    inventory.debit('ETH', 'evm:base:8453', 7n);
+    const seen = new PersistentSeenPacketIds(['pkt-9']);
+    const withSeen = new SwapStatePersister({
+      store,
+      inventory,
+      channelState,
+      seenPacketIds: seen,
+    });
+    withSeen.persist();
+
+    const loaded = store.load()!;
+    expect(loaded.inventory['ETH:evm:base:8453'].available).toBe('993');
+    expect(loaded.inventory['ETH:evm:base:8453'].total).toBe('1000');
+    expect(loaded.channels['ETH:evm:base:8453:chan-a']).toMatchObject({
+      channelId: 'chan-a',
+      cumulativeAmount: '7',
+      nonce: '1',
+    });
+    expect(loaded.bindings[`ETH:evm:base:8453:${SENDER_PUBKEY}`]).toBe(
+      'ETH:evm:base:8453:chan-a'
+    );
+    expect(loaded.seenPacketIds).toEqual(['pkt-9']);
+    expect(persister).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SwapChannelState — binding rehydration
+// ---------------------------------------------------------------------------
+
+describe('SwapChannelState binding rehydration', () => {
+  it('[P0] restored bindings keep a sender pinned to its pre-restart channel', () => {
+    const channels = {
+      'ETH:evm:base:8453:chan-a': {
+        channelId: 'chan-a',
+        cumulativeAmount: 100n,
+        nonce: 3n,
+        updatedAt: 1,
+      },
+      'ETH:evm:base:8453:chan-b': {
+        channelId: 'chan-b',
+        cumulativeAmount: 0n,
+        nonce: 0n,
+        updatedAt: 1,
+      },
+    };
+    // Pre-restart, the sender was bound to chan-b (NOT the first-scanned one).
+    const restored = new SwapChannelState({
+      channels,
+      bindings: {
+        [`ETH:evm:base:8453:${SENDER_PUBKEY}`]: 'ETH:evm:base:8453:chan-b',
+      },
+    });
+    const r = restored.reserve({
+      assetCode: 'ETH',
+      chain: 'evm:base:8453',
+      senderPubkey: SENDER_PUBKEY,
+      cumulativeDelta: 5n,
+    });
+    expect(r.channelId).toBe('chan-b');
+    expect(r.nonce).toBe(1n);
+    // A NEW sender cannot steal the restored-bound channel.
+    const r2 = restored.reserve({
+      assetCode: 'ETH',
+      chain: 'evm:base:8453',
+      senderPubkey: OTHER_SENDER,
+      cumulativeDelta: 5n,
+    });
+    expect(r2.channelId).toBe('chan-a');
+  });
+
+  it('[P2] dangling bindings (channel key absent) are dropped on rehydration', () => {
+    const state = new SwapChannelState({
+      channels: {
+        'ETH:evm:base:8453:chan-a': {
+          channelId: 'chan-a',
+          cumulativeAmount: 0n,
+          nonce: 0n,
+          updatedAt: 0,
+        },
+      },
+      bindings: {
+        [`ETH:evm:base:8453:${SENDER_PUBKEY}`]: 'ETH:evm:base:8453:GONE',
+      },
+    });
+    // Sender re-binds to an available channel instead of failing forever.
+    const r = state.reserve({
+      assetCode: 'ETH',
+      chain: 'evm:base:8453',
+      senderPubkey: SENDER_PUBKEY,
+      cumulativeDelta: 1n,
+    });
+    expect(r.channelId).toBe('chan-a');
+  });
+
+  it('[P1] snapshot() → constructor roundtrip reproduces watermarks + bindings', () => {
+    const state = new SwapChannelState({
+      channels: {
+        'ETH:evm:base:8453:chan-a': {
+          channelId: 'chan-a',
+          cumulativeAmount: 0n,
+          nonce: 0n,
+          updatedAt: 0,
+        },
+      },
+    });
+    state.reserve({
+      assetCode: 'ETH',
+      chain: 'evm:base:8453',
+      senderPubkey: SENDER_PUBKEY,
+      cumulativeDelta: 9n,
+    });
+    const snap = state.snapshot();
+    const clone = new SwapChannelState({
+      channels: snap.channels,
+      bindings: snap.bindings,
+    });
+    expect(clone.snapshot()).toEqual(snap);
+    const r = clone.reserve({
+      assetCode: 'ETH',
+      chain: 'evm:base:8453',
+      senderPubkey: SENDER_PUBKEY,
+      cumulativeDelta: 1n,
+    });
+    expect(r.nonce).toBe(2n);
+    expect(r.cumulativeAmount).toBe(10n);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Crash-recovery through the claim issuer
+// ---------------------------------------------------------------------------
+
+describe('issue #46 — crash recovery through MultiChainClaimIssuer', () => {
+  it('[P0] restart mid-stream: nonce/cumulative continue monotonically from the persisted watermark', async () => {
+    const path = join(makeTmpDir(), 'state.json');
+    const store = new JsonFileSwapStateStore(path);
+
+    // Boot 1: issue two claims, then "crash" (drop all in-memory objects).
+    const boot1 = makeLiveSwapNode(store);
+    const c1 = await boot1.issuer.issueClaim(issueParams(SENDER_PUBKEY, 50n));
+    const c2 = await boot1.issuer.issueClaim(issueParams(SENDER_PUBKEY, 30n));
+    expect(c1.claim).toBeInstanceOf(Uint8Array);
+    expect(c2.claim).toBeInstanceOf(Uint8Array);
+    const preCrash = boot1.channelState.get({
+      assetCode: 'ETH',
+      chain: 'evm:base:8453',
+      senderPubkey: SENDER_PUBKEY,
+    })!;
+    expect(preCrash.nonce).toBe(2n);
+    expect(preCrash.cumulativeAmount).toBe(80n);
+
+    // Boot 2: rehydrate purely from the persisted snapshot.
+    const boot2 = makeLiveSwapNode(store, store.load());
+    const r3 = await boot2.issuer.issueClaim(issueParams(SENDER_PUBKEY, 20n));
+    expect(r3.claim).toBeInstanceOf(Uint8Array);
+    const post = boot2.channelState.get({
+      assetCode: 'ETH',
+      chain: 'evm:base:8453',
+      senderPubkey: SENDER_PUBKEY,
+    })!;
+    // No watermark reset: continues 2n → 3n, 80n → 100n.
+    expect(post.nonce).toBe(3n);
+    expect(post.cumulativeAmount).toBe(100n);
+    // Sticky binding survived: same channel as before the crash.
+    expect(post.channelId).toBe(preCrash.channelId);
+    // Inventory survived the restart too: 1000 - 50 - 30 - 20.
+    expect(boot2.inventory.get('ETH', 'evm:base:8453')!.available).toBe(900n);
+  });
+
+  it('[P0] write-ahead ordering: watermark is persisted BEFORE the balance proof is signed', async () => {
+    const order: string[] = [];
+    const store: SwapStateStore = {
+      load: () => null,
+      save: () => {
+        order.push('persist');
+      },
+    };
+    const swapNode = makeLiveSwapNode(store);
+    swapNode.signer.signBalanceProof.mockImplementation(async () => {
+      order.push('sign');
+      return new Uint8Array([0x01]);
+    });
+    await swapNode.issuer.issueClaim(issueParams());
+    expect(order).toEqual(['persist', 'sign']);
+  });
+
+  it('[P0] write-ahead persist failure: claim refused (PERSISTENCE_FAILED) and debit+reservation rolled back', async () => {
+    const store: SwapStateStore = {
+      load: () => null,
+      save: () => {
+        throw new Error('disk full');
+      },
+    };
+    const swapNode = makeLiveSwapNode(store);
+    await expect(
+      swapNode.issuer.issueClaim(issueParams())
+    ).rejects.toMatchObject({
+      name: 'SwapWalletError',
+      code: 'PERSISTENCE_FAILED',
+    });
+    // Nothing was handed out, so state must be fully reversed.
+    expect(swapNode.signer.signBalanceProof).not.toHaveBeenCalled();
+    expect(swapNode.inventory.get('ETH', 'evm:base:8453')!.available).toBe(
+      1_000n
+    );
+    const entry = swapNode.channelState.get({
+      assetCode: 'ETH',
+      chain: 'evm:base:8453',
+      senderPubkey: SENDER_PUBKEY,
+    })!;
+    expect(entry.nonce).toBe(0n);
+    expect(entry.cumulativeAmount).toBe(0n);
+  });
+
+  it('[P0] signer failure: rollback is re-persisted (disk matches the reversed state)', async () => {
+    const path = join(makeTmpDir(), 'state.json');
+    const store = new JsonFileSwapStateStore(path);
+    const swapNode = makeLiveSwapNode(store);
+    swapNode.signer.signBalanceProof.mockRejectedValueOnce(
+      new Error('hsm down')
+    );
+    await expect(
+      swapNode.issuer.issueClaim(issueParams())
+    ).rejects.toBeInstanceOf(SwapWalletError);
+    const loaded = store.load()!;
+    expect(loaded.inventory['ETH:evm:base:8453'].available).toBe('1000');
+    expect(loaded.channels['ETH:evm:base:8453:chan-a'].nonce).toBe('0');
+    expect(loaded.channels['ETH:evm:base:8453:chan-a'].cumulativeAmount).toBe(
+      '0'
+    );
+  });
+
+  it('[P0] crash between debit and FULFILL: restored state is over-reserved (never behind a handed-out claim) and stays monotone', async () => {
+    const path = join(makeTmpDir(), 'state.json');
+    const realStore = new JsonFileSwapStateStore(path);
+    // Store wrapper that fails every save AFTER the first (the write-ahead
+    // succeeds; the rollback persist fails → simulates a crash after the
+    // reservation hit disk but before FULFILL/rollback could be recorded).
+    let saves = 0;
+    const store: SwapStateStore = {
+      load: () => realStore.load(),
+      save: (s) => {
+        saves += 1;
+        if (saves > 1) throw new Error('crashed');
+        realStore.save(s);
+      },
+    };
+    const swapNode = makeLiveSwapNode(store);
+    swapNode.signer.signBalanceProof.mockRejectedValueOnce(
+      new Error('process died mid-sign')
+    );
+    await expect(
+      swapNode.issuer.issueClaim(issueParams())
+    ).rejects.toBeInstanceOf(SwapWalletError);
+
+    // Disk kept the write-ahead (over-reserved) snapshot: nonce 1, debit 50 —
+    // ahead of any claim a counterparty could hold (none was delivered).
+    const persisted = realStore.load()!;
+    expect(persisted.channels['ETH:evm:base:8453:chan-a'].nonce).toBe('1');
+    expect(persisted.inventory['ETH:evm:base:8453'].available).toBe('950');
+
+    // Recovery: reboot from that snapshot; the next claim continues ABOVE the
+    // aborted reservation — monotone, no possible watermark regression.
+    const boot2 = makeLiveSwapNode(realStore, realStore.load());
+    const r = await boot2.issuer.issueClaim(issueParams(SENDER_PUBKEY, 10n));
+    expect(r.claim).toBeInstanceOf(Uint8Array);
+    const entry = boot2.channelState.get({
+      assetCode: 'ETH',
+      chain: 'evm:base:8453',
+      senderPubkey: SENDER_PUBKEY,
+    })!;
+    expect(entry.nonce).toBe(2n);
+    expect(entry.cumulativeAmount).toBe(60n);
+  });
+
+  it('[P1] without a persistState hook the issuer behaves exactly as before (no persistence calls)', async () => {
+    const inventory = new SwapInventory({
+      balances: { 'ETH:evm:base:8453': { available: 1_000n, total: 1_000n } },
+    });
+    const channelState = new SwapChannelState({
+      channels: {
+        'ETH:evm:base:8453:chan-a': {
+          channelId: 'chan-a',
+          cumulativeAmount: 0n,
+          nonce: 0n,
+          updatedAt: 0,
+        },
+      },
+    });
+    const issuer = new MultiChainClaimIssuer({
+      inventory,
+      signers: {
+        'evm:base:8453': {
+          chain: 'evm:base:8453',
+          chainKind: 'evm' as const,
+          signBalanceProof: vi.fn(async () => new Uint8Array([0x01])),
+        },
+      },
+      channelState,
+    });
+    const result = await issuer.issueClaim(issueParams());
+    expect(result.claim).toBeInstanceOf(Uint8Array);
+  });
+});

--- a/packages/swap/src/state-store.ts
+++ b/packages/swap/src/state-store.ts
@@ -1,0 +1,495 @@
+/**
+ * Swap-node state persistence (issue #46 — rolling-swap prerequisite P2).
+ *
+ * Everything the swap node hands out to counterparties is derived from three
+ * pieces of runtime state that were previously in-memory only:
+ *
+ *   - `SwapInventory` reserves          (`inventory.ts`, keyed `assetCode:chain`)
+ *   - `SwapChannelState` watermarks     (nonce + cumulativeAmount per channel)
+ *     and sticky sender→channel bindings
+ *   - replay reservations               (the swap handler's `seenPacketIds`)
+ *
+ * A crash mid-stream would desynchronize the swap node's channel watermark from
+ * signed claims already handed to counterparties — the next boot would
+ * re-issue nonce 1 on a channel whose counterparty already holds nonce N.
+ * The rolling engine (swap#47) keeps many per-packet advances in flight, so
+ * durability of these watermarks is a hard prerequisite, not an
+ * optimization.
+ *
+ * ## Persistence model
+ *
+ * One JSON snapshot file, written atomically (temp file + `fsync` +
+ * `rename`) on every state mutation that can leave the process. Writes are
+ * SYNCHRONOUS to preserve the swap node's microtask-atomicity invariants
+ * (`debit`/`reserve` are sync; a sync persist keeps the
+ * reserve→persist→sign ordering un-interleavable). Follows the
+ * `JsonFileChannelStore` pattern from toon-client
+ * (`packages/client/src/channel/ChannelStore.ts`) with atomic-rename
+ * hardening.
+ *
+ * ## Crash-consistency rules (write-ahead / persist-before-hand-out)
+ *
+ * 1. **Watermarks are persisted BEFORE a claim can leave the process.**
+ *    `MultiChainClaimIssuer.issueClaim` persists immediately after
+ *    debit+reserve and BEFORE `signBalanceProof` — so at every instant the
+ *    stored watermark is >= the highest watermark embedded in any claim a
+ *    counterparty could hold. If the write-ahead persist fails, the
+ *    debit+reserve are rolled back and NO claim is issued.
+ * 2. **Crash between debit/reserve and FULFILL**: the persisted state may
+ *    include reservations for claims that were never delivered (nonce gap,
+ *    inventory debited for nothing). This is the deliberate safe side of
+ *    the race: on restart the next claim continues monotonically ABOVE the
+ *    aborted reservation, and inventory under-reports rather than
+ *    over-reports. The aborted amounts are recoverable by the operator via
+ *    `SwapInventory.credit` / settlement reconciliation; the swap node never
+ *    hands out a claim that is AHEAD of the stored watermark.
+ * 3. **Signer-failure rollback** (`claim-issuer.ts`): the in-memory
+ *    credit+release rollback is followed by a best-effort persist. If the
+ *    process crashes between rollback and persist, the stored state simply
+ *    retains the (safe, over-reserved) pre-rollback snapshot — see rule 2.
+ * 4. **Replay reservations**: `PersistentSeenPacketIds` persists on every
+ *    add/delete (the handler adds BEFORE issuing a claim). After a crash,
+ *    a packet whose id was reserved but never fulfilled is rejected as a
+ *    duplicate (F04) — fail-closed against double-issuance at the cost of
+ *    one retry-liveness edge. When an operator supplies their own
+ *    `seenPacketIds` set instead, it is NOT persisted and the accepted
+ *    replay window on restart is the full set (bounded by the operator's
+ *    own cap; the SDK default is a 10k-entry LRU).
+ * 5. **Shutdown does not persist.** `SwapNodeInstance.stop()` zeroes in-memory
+ *    reservation bookkeeping (`releaseAll`) for GC; the on-disk snapshot
+ *    keeps the last handed-out watermarks and is authoritative on the next
+ *    boot.
+ *
+ * ## Rehydration precedence
+ *
+ * On `startSwapNode`, persisted entries WIN over config-supplied initial values
+ * for any key present in the snapshot (a restart must never reset spent
+ * inventory or channel watermarks back to their notional boot values).
+ * Config supplies initial values only for keys the snapshot has never seen.
+ * To intentionally reset, an operator deletes the state file.
+ */
+
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  writeSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+
+import type { SwapInventory } from './inventory.js';
+import type { SwapChannelState } from './channel-state.js';
+
+// ---------------------------------------------------------------------------
+// Persisted shape (all bigints string-encoded to preserve precision)
+// ---------------------------------------------------------------------------
+
+export interface PersistedInventoryEntry {
+  /** String-encoded bigint. */
+  available: string;
+  /** String-encoded bigint. */
+  total: string;
+  updatedAt: number;
+}
+
+export interface PersistedChannelEntry {
+  channelId: string;
+  /** String-encoded bigint. */
+  cumulativeAmount: string;
+  /** String-encoded bigint. */
+  nonce: string;
+  updatedAt: number;
+}
+
+export interface PersistedSwapState {
+  /** Schema version — bump on breaking shape changes. */
+  version: 1;
+  /** `${assetCode}:${chain}` → reserves. */
+  inventory: Record<string, PersistedInventoryEntry>;
+  /** `${assetCode}:${chain}:${channelId}` → watermark entry. */
+  channels: Record<string, PersistedChannelEntry>;
+  /** `${assetCode}:${chain}:${senderPubkey}` → stored channel key. */
+  bindings: Record<string, string>;
+  /** Replay reservations (insertion-ordered, oldest first). */
+  seenPacketIds: string[];
+}
+
+/** Storage abstraction so tests / future sqlite backends can swap in. */
+export interface SwapStateStore {
+  /** Returns `null` when no state has ever been persisted. */
+  load(): PersistedSwapState | null;
+  save(state: PersistedSwapState): void;
+}
+
+export type SwapStateStoreErrorCode = 'LOAD_FAILED' | 'SAVE_FAILED';
+
+export class SwapStateStoreError extends Error {
+  public readonly code: SwapStateStoreErrorCode;
+
+  constructor(
+    code: SwapStateStoreErrorCode,
+    message: string,
+    options?: { cause?: unknown }
+  ) {
+    super(message, options as ErrorOptions | undefined);
+    this.name = 'SwapStateStoreError';
+    this.code = code;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// JSON-file store (atomic rename)
+// ---------------------------------------------------------------------------
+
+/**
+ * Reject keys that would pollute `Object.prototype` when the parsed JSON is
+ * fanned back out into runtime maps (mirrors the CLI's `assertSafeKey`
+ * prototype-pollution guard — `JSON.parse` preserves `__proto__` as an own
+ * property).
+ */
+function isUnsafeKey(key: string): boolean {
+  return key === '__proto__' || key === 'constructor' || key === 'prototype';
+}
+
+function copyRecord<T>(
+  raw: Record<string, T>,
+  scope: string,
+  validate: (v: T, key: string) => void
+): Record<string, T> {
+  const out: Record<string, T> = Object.create(null) as Record<string, T>;
+  for (const [k, v] of Object.entries(raw)) {
+    if (isUnsafeKey(k)) {
+      throw new Error(`Unsafe key "${k}" rejected in ${scope}`);
+    }
+    validate(v, k);
+    out[k] = v;
+  }
+  return out;
+}
+
+function assertBigintString(v: unknown, ctx: string): void {
+  if (typeof v !== 'string') {
+    throw new Error(`${ctx} must be a string-encoded bigint`);
+  }
+  BigInt(v); // throws SyntaxError on malformed input
+}
+
+/**
+ * File-backed {@link SwapStateStore}.
+ *
+ * Durability: `save()` writes the full snapshot to `<path>.tmp`, `fsync`s
+ * the file descriptor, then atomically `rename`s over `<path>` (and
+ * best-effort `fsync`s the containing directory). A crash mid-write
+ * therefore leaves either the previous complete snapshot or the new
+ * complete snapshot — never a torn file.
+ *
+ * Corruption policy: a snapshot that exists but cannot be parsed/validated
+ * FAILS `load()` loudly (`SwapStateStoreError('LOAD_FAILED')`) rather than
+ * silently booting from config — silently resetting watermarks is exactly
+ * the desync this module exists to prevent.
+ */
+export class JsonFileSwapStateStore implements SwapStateStore {
+  private readonly filePath: string;
+
+  constructor(filePath: string) {
+    if (typeof filePath !== 'string' || filePath.length === 0) {
+      throw new SwapStateStoreError(
+        'LOAD_FAILED',
+        'JsonFileSwapStateStore requires a non-empty file path'
+      );
+    }
+    this.filePath = filePath;
+  }
+
+  load(): PersistedSwapState | null {
+    if (!existsSync(this.filePath)) return null;
+    let raw: unknown;
+    try {
+      raw = JSON.parse(readFileSync(this.filePath, 'utf-8'));
+    } catch (err) {
+      throw new SwapStateStoreError(
+        'LOAD_FAILED',
+        `Swap-node state file ${this.filePath} is unreadable or corrupt; refusing to boot with reset watermarks. Restore the file (or delete it to intentionally reset).`,
+        { cause: err }
+      );
+    }
+    try {
+      return validatePersistedState(raw);
+    } catch (err) {
+      throw new SwapStateStoreError(
+        'LOAD_FAILED',
+        `Swap-node state file ${this.filePath} failed validation: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        { cause: err }
+      );
+    }
+  }
+
+  save(state: PersistedSwapState): void {
+    const tmpPath = `${this.filePath}.tmp`;
+    try {
+      mkdirSync(dirname(this.filePath), { recursive: true });
+      const json = JSON.stringify(state, null, 2);
+      const fd = openSync(tmpPath, 'w');
+      try {
+        writeSync(fd, json, null, 'utf-8');
+        fsyncSync(fd);
+      } finally {
+        closeSync(fd);
+      }
+      renameSync(tmpPath, this.filePath);
+      // Best-effort directory fsync so the rename itself is durable.
+      try {
+        const dirFd = openSync(dirname(this.filePath), 'r');
+        try {
+          fsyncSync(dirFd);
+        } finally {
+          closeSync(dirFd);
+        }
+      } catch {
+        // Not supported on all platforms/filesystems — the file-level fsync
+        // above already guarantees snapshot integrity.
+      }
+    } catch (err) {
+      throw new SwapStateStoreError(
+        'SAVE_FAILED',
+        `Failed to persist swap-node state to ${this.filePath}`,
+        { cause: err }
+      );
+    }
+  }
+}
+
+/** @internal — exported for direct testing of the validation surface. */
+export function validatePersistedState(raw: unknown): PersistedSwapState {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error('state must be a JSON object');
+  }
+  const rec = raw as Record<string, unknown>;
+  if (rec['version'] !== 1) {
+    throw new Error(
+      `unsupported state schema version ${JSON.stringify(rec['version'])} (expected 1)`
+    );
+  }
+  const invRaw = rec['inventory'];
+  const chanRaw = rec['channels'];
+  const bindRaw = rec['bindings'];
+  const seenRaw = rec['seenPacketIds'];
+  if (typeof invRaw !== 'object' || invRaw === null || Array.isArray(invRaw)) {
+    throw new Error('state.inventory must be an object');
+  }
+  if (
+    typeof chanRaw !== 'object' ||
+    chanRaw === null ||
+    Array.isArray(chanRaw)
+  ) {
+    throw new Error('state.channels must be an object');
+  }
+  if (
+    typeof bindRaw !== 'object' ||
+    bindRaw === null ||
+    Array.isArray(bindRaw)
+  ) {
+    throw new Error('state.bindings must be an object');
+  }
+  if (!Array.isArray(seenRaw) || seenRaw.some((s) => typeof s !== 'string')) {
+    throw new Error('state.seenPacketIds must be an array of strings');
+  }
+
+  const inventory = copyRecord(
+    invRaw as Record<string, PersistedInventoryEntry>,
+    'state.inventory',
+    (v, k) => {
+      assertBigintString(v?.available, `state.inventory["${k}"].available`);
+      assertBigintString(v?.total, `state.inventory["${k}"].total`);
+    }
+  );
+  const channels = copyRecord(
+    chanRaw as Record<string, PersistedChannelEntry>,
+    'state.channels',
+    (v, k) => {
+      if (typeof v?.channelId !== 'string' || v.channelId.length === 0) {
+        throw new Error(`state.channels["${k}"].channelId must be a string`);
+      }
+      assertBigintString(
+        v.cumulativeAmount,
+        `state.channels["${k}"].cumulativeAmount`
+      );
+      assertBigintString(v.nonce, `state.channels["${k}"].nonce`);
+    }
+  );
+  const bindings = copyRecord(
+    bindRaw as Record<string, string>,
+    'state.bindings',
+    (v, k) => {
+      if (typeof v !== 'string') {
+        throw new Error(`state.bindings["${k}"] must be a string`);
+      }
+    }
+  );
+  return {
+    version: 1,
+    inventory,
+    channels,
+    bindings,
+    seenPacketIds: [...(seenRaw as string[])],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Persistent replay-reservation set
+// ---------------------------------------------------------------------------
+
+/**
+ * Matches the SDK swap-handler's `DEFAULT_SEEN_PACKET_IDS_CAP` so switching
+ * from the SDK's in-memory LRU to this persistent set does not change the
+ * replay window.
+ */
+export const DEFAULT_PERSISTED_SEEN_IDS_CAP = 10_000;
+
+/**
+ * Bounded, insertion-ordered, persistently-snapshotted replay set.
+ *
+ * Satisfies the SDK's `SeenPacketIdsLike` contract (`has`/`add`/`delete` +
+ * `size`). The swap handler calls `add(packetId)` BEFORE issuing a claim
+ * and `delete(packetId)` when the claim path aborts — with `onMutate`
+ * wired to `SwapStatePersister.persist`, every reservation hits disk
+ * before the corresponding claim can leave the process (crash rule 4).
+ */
+export class PersistentSeenPacketIds {
+  private readonly ids = new Set<string>();
+  private readonly cap: number;
+  private onMutate?: () => void;
+
+  constructor(
+    initial?: Iterable<string>,
+    cap = DEFAULT_PERSISTED_SEEN_IDS_CAP
+  ) {
+    if (!Number.isInteger(cap) || cap <= 0) {
+      throw new Error('PersistentSeenPacketIds cap must be a positive integer');
+    }
+    this.cap = cap;
+    if (initial) {
+      for (const id of initial) {
+        this.ids.add(id);
+        this.evictIfNeeded();
+      }
+    }
+  }
+
+  /** Wire the persistence hook (called synchronously after add/delete). */
+  setOnMutate(fn: () => void): void {
+    this.onMutate = fn;
+  }
+
+  get size(): number {
+    return this.ids.size;
+  }
+
+  has(value: string): boolean {
+    return this.ids.has(value);
+  }
+
+  add(value: string): this {
+    if (this.ids.has(value)) return this;
+    this.ids.add(value);
+    this.evictIfNeeded();
+    this.onMutate?.();
+    return this;
+  }
+
+  delete(value: string): boolean {
+    const removed = this.ids.delete(value);
+    if (removed) this.onMutate?.();
+    return removed;
+  }
+
+  /** Snapshot for persistence (insertion order, oldest first). */
+  values(): string[] {
+    return [...this.ids];
+  }
+
+  private evictIfNeeded(): void {
+    while (this.ids.size > this.cap) {
+      const oldest = this.ids.values().next();
+      if (oldest.done) break;
+      this.ids.delete(oldest.value);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Persister — snapshots live state into the store
+// ---------------------------------------------------------------------------
+
+export interface SwapStatePersisterInit {
+  store: SwapStateStore;
+  inventory: SwapInventory;
+  channelState: SwapChannelState;
+  /**
+   * When the swap node owns its replay set (no operator-supplied
+   * `seenPacketIds`), included in every snapshot. Omitted → snapshots carry
+   * an empty list and the replay window resets on restart (documented crash
+   * rule 4).
+   */
+  seenPacketIds?: PersistentSeenPacketIds;
+}
+
+/**
+ * Assembles a {@link PersistedSwapState} snapshot from the live
+ * `SwapInventory` + `SwapChannelState` (+ replay set) and saves it through
+ * the configured store. `persist()` is synchronous — see the module
+ * docblock for why.
+ */
+export class SwapStatePersister {
+  private readonly store: SwapStateStore;
+  private readonly inventory: SwapInventory;
+  private readonly channelState: SwapChannelState;
+  private readonly seenPacketIds?: PersistentSeenPacketIds;
+
+  constructor(init: SwapStatePersisterInit) {
+    this.store = init.store;
+    this.inventory = init.inventory;
+    this.channelState = init.channelState;
+    if (init.seenPacketIds) this.seenPacketIds = init.seenPacketIds;
+  }
+
+  persist(): void {
+    const inventory: Record<string, PersistedInventoryEntry> = Object.create(
+      null
+    ) as Record<string, PersistedInventoryEntry>;
+    for (const b of this.inventory.snapshot()) {
+      inventory[`${b.assetCode}:${b.chain}`] = {
+        available: b.available.toString(),
+        total: b.total.toString(),
+        updatedAt: b.updatedAt,
+      };
+    }
+
+    const { channels: liveChannels, bindings } = this.channelState.snapshot();
+    const channels: Record<string, PersistedChannelEntry> = Object.create(
+      null
+    ) as Record<string, PersistedChannelEntry>;
+    for (const [key, entry] of Object.entries(liveChannels)) {
+      channels[key] = {
+        channelId: entry.channelId,
+        cumulativeAmount: entry.cumulativeAmount.toString(),
+        nonce: entry.nonce.toString(),
+        updatedAt: entry.updatedAt,
+      };
+    }
+
+    this.store.save({
+      version: 1,
+      inventory,
+      channels,
+      bindings,
+      seenPacketIds: this.seenPacketIds?.values() ?? [],
+    });
+  }
+}

--- a/packages/swap/src/swap-node-persistence.test.ts
+++ b/packages/swap/src/swap-node-persistence.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Issue #46 — `startSwapNode()` persistence wiring tests.
+ *
+ * Scenarios:
+ *   - boot with `statePath` writes an initial snapshot (fail-fast writability)
+ *   - restart rehydrates persisted inventory/watermarks; `GET /health`
+ *     reflects the rehydrated values, not the config notionals
+ *   - persisted channel entries absent from config are restored
+ *   - corrupt state file fails boot loudly (STATE_LOAD_FAILED)
+ *   - statePath + stateStore together is INVALID_CONFIG
+ */
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { startSwapNode, validateConfig } from './swap-node.js';
+import type { SwapNodeConfig } from './swap-node.js';
+import { JsonFileSwapStateStore } from './state-store.js';
+import { SwapNodeStartError } from './errors.js';
+
+const VALID_MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+function fakeConnector() {
+  return {
+    close: async () => undefined,
+    send: async () => ({ ok: true }),
+  };
+}
+
+function validConfig(statePath: string): SwapNodeConfig {
+  return {
+    mnemonic: VALID_MNEMONIC,
+    connector: fakeConnector() as unknown as SwapNodeConfig['connector'],
+    swapPairs: [
+      {
+        from: { assetCode: 'USDC', assetScale: 6, chain: 'evm:8453' },
+        to: { assetCode: 'USDC', assetScale: 6, chain: 'evm:8453' },
+        rate: '1.0',
+      },
+    ],
+    chains: ['evm'],
+    channels: {
+      'evm:8453': [
+        { channelId: 'c-1', cumulativeAmount: 0n, nonce: 0n, updatedAt: 0 },
+      ],
+    },
+    inventory: { 'evm:8453': 1_000_000n },
+    relayUrls: ['ws://localhost:0'],
+    blsPort: 0,
+    statePath,
+  };
+}
+
+const tmpDirs: string[] = [];
+function makeTmpDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'swap node-boot-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe('issue #46 — startSwapNode state persistence', () => {
+  it('[P0] boot writes an initial snapshot merging config state', async () => {
+    const statePath = join(makeTmpDir(), 'swap-state.json');
+    const instance = await startSwapNode(validConfig(statePath));
+    try {
+      expect(existsSync(statePath)).toBe(true);
+      const snap = new JsonFileSwapStateStore(statePath).load()!;
+      expect(snap.inventory['USDC:evm:8453'].available).toBe('1000000');
+      expect(snap.channels['USDC:evm:8453:c-1'].nonce).toBe('0');
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('[P0] restart rehydrates persisted state; /health reflects rehydrated inventory (not config)', async () => {
+    const statePath = join(makeTmpDir(), 'swap-state.json');
+
+    // Simulate a previous run that spent inventory and advanced watermarks
+    // (including a channel that was provisioned dynamically, absent from
+    // config) before crashing.
+    new JsonFileSwapStateStore(statePath).save({
+      version: 1,
+      inventory: {
+        'USDC:evm:8453': {
+          available: '250000',
+          total: '1000000',
+          updatedAt: 111,
+        },
+      },
+      channels: {
+        'USDC:evm:8453:c-1': {
+          channelId: 'c-1',
+          cumulativeAmount: '750000',
+          nonce: '17',
+          updatedAt: 111,
+        },
+        'USDC:evm:8453:c-dynamic': {
+          channelId: 'c-dynamic',
+          cumulativeAmount: '5',
+          nonce: '2',
+          updatedAt: 111,
+        },
+      },
+      bindings: {},
+      seenPacketIds: ['pkt-replayed'],
+    });
+
+    const instance = await startSwapNode(validConfig(statePath));
+    try {
+      const res = await fetch(`http://127.0.0.1:${instance.blsPort}/health`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        inventory: Record<string, string>;
+        inventoryAvailable: Record<string, string>;
+      };
+      // Persisted values win over the config notional (1000000/1000000).
+      expect(body.inventoryAvailable['USDC:evm:8453']).toBe('250000');
+      expect(body.inventory['USDC:evm:8453']).toBe('1000000');
+
+      // The boot snapshot must retain the rehydrated watermarks — including
+      // the dynamically-provisioned channel not present in config — and the
+      // replay reservations.
+      const snap = new JsonFileSwapStateStore(statePath).load()!;
+      expect(snap.channels['USDC:evm:8453:c-1'].nonce).toBe('17');
+      expect(snap.channels['USDC:evm:8453:c-1'].cumulativeAmount).toBe(
+        '750000'
+      );
+      expect(snap.channels['USDC:evm:8453:c-dynamic'].nonce).toBe('2');
+      expect(snap.seenPacketIds).toEqual(['pkt-replayed']);
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('[P0] stop() does not clobber persisted watermarks (no persist of releaseAll zeros)', async () => {
+    const statePath = join(makeTmpDir(), 'swap-state.json');
+    new JsonFileSwapStateStore(statePath).save({
+      version: 1,
+      inventory: {},
+      channels: {
+        'USDC:evm:8453:c-1': {
+          channelId: 'c-1',
+          cumulativeAmount: '99',
+          nonce: '9',
+          updatedAt: 1,
+        },
+      },
+      bindings: {},
+      seenPacketIds: [],
+    });
+    const instance = await startSwapNode(validConfig(statePath));
+    await instance.stop();
+    const snap = new JsonFileSwapStateStore(statePath).load()!;
+    // Watermark survives a clean stop — releaseAll() zeros memory only.
+    expect(snap.channels['USDC:evm:8453:c-1'].nonce).toBe('9');
+    expect(snap.channels['USDC:evm:8453:c-1'].cumulativeAmount).toBe('99');
+  });
+
+  it('[P0] corrupt state file fails boot with STATE_LOAD_FAILED (no silent watermark reset)', async () => {
+    const statePath = join(makeTmpDir(), 'swap-state.json');
+    writeFileSync(statePath, 'not json at all', 'utf-8');
+    await expect(startSwapNode(validConfig(statePath))).rejects.toMatchObject({
+      name: 'SwapNodeStartError',
+      code: 'STATE_LOAD_FAILED',
+    });
+  });
+
+  it('[P1] statePath + stateStore together is INVALID_CONFIG', () => {
+    const cfg = validConfig(join(makeTmpDir(), 's.json'));
+    cfg.stateStore = { load: () => null, save: () => undefined };
+    expect(() => validateConfig(cfg)).toThrowError(SwapNodeStartError);
+    try {
+      validateConfig(cfg);
+    } catch (err) {
+      expect((err as SwapNodeStartError).code).toBe('INVALID_CONFIG');
+    }
+  });
+
+  it('[P2] empty statePath is INVALID_CONFIG', () => {
+    const cfg = validConfig('x');
+    cfg.statePath = '';
+    expect(() => validateConfig(cfg)).toThrowError(/statePath/);
+  });
+
+  it('[P1] without statePath/stateStore, no snapshot file is written (legacy in-memory mode)', async () => {
+    const dir = makeTmpDir();
+    const cfg = validConfig(join(dir, 'unused.json'));
+    delete cfg.statePath;
+    const instance = await startSwapNode(cfg);
+    try {
+      expect(existsSync(join(dir, 'unused.json'))).toBe(false);
+    } finally {
+      await instance.stop();
+    }
+  });
+});

--- a/packages/swap/src/swap-node.ts
+++ b/packages/swap/src/swap-node.ts
@@ -70,6 +70,12 @@ import {
 import type { PaymentChannelSigner } from './payment-channel-signer.js';
 import { MultiChainClaimIssuer } from './claim-issuer.js';
 import { SwapNodeStartError } from './errors.js';
+import {
+  JsonFileSwapStateStore,
+  SwapStatePersister,
+  PersistentSeenPacketIds,
+} from './state-store.js';
+import type { SwapStateStore, PersistedSwapState } from './state-store.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -240,6 +246,25 @@ export interface SwapNodeConfig {
    * is forwarded verbatim; `startSwapNode()` does NOT size-cap it.
    */
   seenPacketIds?: Set<string>;
+
+  // --- State persistence (issue #46; at most one of statePath/stateStore) ---
+  /**
+   * Path to the swap node's durable state snapshot (JSON). When set, `startSwapNode`
+   * creates a {@link JsonFileSwapStateStore} at this path, rehydrates
+   * inventory / channel watermarks / sticky bindings / replay reservations
+   * from it, and persists (write-ahead) on every claim issuance. Persisted
+   * values WIN over config-supplied initial values for keys present in the
+   * snapshot — delete the file to intentionally reset. When neither this
+   * nor `stateStore` is set, the swap node runs in-memory as before (state is
+   * lost on restart).
+   */
+  statePath?: string;
+  /**
+   * Operator-supplied {@link SwapStateStore} implementation (e.g. a test
+   * double or a future sqlite backend). Mutually exclusive with
+   * `statePath`.
+   */
+  stateStore?: SwapStateStore;
 
   // --- Shared infra ---
   relayUrls: readonly string[];
@@ -536,6 +561,22 @@ export function validateConfig(config: SwapNodeConfig): void {
     );
   }
 
+  if (config.statePath !== undefined && config.stateStore !== undefined) {
+    throw new SwapNodeStartError(
+      'INVALID_CONFIG',
+      'SwapNodeConfig: provide either statePath or stateStore, not both'
+    );
+  }
+  if (
+    config.statePath !== undefined &&
+    (typeof config.statePath !== 'string' || config.statePath.length === 0)
+  ) {
+    throw new SwapNodeStartError(
+      'INVALID_CONFIG',
+      'SwapNodeConfig.statePath MUST be a non-empty string when set'
+    );
+  }
+
   if (!Array.isArray(config.swapPairs) || config.swapPairs.length === 0) {
     throw new SwapNodeStartError(
       'INVALID_CONFIG',
@@ -754,16 +795,64 @@ export async function startSwapNode(
     }
   }
 
+  // 4b. Issue #46 — durable state store + rehydration.
+  //
+  // A snapshot that exists but cannot be loaded FAILS boot loudly
+  // (STATE_LOAD_FAILED): silently booting from config would reset channel
+  // watermarks below claims already handed out — the exact desync this
+  // feature prevents. Delete the state file to intentionally reset.
+  const stateStore: SwapStateStore | undefined =
+    config.stateStore ??
+    (config.statePath !== undefined
+      ? new JsonFileSwapStateStore(config.statePath)
+      : undefined);
+  let persistedState: PersistedSwapState | null = null;
+  if (stateStore) {
+    try {
+      persistedState = stateStore.load();
+    } catch (err) {
+      throw new SwapNodeStartError(
+        'STATE_LOAD_FAILED',
+        `Failed to load persisted swap-node state${config.statePath ? ` from ${config.statePath}` : ''}: ${errSummary(err).message}`,
+        { cause: err }
+      );
+    }
+    if (persistedState) {
+      logger.info?.('swap.state.rehydrated', {
+        inventoryKeys: Object.keys(persistedState.inventory).length,
+        channelKeys: Object.keys(persistedState.channels).length,
+        bindings: Object.keys(persistedState.bindings).length,
+        seenPacketIds: persistedState.seenPacketIds.length,
+      });
+    }
+  }
+
   // 5. Inventory — map operator-supplied `Record<chain, bigint>` into the
   //    `SwapInventory` per-asset/per-chain shape. We key off pair.to.assetCode
   //    for each referenced chain.
-  const inventoryInit: Record<string, { available: bigint; total: bigint }> =
-    {};
+  //
+  //    Issue #46 — persisted entries then OVERLAY the config-derived values
+  //    (persisted wins): a restart must not reset spent inventory back to
+  //    the notional boot value. Config seeds only keys the snapshot has
+  //    never recorded.
+  const inventoryInit: Record<
+    string,
+    { available: bigint; total: bigint; updatedAt?: number }
+  > = {};
   for (const pair of config.swapPairs) {
     const chain = pair.to.chain;
     const asset = pair.to.assetCode;
     const bal = config.inventory[chain] ?? 0n;
     inventoryInit[`${asset}:${chain}`] = { available: bal, total: bal };
+  }
+  if (persistedState) {
+    for (const [k, v] of Object.entries(persistedState.inventory)) {
+      inventoryInit[k] = {
+        available: BigInt(v.available),
+        total: BigInt(v.total),
+        updatedAt: v.updatedAt,
+      };
+    }
   }
   const inventory = new SwapInventory({ balances: inventoryInit });
 
@@ -772,6 +861,13 @@ export async function startSwapNode(
   //    bootstrap we only know `chain`, not a sender — so we register each
   //    channel under `*` (wildcard) sender. The Story 12.8 E2E will replace
   //    this with per-sender provisioning as real peers connect.
+  //
+  //    Issue #46 — persisted watermarks OVERLAY config entries (persisted
+  //    wins; nonce/cumulative never regress across a restart). Persisted
+  //    keys ABSENT from config are restored too: channels provisioned
+  //    dynamically at runtime (`provisionChannel`) must keep their
+  //    watermarks — `provisionChannel` is a no-op for keys that already
+  //    exist, which protects the restored entries from being re-zeroed.
   const channelInit: Record<string, ChannelEntry> = {};
   for (const pair of config.swapPairs) {
     const entries = config.channels[pair.to.chain] ?? [];
@@ -780,10 +876,68 @@ export async function startSwapNode(
       channelInit[key] = { ...entry };
     }
   }
+  if (persistedState) {
+    for (const [k, v] of Object.entries(persistedState.channels)) {
+      channelInit[k] = {
+        channelId: v.channelId,
+        cumulativeAmount: BigInt(v.cumulativeAmount),
+        nonce: BigInt(v.nonce),
+        updatedAt: v.updatedAt,
+      };
+    }
+  }
   const channelState = new SwapChannelState({
     channels: channelInit,
     logger: { warn: logger.warn },
+    // Restored sticky bindings keep each sender pinned to the channel its
+    // existing balance proofs were issued against (dangling ones dropped).
+    ...(persistedState && { bindings: persistedState.bindings }),
   });
+
+  // 6b. Issue #46 — persister + persistent replay set.
+  //
+  // The replay set is swap-node-owned ONLY when the operator did not inject
+  // `config.seenPacketIds`. An operator-supplied set is forwarded verbatim
+  // (SDK contract) and NOT persisted — on restart the accepted replay
+  // window is that set's own bound; we surface this at `warn`.
+  let persistentSeen: PersistentSeenPacketIds | undefined;
+  if (stateStore && config.seenPacketIds === undefined) {
+    persistentSeen = new PersistentSeenPacketIds(
+      persistedState?.seenPacketIds ?? []
+    );
+  } else if (stateStore && config.seenPacketIds !== undefined) {
+    logger.warn?.('swap.state.seen_packet_ids_not_persisted', {
+      reason:
+        'operator-supplied seenPacketIds is used verbatim and is not included in the persisted snapshot; replay reservations reset on restart',
+    });
+  }
+  const persister = stateStore
+    ? new SwapStatePersister({
+        store: stateStore,
+        inventory,
+        channelState,
+        ...(persistentSeen && { seenPacketIds: persistentSeen }),
+      })
+    : undefined;
+  if (persister && persistentSeen) {
+    // Every replay reservation (added by the SDK handler BEFORE a claim is
+    // issued) hits disk synchronously — crash rule 4 in state-store.ts.
+    persistentSeen.setOnMutate(() => persister.persist());
+  }
+  if (persister) {
+    // Boot-time snapshot: verifies writability up front (fail fast instead
+    // of on the first claim) and materializes the merged config+persisted
+    // state so a crash before the first claim still restores correctly.
+    try {
+      persister.persist();
+    } catch (err) {
+      throw new SwapNodeStartError(
+        'STATE_PERSIST_FAILED',
+        `Failed to write initial swap-node state snapshot${config.statePath ? ` to ${config.statePath}` : ''}: ${errSummary(err).message}`,
+        { cause: err }
+      );
+    }
+  }
 
   // 7. signerAddresses map + claim issuer.
   const signerAddresses = buildSignerAddresses(config.swapPairs, swapNodeKeys);
@@ -792,6 +946,8 @@ export async function startSwapNode(
     signers,
     channelState,
     signerAddresses,
+    // Issue #46 — write-ahead persist before any claim leaves the process.
+    ...(persister && { persistState: () => persister.persist() }),
     logger: {
       debug: logger.debug,
       info: logger.info,
@@ -806,7 +962,14 @@ export async function startSwapNode(
     swapPairs: [...config.swapPairs],
     claimIssuer,
     ...(config.rateProvider && { rateProvider: config.rateProvider }),
-    ...(config.seenPacketIds && { seenPacketIds: config.seenPacketIds }),
+    // Issue #46 — prefer the operator's set (verbatim, SDK contract), else
+    // the swap-node-owned persistent replay set when persistence is enabled,
+    // else the SDK's default in-memory LRU.
+    ...((config.seenPacketIds ?? persistentSeen) && {
+      seenPacketIds: (config.seenPacketIds ?? persistentSeen) as NonNullable<
+        CreateSwapHandlerConfig['seenPacketIds']
+      >,
+    }),
     logger: {
       debug: logger.debug,
       info: logger.info,
@@ -1453,6 +1616,11 @@ export async function startSwapNode(
           });
         }
       }
+      // Issue #46 — deliberately NO persist here: `releaseAll()` zeroes the
+      // in-memory reservation bookkeeping for GC, but the on-disk snapshot
+      // must keep the last handed-out watermarks (they are what the next
+      // boot rehydrates). Persisting the zeroed state would be the
+      // watermark reset this feature exists to prevent.
       try {
         channelState.releaseAll();
       } catch (err) {


### PR DESCRIPTION
## Summary

All mill state was in-memory and lost on restart (`channel-state.ts` header, `inventory.ts`, sdk-side replay LRU). A crash mid-stream desynchronized the mill's channel watermark from claims already handed to counterparties — a hard blocker for the rolling engine (#47), which keeps many per-packet advances in flight. This PR makes inventory, channel nonce/cumulative watermarks, sticky sender→channel bindings, and replay reservations durable, with restore-on-startup and write-ahead ordering.

## Persistence model

- **One JSON snapshot file** (`state-store.ts`), following toon-client's `JsonFileChannelStore` pattern with atomic-rename hardening: every save writes `<path>.tmp`, `fsync`s, then `rename`s over `<path>` (+ best-effort directory fsync). A crash mid-write leaves either the previous or the new complete snapshot — never a torn file. Writes are synchronous to preserve the mill's microtask-atomicity invariants (`debit`/`reserve` are sync, so reserve→persist→sign cannot interleave).
- **Opt-in**: `MillConfig.statePath` (CLI config `statePath`, env `MILL_STATE_PATH`) or an operator-supplied `MillConfig.stateStore` (e.g. future sqlite backend). Without either, the mill runs in-memory exactly as before.
- **Rehydration on `startMill`**: persisted entries WIN over config-supplied notionals for keys in the snapshot (a restart must never reset spent inventory or watermarks); config seeds only never-seen keys. Persisted channels absent from config are restored too, so dynamically `provisionChannel`ed channels keep their watermarks (`provisionChannel` is a no-op for existing keys). Delete the state file to intentionally reset.
- **Replay reservations**: when persistence is on and no operator `seenPacketIds` is injected, the mill supplies a `PersistentSeenPacketIds` (bounded FIFO, cap 10k = SDK default) to `createSwapHandler`; every add/delete is snapshotted synchronously. Operator-supplied sets are forwarded verbatim and NOT persisted (surfaced at `warn`; replay window then resets on restart).

## Crash-consistency guarantees (documented in `state-store.ts`)

1. **Persist-before-hand-out**: `MultiChainClaimIssuer.issueClaim` persists the post-reserve watermark AFTER debit+reserve and BEFORE `signBalanceProof` — the stored watermark is always ≥ any watermark embedded in a claim a counterparty could hold. If the write-ahead persist throws, debit+reserve are rolled back and the claim is refused (`PERSISTENCE_FAILED` → ILP T00).
2. **Crash between debit and FULFILL** (the recovery rule the issue asked to define): the snapshot may contain reservations for claims never delivered — deliberately the safe side. On restart the next claim continues monotonically ABOVE the aborted reservation (nonce gap is fine, claims are cumulative), and inventory under-reports rather than over-reports; aborted amounts are recoverable via `credit`/settlement reconciliation.
3. **Signer-failure rollback** re-persists the reversed state best-effort; a crash before that persist leaves the (safe, over-reserved) write-ahead snapshot.
4. **Replay fail-closed**: the handler adds the packet id before issuing; after a crash a reserved-but-unfulfilled packet is F04-rejected rather than double-issued.
5. **Shutdown does not persist**: `stop()`'s `releaseAll()` zeroes memory only; the disk snapshot keeps the last handed-out watermarks for the next boot.
6. **Corruption fails loudly**: an unreadable/invalid snapshot aborts boot with `STATE_LOAD_FAILED` instead of silently resetting watermarks; boot also writes an initial snapshot to fail fast on unwritable paths (`STATE_PERSIST_FAILED`).

## Acceptance criteria

- ✅ Restart mid-stream: next claim continues nonce/cumulative monotonically — `state-store.test.ts` "restart mid-stream", "crash between debit and FULFILL"
- ✅ Inventory survives restart; `GET /health` reflects rehydrated values — `mill-persistence.test.ts`
- ✅ Crash between debit and FULFILL leaves recoverable state; recovery rule documented (`state-store.ts` module docblock, rules 1–5)
- ✅ Tests cover restart + rollback paths (30 new tests)

## Testing

- `pnpm -r build` ✅; `pnpm -r test` ✅ 160 passed / 2 skipped (baseline on main: 130 / 2); `pnpm lint` 0 errors; `pnpm format:check` clean
- Manually verified end-to-end through the built CLI: boot with `statePath` → snapshot written + `/health` ok → `kill -9` → snapshot mutated to simulate mid-stream state → reboot rehydrates (health shows persisted 400000/1000000, watermark nonce 23 kept across a clean stop) → corrupt file → boot fails with `STATE_LOAD_FAILED`

Note: branched off `origin/main`; expected to conflict trivially with the parallel sdk-1.x migration (#45) — merge-order resolution is anticipated.

Part of toon-protocol/toon-meta#145. Closes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
