### PR TITLE
Rolling swap: maker staleness-reject (maxRateAge) — prototype + calibration

### DIFF
--- a/.changeset/tidy-clocks-refuse.md
+++ b/.changeset/tidy-clocks-refuse.md
@@ -1,0 +1,14 @@
+---
+'@toon-protocol/swap': minor
+---
+
+Maker staleness-reject (`maxRateAge`) prototype — toon-protocol/swap#48, rolling-swap epic toon-meta#145 (spec §4).
+
+New maker-owned per-chain/per-pair freshness bound: when configured, any kind:1059 fill packet whose pair's rate feed has not ticked within the bound is rejected BENIGNLY — before the replay reservation, pricing, and leg-B claim issuance — with a machine-distinguishable contract the sender treats as "re-quote and retry":
+
+- handler-level code `T99`, `message: 'stale_rate'`, base64-JSON `data` `{"reason":"stale_rate","maxRateAgeMs":…,"lastRateAt":…,"pair":…}` (`StaleRateRejectData`)
+- `rejectReason.code: 'timeout'` → wire T00 (T-class, retryable) on connector <=3.20.1, whose `REJECT_CODE_MAP` has no `stale_rate`/T99 entry yet; senders MUST discriminate on `data.reason === 'stale_rate'` (fallback `message`), not the wire code
+
+Config: `SwapNodeConfig.maxRateAge` (`{ defaultMs?, perChain?, perPair? }`; perPair > min(perChain across both legs, exact id or family) > defaultMs), env `SWAP_MAX_RATE_AGE` (JSON) / `SWAP_MAX_RATE_AGE_MS`. Requires a `rateProvider`; `SwapNodeConfig.rateProvider` is widened to return timestamped quotes `{ rate, at }` (bare strings still accepted — but leave the guard inert). `maxRateAge` without a `rateProvider` fails boot with `INVALID_CONFIG`.
+
+Calibrated per-chain-class starting points exported as `RECOMMENDED_MAX_RATE_AGE_MS` (`evm: 1500`, `solana: 3000`, `mina: 15000`) — derived and pinned by the seeded simulation harness in `max-rate-age.calibration.test.ts` (rule of thumb: ~4-6× the feed's median tick interval, ≈ its p99 gap). Unconfigured swap nodes are behavior-identical.

--- a/packages/swap/src/cli.ts
+++ b/packages/swap/src/cli.ts
@@ -23,6 +23,17 @@
  *   TOON_PARENT_AUTH_TOKEN — BTP auth token for the parent peer (default: "")
  *   TOON_ILP_ADDRESS       — advertised ILP address + self-route prefix
  *   TOON_NODE_ID           — connector nodeId override (default: toon-swap-<pk16>)
+ *   SWAP_MAX_RATE_AGE_MS   — maker staleness bound default (positive integer ms;
+ *                            sets/overrides maxRateAge.defaultMs)
+ *   SWAP_MAX_RATE_AGE      — full per-chain/per-pair maxRateAge config as JSON,
+ *                            e.g. '{"defaultMs":3000,"perChain":{"mina":15000}}'
+ *                            (SWAP_MAX_RATE_AGE_MS still overrides defaultMs)
+ *
+ * NOTE on maxRateAge (swap#48): the staleness bound applies to the maker's
+ * own rate-feed ticks, so it REQUIRES a `rateProvider` returning timestamped
+ * quotes — which only programmatic `startSwapNode()` embeddings can supply.
+ * Setting it on a static-rate JSON-config swap node fails boot with
+ * INVALID_CONFIG (loud by design; a static rate has no age to measure).
  */
 
 import { parseArgs } from 'node:util';
@@ -79,6 +90,10 @@ interface CliRawConfig {
   // Embedded-connector ClaimReceiver signer + parent treasury address.
   settlementPrivateKey?: string;
   parentEvmAddress?: string;
+  // Maker staleness bound(s) — swap#48. Forwarded verbatim; startSwapNode()'s
+  // validateConfig() enforces the shape AND the rateProvider requirement
+  // (see the maxRateAge NOTE in the header).
+  maxRateAge?: unknown;
 }
 
 function toBigInt(v: unknown): bigint {
@@ -176,6 +191,9 @@ function parseRawConfig(raw: CliRawConfig): SwapNodeConfig {
     cfg.settlementPrivateKey = raw.settlementPrivateKey;
   }
   if (raw.parentEvmAddress) cfg.parentEvmAddress = raw.parentEvmAddress;
+  if (raw.maxRateAge !== undefined) {
+    cfg.maxRateAge = raw.maxRateAge as SwapNodeConfig['maxRateAge'];
+  }
   return cfg;
 }
 
@@ -217,6 +235,34 @@ function applyEnvOverlay(cfg: SwapNodeConfig): SwapNodeConfig {
   }
   if (env['TOON_ILP_ADDRESS']) out.ilpAddress = env['TOON_ILP_ADDRESS'];
   if (env['TOON_NODE_ID']) out.nodeId = env['TOON_NODE_ID'];
+  // Maker staleness bound(s) — swap#48. SWAP_MAX_RATE_AGE replaces the whole
+  // structure; SWAP_MAX_RATE_AGE_MS then overrides just defaultMs (so the two
+  // compose: JSON for per-chain/per-pair shape, _MS for a quick default).
+  if (env['SWAP_MAX_RATE_AGE']) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(env['SWAP_MAX_RATE_AGE']);
+    } catch {
+      throw new Error(
+        'SWAP_MAX_RATE_AGE must be valid JSON, e.g. {"defaultMs":3000,"perChain":{"mina":15000}}'
+      );
+    }
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      throw new Error('SWAP_MAX_RATE_AGE must be a JSON object');
+    }
+    out.maxRateAge = parsed as SwapNodeConfig['maxRateAge'];
+  }
+  if (env['SWAP_MAX_RATE_AGE_MS']) {
+    const ms = Number(env['SWAP_MAX_RATE_AGE_MS']);
+    if (!Number.isFinite(ms) || !Number.isInteger(ms) || ms <= 0) {
+      throw new Error('SWAP_MAX_RATE_AGE_MS must be a positive integer (ms)');
+    }
+    out.maxRateAge = { ...(out.maxRateAge ?? {}), defaultMs: ms };
+  }
   return out;
 }
 

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -81,6 +81,33 @@ export type {
 export { SwapNodeStartError } from './errors.js';
 export type { SwapNodeStartErrorCode } from './errors.js';
 
+// Maker staleness reject — maxRateAge (toon-protocol/swap#48, rolling-swap §4)
+export {
+  RateFreshnessGuard,
+  withMaxRateAge,
+  buildStaleRateReject,
+  normalizeRateProvider,
+  validateMaxRateAgeConfig,
+  pairKey,
+  StaleRateError,
+  STALE_RATE_REJECT_CODE,
+  STALE_RATE_REJECT_MESSAGE,
+  STALE_RATE_REASON,
+  STALE_RATE_SEMANTIC_REASON,
+  RECOMMENDED_MAX_RATE_AGE_MS,
+} from './rate-staleness.js';
+export type {
+  MaxRateAgeConfig,
+  SwapRateProvider,
+  SwapRateQuote,
+  TimestampedRate,
+  StaleRateRejectData,
+  FreshnessVerdict,
+  RateFreshnessGuardConfig,
+  WithMaxRateAgeOptions,
+  RateStalenessLogger,
+} from './rate-staleness.js';
+
 // Convenience re-export for operators (Story 12.7 AC-1) — do not wrap.
 export { createSwapHandler } from '@toon-protocol/sdk';
 export type { CreateSwapHandlerConfig } from '@toon-protocol/sdk';

--- a/packages/swap/src/max-rate-age.calibration.test.ts
+++ b/packages/swap/src/max-rate-age.calibration.test.ts
@@ -1,0 +1,417 @@
+/**
+ * maxRateAge calibration harness — toon-protocol/swap#48 (epic toon-meta#145).
+ *
+ * The epic's highest-risk open question: too loose a bound → a slow-feed
+ * maker gets farmed for stale prices; too tight → constant `stale_rate`
+ * rejects on slow chains (Mina) and the swap stalls. This harness MODELS the
+ * tradeoff so the recommended per-chain-class defaults
+ * ({@link RECOMMENDED_MAX_RATE_AGE_MS}) are derived, not guessed — and stay
+ * pinned by assertions as the code evolves.
+ *
+ * ## Model
+ *
+ * - The maker's rate feed is a renewal process: tick intervals are
+ *   lognormal(medianTickMs, sigma), with probability `gapProb` an interval is
+ *   instead a "gap" — a feed outage/hiccup, lognormal(gapMedianMs, gapSigma).
+ *   (The rolling-swap spec's worked example is a 12.6 s Mina feed gap
+ *   tripping a 10 s bound — the mina-class model reproduces that regime.)
+ * - Fill packets arrive as a Poisson process, independent of the feed. At
+ *   each arrival the maker evaluates `age = now − lastTick`; the packet is
+ *   REJECTED (`stale_rate`) iff `age > maxRateAge`.
+ * - Staleness exposure of an ACCEPTED fill ≈ |price drift| over `age` under
+ *   Brownian drift: `σ·√(age)` bps, evaluated at a calm regime (~1 bps/√s ≈
+ *   60%-annualized crypto vol) and a burst regime (10×). The adversary farms
+ *   exactly this: it fills only when the market has moved more than the
+ *   half-spread since the maker's last tick, so `σ·√(maxRateAge)` vs the
+ *   half-spread is the "farmability" budget the bound caps.
+ * - Stall behavior: a feed blackout longer than the bound rejects EVERY
+ *   packet until the next tick, so `maxBlackoutMs = max(interval − A)` is
+ *   how long a sender (backing off ≥ one maxRateAge per the spec) is stalled.
+ *
+ * Deterministic (seeded mulberry32) — same numbers on every run/CI box.
+ *
+ * Run `CALIBRATE=1 vitest run src/max-rate-age.calibration.test.ts` to print
+ * the full reject-rate/exposure curves behind the recommendations.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { RECOMMENDED_MAX_RATE_AGE_MS } from './rate-staleness.js';
+
+// ---------------------------------------------------------------------------
+// Deterministic PRNG + samplers
+// ---------------------------------------------------------------------------
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Standard normal via Box-Muller. */
+function gaussian(rng: () => number): number {
+  let u = 0;
+  while (u === 0) u = rng(); // avoid log(0)
+  const v = rng();
+  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}
+
+/** Lognormal parameterized by its MEDIAN (exp(mu)) and shape sigma. */
+function lognormal(rng: () => number, median: number, sigma: number): number {
+  return median * Math.exp(sigma * gaussian(rng));
+}
+
+/** Exponential inter-arrival with the given mean. */
+function exponential(rng: () => number, mean: number): number {
+  let u = 0;
+  while (u === 0) u = rng();
+  return -mean * Math.log(u);
+}
+
+function quantile(sortedAscending: readonly number[], q: number): number {
+  if (sortedAscending.length === 0) return NaN;
+  const idx = Math.min(
+    sortedAscending.length - 1,
+    Math.floor(q * sortedAscending.length)
+  );
+  return sortedAscending[idx]!;
+}
+
+// ---------------------------------------------------------------------------
+// Feed models (assumptions — documented, maker-tunable in reality)
+// ---------------------------------------------------------------------------
+
+interface FeedModel {
+  name: string;
+  /** Median feed tick interval (ms). */
+  medianTickMs: number;
+  /** Lognormal shape of regular tick intervals. */
+  sigma: number;
+  /** Probability an interval is a gap (feed hiccup/outage) instead. */
+  gapProb: number;
+  /** Median gap length (ms). */
+  gapMedianMs: number;
+  /** Lognormal shape of gaps. */
+  gapSigma: number;
+  /** Simulated horizon (ms). */
+  horizonMs: number;
+  /** Poisson fill-packet arrival rate (packets/sec). */
+  packetsPerSec: number;
+  seed: number;
+}
+
+/**
+ * Base-class EVM L2: the maker prices off a CEX websocket ticker —
+ * sub-second cadence, rare short hiccups.
+ */
+const BASE_CLASS: FeedModel = {
+  name: 'evm (Base-class)',
+  medianTickMs: 250,
+  sigma: 0.5,
+  gapProb: 0.001,
+  gapMedianMs: 2_000,
+  gapSigma: 0.5,
+  horizonMs: 4 * 3_600_000,
+  packetsPerSec: 2,
+  seed: 0xba5e,
+};
+
+/** Solana-class: ~500 ms feed cadence, slightly gappier. */
+const SOLANA_CLASS: FeedModel = {
+  name: 'solana',
+  medianTickMs: 500,
+  sigma: 0.5,
+  gapProb: 0.002,
+  gapMedianMs: 4_000,
+  gapSigma: 0.5,
+  horizonMs: 4 * 3_600_000,
+  packetsPerSec: 2,
+  seed: 0x50a1a,
+};
+
+/**
+ * Mina-class: seconds-scale feed with a heavy gap tail — the spec's worked
+ * example (§9: a 12.6 s feed gap against maxRateAge = 10 s) lives in this
+ * regime.
+ */
+const MINA_CLASS: FeedModel = {
+  name: 'mina',
+  medianTickMs: 4_000,
+  sigma: 0.6,
+  gapProb: 0.02,
+  gapMedianMs: 12_000,
+  gapSigma: 0.4,
+  horizonMs: 12 * 3_600_000,
+  packetsPerSec: 2,
+  seed: 0x314a,
+};
+
+/** Volatility regimes for the exposure proxy (bps per √second). */
+const VOL_CALM_BPS_SQRT_S = 1; // ≈ 60%-annualized
+const VOL_BURST_BPS_SQRT_S = 10; // 10× vol burst — when farming actually pays
+
+// ---------------------------------------------------------------------------
+// Simulation
+// ---------------------------------------------------------------------------
+
+interface SimData {
+  /** Quote age (ms) at each packet arrival, in arrival order. */
+  agesAtArrival: number[];
+  /** Every feed inter-tick interval (ms). */
+  intervals: number[];
+}
+
+function simulateFeed(model: FeedModel): SimData {
+  const rng = mulberry32(model.seed);
+  // 1. Tick times.
+  const intervals: number[] = [];
+  const tickTimes: number[] = [0];
+  let t = 0;
+  while (t < model.horizonMs) {
+    const isGap = rng() < model.gapProb;
+    const interval = isGap
+      ? lognormal(rng, model.gapMedianMs, model.gapSigma)
+      : lognormal(rng, model.medianTickMs, model.sigma);
+    intervals.push(interval);
+    t += interval;
+    tickTimes.push(t);
+  }
+  // 2. Packet arrivals (independent Poisson), merged against ticks.
+  const meanInterArrival = 1000 / model.packetsPerSec;
+  const agesAtArrival: number[] = [];
+  let arrival = exponential(rng, meanInterArrival);
+  let tickIdx = 0;
+  while (arrival < model.horizonMs) {
+    while (
+      tickIdx + 1 < tickTimes.length &&
+      tickTimes[tickIdx + 1]! <= arrival
+    ) {
+      tickIdx++;
+    }
+    agesAtArrival.push(arrival - tickTimes[tickIdx]!);
+    arrival += exponential(rng, meanInterArrival);
+  }
+  return { agesAtArrival, intervals };
+}
+
+interface CandidateMetrics {
+  maxRateAgeMs: number;
+  rejectRate: number;
+  /** p99 quote age among ACCEPTED fills (ms). */
+  p99AcceptedAgeMs: number;
+  meanAcceptedAgeMs: number;
+  /** Longest feed blackout beyond the bound (ms) — worst sender stall. */
+  maxBlackoutMs: number;
+  /** Worst-case per-fill drift bound σ·√A (bps) at calm / burst vol. */
+  worstExposureCalmBps: number;
+  worstExposureBurstBps: number;
+  /** Expected per-fill drift E[σ√age | accepted] (bps) at burst vol. */
+  meanExposureBurstBps: number;
+}
+
+function evaluate(sim: SimData, candidatesMs: number[]): CandidateMetrics[] {
+  return candidatesMs.map((A) => {
+    let rejects = 0;
+    let acceptedSum = 0;
+    let exposureSum = 0;
+    const accepted: number[] = [];
+    for (const age of sim.agesAtArrival) {
+      if (age > A) {
+        rejects++;
+      } else {
+        accepted.push(age);
+        acceptedSum += age;
+        exposureSum += Math.sqrt(age / 1000);
+      }
+    }
+    accepted.sort((a, b) => a - b);
+    let maxBlackoutMs = 0;
+    for (const interval of sim.intervals) {
+      const blackout = interval - A;
+      if (blackout > maxBlackoutMs) maxBlackoutMs = blackout;
+    }
+    const nAccepted = accepted.length;
+    return {
+      maxRateAgeMs: A,
+      rejectRate: rejects / sim.agesAtArrival.length,
+      p99AcceptedAgeMs: quantile(accepted, 0.99),
+      meanAcceptedAgeMs: nAccepted ? acceptedSum / nAccepted : NaN,
+      maxBlackoutMs,
+      worstExposureCalmBps: VOL_CALM_BPS_SQRT_S * Math.sqrt(A / 1000),
+      worstExposureBurstBps: VOL_BURST_BPS_SQRT_S * Math.sqrt(A / 1000),
+      meanExposureBurstBps: nAccepted
+        ? (VOL_BURST_BPS_SQRT_S * exposureSum) / nAccepted
+        : NaN,
+    };
+  });
+}
+
+function report(model: FeedModel, metrics: CandidateMetrics[]): void {
+  if (!process.env['CALIBRATE']) return;
+  // eslint-disable-next-line no-console
+  console.log(
+    `\n=== ${model.name} — median tick ${model.medianTickMs}ms, gapProb ${model.gapProb}, gap median ${model.gapMedianMs}ms ===`
+  );
+  // eslint-disable-next-line no-console
+  console.table(
+    metrics.map((m) => ({
+      'A (ms)': m.maxRateAgeMs,
+      'reject %': (m.rejectRate * 100).toFixed(2),
+      'p99 fill age (ms)': Math.round(m.p99AcceptedAgeMs),
+      'max stall (ms)': Math.round(m.maxBlackoutMs),
+      'worst exp calm (bps)': m.worstExposureCalmBps.toFixed(1),
+      'worst exp burst (bps)': m.worstExposureBurstBps.toFixed(1),
+      'mean exp burst (bps)': m.meanExposureBurstBps.toFixed(1),
+    }))
+  );
+}
+
+// ---------------------------------------------------------------------------
+// The curves
+// ---------------------------------------------------------------------------
+
+const BASE_CANDIDATES = [100, 250, 500, 750, 1_000, 1_500, 2_000, 3_000, 5_000];
+const SOLANA_CANDIDATES = [250, 500, 1_000, 1_500, 2_000, 3_000, 5_000, 10_000];
+const MINA_CANDIDATES = [
+  2_000, 4_000, 6_000, 8_000, 10_000, 12_000, 15_000, 20_000, 30_000, 60_000,
+];
+
+const baseSim = simulateFeed(BASE_CLASS);
+const baseMetrics = evaluate(baseSim, BASE_CANDIDATES);
+const solanaSim = simulateFeed(SOLANA_CLASS);
+const solanaMetrics = evaluate(solanaSim, SOLANA_CANDIDATES);
+const minaSim = simulateFeed(MINA_CLASS);
+const minaMetrics = evaluate(minaSim, MINA_CANDIDATES);
+
+function at(metrics: CandidateMetrics[], A: number): CandidateMetrics {
+  const m = metrics.find((x) => x.maxRateAgeMs === A);
+  if (!m) throw new Error(`no candidate ${A}`);
+  return m;
+}
+
+describe('maxRateAge calibration — reject-rate vs staleness-exposure curves', () => {
+  it('prints the calibration tables when CALIBRATE=1', () => {
+    report(BASE_CLASS, baseMetrics);
+    report(SOLANA_CLASS, solanaMetrics);
+    report(MINA_CLASS, minaMetrics);
+    expect(true).toBe(true);
+  });
+
+  it('sanity: reject rate is non-increasing and exposure non-decreasing in the bound', () => {
+    for (const metrics of [baseMetrics, solanaMetrics, minaMetrics]) {
+      for (let i = 1; i < metrics.length; i++) {
+        expect(metrics[i]!.rejectRate).toBeLessThanOrEqual(
+          metrics[i - 1]!.rejectRate + 1e-12
+        );
+        expect(metrics[i]!.meanAcceptedAgeMs).toBeGreaterThanOrEqual(
+          metrics[i - 1]!.meanAcceptedAgeMs - 1e-9
+        );
+      }
+    }
+  });
+
+  it('too tight — a bound at the feed median tick is a reject storm on every class', () => {
+    // This is the "constant rejects on Mina" failure mode from the epic: at
+    // A ≈ the median tick interval, a third or more of all packets bounce.
+    expect(at(baseMetrics, 250).rejectRate).toBeGreaterThan(0.2);
+    expect(at(solanaMetrics, 500).rejectRate).toBeGreaterThan(0.2);
+    expect(at(minaMetrics, 4_000).rejectRate).toBeGreaterThan(0.2);
+  });
+
+  it('spec §4 indicative "low hundreds of ms" on Base-class is TOO TIGHT for a ~250ms feed', () => {
+    // Calibration finding (revises the spec's indicative starting point):
+    // the bound must clear several multiples of the feed cadence, or fresh
+    // traffic is rejected en masse.
+    expect(at(baseMetrics, 100).rejectRate).toBeGreaterThan(0.5);
+    // Even 2× the median cadence still bounces >3% of fresh traffic.
+    expect(at(baseMetrics, 500).rejectRate).toBeGreaterThan(0.03);
+  });
+
+  it('recommended default (evm: 1500ms) keeps rejects under 1% with sub-25bps burst exposure', () => {
+    expect(RECOMMENDED_MAX_RATE_AGE_MS['evm']).toBe(1_500);
+    const m = at(baseMetrics, 1_500);
+    expect(m.rejectRate).toBeLessThan(0.01);
+    expect(m.worstExposureBurstBps).toBeLessThan(25);
+    // No reject storm ⇒ the swap keeps rolling: worst stall ≈ the worst
+    // feed blackout beyond the bound, seconds not minutes.
+    expect(m.maxBlackoutMs).toBeLessThan(10_000);
+  });
+
+  it('recommended default (solana: 3000ms) keeps rejects under 1%', () => {
+    expect(RECOMMENDED_MAX_RATE_AGE_MS['solana']).toBe(3_000);
+    const m = at(solanaMetrics, 3_000);
+    expect(m.rejectRate).toBeLessThan(0.01);
+    expect(m.maxBlackoutMs).toBeLessThan(15_000);
+  });
+
+  it('recommended default (mina: 15000ms) — no reject storm under Mina-class latency (AC)', () => {
+    expect(RECOMMENDED_MAX_RATE_AGE_MS['mina']).toBe(15_000);
+    const m = at(minaMetrics, 15_000);
+    // "no reject storm at recommended settings under Mina-class latency"
+    expect(m.rejectRate).toBeLessThan(0.02);
+  });
+
+  it("the spec's worked-example bound (mina: 10s) rejects materially more than 15s — quantifying the §9 story", () => {
+    const at10 = at(minaMetrics, 10_000);
+    const at15 = at(minaMetrics, 15_000);
+    // The §9 example (12.6s gap vs 10s bound) is a routine event in this
+    // regime, not a fluke: 10s trips several times as often as 15s.
+    expect(at10.rejectRate).toBeGreaterThan(at15.rejectRate * 2);
+  });
+
+  it('loosening mina past ~20s buys almost no fewer rejects but linearly more farmable exposure', () => {
+    const at20 = at(minaMetrics, 20_000);
+    const at60 = at(minaMetrics, 60_000);
+    // Reject-rate improvement collapses past the gap tail…
+    expect(at20.rejectRate - at60.rejectRate).toBeLessThan(0.01);
+    // …while the worst-case staleness budget an adversary can farm keeps
+    // growing with √A (77 bps at 60s burst — several half-spreads).
+    expect(at60.worstExposureBurstBps).toBeGreaterThan(
+      at20.worstExposureBurstBps * 1.5
+    );
+  });
+
+  it('mina finding: even at the recommended bound, burst-vol exposure exceeds a typical half-spread', () => {
+    // σ_burst·√15s ≈ 39 bps > a typical 10-30 bps half-spread: on slow-feed
+    // chains maxRateAge alone CANNOT price away burst-regime staleness.
+    // The residual must come from the advertised spread and the §6
+    // controller shrinking δ on stale_rate signals — documented as a design
+    // consequence, not a bug in the bound.
+    const m = at(minaMetrics, 15_000);
+    expect(m.worstExposureBurstBps).toBeGreaterThan(30);
+  });
+
+  it('rule of thumb: the knee sits at ~4-6× median tick (3.5-8× band), ≥ 0.8× p99 tick interval', () => {
+    for (const [model, metrics, rec] of [
+      [BASE_CLASS, baseMetrics, RECOMMENDED_MAX_RATE_AGE_MS['evm']!],
+      [SOLANA_CLASS, solanaMetrics, RECOMMENDED_MAX_RATE_AGE_MS['solana']!],
+      [MINA_CLASS, minaMetrics, RECOMMENDED_MAX_RATE_AGE_MS['mina']!],
+    ] as const) {
+      const sorted = [
+        ...(metrics === baseMetrics
+          ? baseSim.intervals
+          : metrics === solanaMetrics
+            ? solanaSim.intervals
+            : minaSim.intervals),
+      ].sort((a, b) => a - b);
+      const p99Interval = quantile(sorted, 0.99);
+      expect(rec).toBeGreaterThanOrEqual(3.5 * model.medianTickMs);
+      expect(rec).toBeLessThanOrEqual(8 * model.medianTickMs);
+      // ≥ 0.8× p99: the recommended bound sits AT the knee — just inside
+      // the feed's gap tail (mina's p99 interval ≈ 17.3s vs rec 15s), which
+      // is exactly why its residual reject rate (~1.5%) is higher than the
+      // fast chains'. Sitting fully past the tail (20s+) trades near-zero
+      // rejects for linearly more farmable exposure — see the next test.
+      expect(rec).toBeGreaterThanOrEqual(p99Interval * 0.8);
+    }
+  });
+
+  it('determinism: the harness is seeded — same curve on every run', () => {
+    const again = evaluate(simulateFeed(MINA_CLASS), [15_000]);
+    expect(again[0]!.rejectRate).toBe(at(minaMetrics, 15_000).rejectRate);
+  });
+});

--- a/packages/swap/src/rate-staleness.test.ts
+++ b/packages/swap/src/rate-staleness.test.ts
@@ -1,0 +1,511 @@
+/**
+ * Unit tests for the maker staleness reject (`maxRateAge`) — swap#48.
+ *
+ * Covers:
+ *   - bound resolution precedence (perPair > perChain exact/family min > default)
+ *   - fresh/stale boundary semantics (strictly-greater-than the bound)
+ *   - provider-failure fallback (age against last good tick)
+ *   - untimestamped-quote inertness (warn once, treat as fresh)
+ *   - the reject contract shape (T99 / 'stale_rate' / base64-JSON data /
+ *     rejectReason NOT left to the generic ilpCodeToSemantic collapse)
+ *   - the withMaxRateAge gate: stale reject BEFORE the inner handler runs,
+ *     fresh/malformed/unsupported-pair pass-through, non-1059 pass-through
+ *   - toSdkRateProvider: normalization + pricing-time staleness backstop
+ *   - validateMaxRateAgeConfig / SwapNodeConfig.maxRateAge validation
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
+import type { UnsignedEvent } from 'nostr-tools/pure';
+import { wrapSwapPacket, createHandlerContext } from '@toon-protocol/sdk';
+import type { Handler, HandlerContext } from '@toon-protocol/sdk';
+import { encodeEventToToon } from '@toon-protocol/core';
+import type { SwapPair } from '@toon-protocol/core';
+
+import {
+  RateFreshnessGuard,
+  withMaxRateAge,
+  buildStaleRateReject,
+  normalizeRateProvider,
+  validateMaxRateAgeConfig,
+  pairKey,
+  StaleRateError,
+  STALE_RATE_REJECT_CODE,
+  STALE_RATE_REJECT_MESSAGE,
+  STALE_RATE_REASON,
+  STALE_RATE_SEMANTIC_REASON,
+  RECOMMENDED_MAX_RATE_AGE_MS,
+} from './rate-staleness.js';
+import type { StaleRateRejectData } from './rate-staleness.js';
+import { validateConfig } from './swap-node.js';
+import type { SwapNodeConfig } from './swap-node.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PAIR_EVM: SwapPair = {
+  from: { assetCode: 'USDC', assetScale: 6, chain: 'evm:31337' },
+  to: { assetCode: 'ETH', assetScale: 18, chain: 'evm:31337' },
+  rate: '0.0004',
+};
+
+const PAIR_MINA: SwapPair = {
+  from: { assetCode: 'USDC', assetScale: 6, chain: 'evm:31337' },
+  to: { assetCode: 'MINA', assetScale: 9, chain: 'mina:devnet' },
+  rate: '2.5',
+};
+
+function guardWith(opts: {
+  maxRateAge: ConstructorParameters<typeof RateFreshnessGuard>[0]['maxRateAge'];
+  provider?: ConstructorParameters<
+    typeof RateFreshnessGuard
+  >[0]['rateProvider'];
+  now?: () => number;
+  warn?: (...args: unknown[]) => void;
+}): RateFreshnessGuard {
+  return new RateFreshnessGuard({
+    maxRateAge: opts.maxRateAge,
+    rateProvider:
+      opts.provider ?? (() => ({ rate: '1', at: opts.now?.() ?? 0 })),
+    ...(opts.now && { now: opts.now }),
+    ...(opts.warn && { logger: { warn: opts.warn } }),
+  });
+}
+
+function decodeRejectData(dataB64: string): StaleRateRejectData {
+  return JSON.parse(
+    Buffer.from(dataB64, 'base64').toString('utf8')
+  ) as StaleRateRejectData;
+}
+
+// ---------------------------------------------------------------------------
+// pairKey + bound resolution
+// ---------------------------------------------------------------------------
+
+describe('pairKey', () => {
+  it('formats FROMASSET:fromChain->TOASSET:toChain', () => {
+    expect(pairKey(PAIR_MINA)).toBe('USDC:evm:31337->MINA:mina:devnet');
+  });
+});
+
+describe('RateFreshnessGuard.resolveMaxRateAgeMs', () => {
+  it('perPair beats perChain and default', () => {
+    const guard = guardWith({
+      maxRateAge: {
+        defaultMs: 1000,
+        perChain: { 'mina:devnet': 2000 },
+        perPair: { [pairKey(PAIR_MINA)]: 42 },
+      },
+    });
+    expect(guard.resolveMaxRateAgeMs(PAIR_MINA)).toBe(42);
+  });
+
+  it('perChain matches exact chain ids AND families across both legs, minimum wins', () => {
+    const guard = guardWith({
+      maxRateAge: {
+        defaultMs: 60_000,
+        perChain: { evm: 5000, 'mina:devnet': 2000 },
+      },
+    });
+    // PAIR_MINA touches evm:31337 (family evm → 5000) and mina:devnet (2000).
+    expect(guard.resolveMaxRateAgeMs(PAIR_MINA)).toBe(2000);
+    // PAIR_EVM only matches the evm family entry.
+    expect(guard.resolveMaxRateAgeMs(PAIR_EVM)).toBe(5000);
+  });
+
+  it('falls back to defaultMs, then undefined (unguarded)', () => {
+    const withDefault = guardWith({ maxRateAge: { defaultMs: 750 } });
+    expect(withDefault.resolveMaxRateAgeMs(PAIR_EVM)).toBe(750);
+    const empty = guardWith({ maxRateAge: {} });
+    expect(empty.resolveMaxRateAgeMs(PAIR_EVM)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// check() — freshness verdicts
+// ---------------------------------------------------------------------------
+
+describe('RateFreshnessGuard.check', () => {
+  it('fresh timestamped quote passes; age strictly greater than the bound rejects', async () => {
+    let t = 100_000;
+    let quoteAt = 100_000;
+    const guard = guardWith({
+      maxRateAge: { defaultMs: 1000 },
+      provider: () => ({ rate: '1', at: quoteAt }),
+      now: () => t,
+    });
+
+    // age == bound → NOT stale (spec: now − lastRateUpdate > maxRateAge)
+    t = 101_000;
+    expect(await guard.check(PAIR_EVM)).toEqual({ stale: false });
+
+    // age == bound + 1 → stale
+    t = 101_001;
+    const verdict = await guard.check(PAIR_EVM);
+    expect(verdict.stale).toBe(true);
+    if (verdict.stale) {
+      expect(verdict.data).toEqual({
+        reason: STALE_RATE_REASON,
+        maxRateAgeMs: 1000,
+        lastRateAt: 100_000,
+        pair: pairKey(PAIR_EVM),
+      });
+    }
+
+    // feed ticks again → fresh again ("sender re-requests and continues")
+    quoteAt = 101_000;
+    expect(await guard.check(PAIR_EVM)).toEqual({ stale: false });
+  });
+
+  it('unguarded pair (no bound resolves) never consults the provider', async () => {
+    const provider = vi.fn(() => ({ rate: '1', at: 0 }));
+    const guard = guardWith({
+      maxRateAge: { perChain: { 'solana:devnet': 100 } },
+      provider,
+    });
+    expect(await guard.check(PAIR_EVM)).toEqual({ stale: false });
+    expect(provider).not.toHaveBeenCalled();
+  });
+
+  it('provider failure ages against the last good tick; never-ticked → stale with lastRateAt null', async () => {
+    let t = 50_000;
+    let fail = true;
+    const guard = guardWith({
+      maxRateAge: { defaultMs: 1000 },
+      provider: () => {
+        if (fail) throw new Error('feed down');
+        return { rate: '1', at: t };
+      },
+      now: () => t,
+    });
+
+    // Feed down and never ticked → stale, lastRateAt: null.
+    const neverTicked = await guard.check(PAIR_EVM);
+    expect(neverTicked.stale).toBe(true);
+    if (neverTicked.stale) expect(neverTicked.data.lastRateAt).toBeNull();
+
+    // Tick once, then feed goes down: within the bound → pass.
+    fail = false;
+    await guard.check(PAIR_EVM);
+    fail = true;
+    t = 50_500;
+    expect(await guard.check(PAIR_EVM)).toEqual({ stale: false });
+
+    // Past the bound while the feed is down → stale against the last tick.
+    t = 51_001;
+    const staleDown = await guard.check(PAIR_EVM);
+    expect(staleDown.stale).toBe(true);
+    if (staleDown.stale) expect(staleDown.data.lastRateAt).toBe(50_000);
+  });
+
+  it('untimestamped (bare string) quotes are inert: treated as fresh, warned once per pair', async () => {
+    const warn = vi.fn();
+    let t = 0;
+    const guard = guardWith({
+      maxRateAge: { defaultMs: 10 },
+      provider: () => '0.5',
+      now: () => t,
+      warn,
+    });
+    t = 1_000_000; // any age — unmeasurable
+    expect(await guard.check(PAIR_EVM)).toEqual({ stale: false });
+    expect(await guard.check(PAIR_EVM)).toEqual({ stale: false });
+    const untimestampedWarns = warn.mock.calls.filter(
+      (c) => c[0] === 'swap.rate_staleness.untimestamped_quote'
+    );
+    expect(untimestampedWarns.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reject contract
+// ---------------------------------------------------------------------------
+
+describe('buildStaleRateReject — the reject contract', () => {
+  const data: StaleRateRejectData = {
+    reason: STALE_RATE_REASON,
+    maxRateAgeMs: 10_000,
+    lastRateAt: 123_456,
+    pair: pairKey(PAIR_MINA),
+  };
+
+  it('emits T99 / stale_rate / base64-JSON data per rolling-swap §4', () => {
+    const reject = buildStaleRateReject(data);
+    expect(reject.accept).toBe(false);
+    expect(reject.code).toBe(STALE_RATE_REJECT_CODE);
+    expect(STALE_RATE_REJECT_CODE).toBe('T99');
+    expect(reject.message).toBe(STALE_RATE_REJECT_MESSAGE);
+    expect(STALE_RATE_REJECT_MESSAGE).toBe('stale_rate');
+    expect(decodeRejectData(reject.data)).toEqual(data);
+  });
+
+  it('pins rejectReason so the connector adapter does NOT collapse T99 to a fatal class', () => {
+    // startSwapNode()'s generic reverse-map only fills rejectReason when absent;
+    // ilpCodeToSemantic('T99') would collapse to 'invalid_request' → wire
+    // F00 (fatal). The contract pins a T-class semantic instead.
+    const reject = buildStaleRateReject(data);
+    expect(reject.rejectReason).toEqual({
+      code: STALE_RATE_SEMANTIC_REASON,
+      message: STALE_RATE_REJECT_MESSAGE,
+    });
+    // 'timeout' → T00 in connector <=3.20.1 REJECT_CODE_MAP (T-class,
+    // retryable). Flip to 'stale_rate' when the connector maps it to T99.
+    expect(STALE_RATE_SEMANTIC_REASON).toBe('timeout');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toSdkRateProvider — pricing-time backstop
+// ---------------------------------------------------------------------------
+
+describe('RateFreshnessGuard.toSdkRateProvider', () => {
+  it('returns the plain rate for fresh timestamped quotes and bare strings', async () => {
+    const t = 1_000;
+    const guard = guardWith({
+      maxRateAge: { defaultMs: 500 },
+      provider: () => ({ rate: '0.25', at: t }),
+      now: () => t,
+    });
+    await expect(guard.toSdkRateProvider()(PAIR_EVM)).resolves.toBe('0.25');
+
+    const bare = guardWith({
+      maxRateAge: { defaultMs: 500 },
+      provider: () => '0.75',
+      now: () => t,
+    });
+    await expect(bare.toSdkRateProvider()(PAIR_EVM)).resolves.toBe('0.75');
+  });
+
+  it('throws StaleRateError when the pricing-time quote is already past the bound', async () => {
+    const t = 10_000;
+    const guard = guardWith({
+      maxRateAge: { defaultMs: 500 },
+      provider: () => ({ rate: '0.25', at: 9_000 }),
+      now: () => t,
+    });
+    const err = await guard
+      .toSdkRateProvider()(PAIR_EVM)
+      .then(() => null)
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(StaleRateError);
+    expect((err as StaleRateError).code).toBe('STALE_RATE');
+    expect((err as StaleRateError).data.lastRateAt).toBe(9_000);
+  });
+});
+
+describe('normalizeRateProvider', () => {
+  it('strips timestamps without any staleness enforcement', async () => {
+    const normalized = normalizeRateProvider(() => ({ rate: '3.14', at: 0 }));
+    await expect(normalized(PAIR_EVM)).resolves.toBe('3.14');
+    const passthrough = normalizeRateProvider(() => '2.71');
+    await expect(passthrough(PAIR_EVM)).resolves.toBe('2.71');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withMaxRateAge — the gate decorator
+// ---------------------------------------------------------------------------
+
+function buildWrappedSwapCtx(opts: {
+  recipientSecretKey: Uint8Array;
+  pair?: SwapPair;
+  tags?: string[][];
+  kind?: number;
+  toonOverride?: string;
+}): HandlerContext {
+  const senderSecretKey = generateSecretKey();
+  const senderPubkey = getPublicKey(senderSecretKey);
+  let toonBase64 = opts.toonOverride;
+  if (toonBase64 === undefined) {
+    const pair = opts.pair ?? PAIR_EVM;
+    const rumor: UnsignedEvent = {
+      kind: 30_078,
+      pubkey: senderPubkey,
+      created_at: Math.floor(Date.now() / 1000),
+      content: '',
+      tags: opts.tags ?? [
+        ['swap-from', `${pair.from.assetCode}:${pair.from.chain}`],
+        ['swap-to', `${pair.to.assetCode}:${pair.to.chain}`],
+        ['chain-recipient', '0x' + '11'.repeat(20)],
+      ],
+    };
+    const { giftWrap } = wrapSwapPacket({
+      rumor,
+      senderSecretKey,
+      recipientPubkey: getPublicKey(opts.recipientSecretKey),
+    });
+    toonBase64 = Buffer.from(encodeEventToToon(giftWrap)).toString('base64');
+  }
+  return createHandlerContext({
+    toon: toonBase64,
+    meta: { kind: opts.kind ?? 1059, pubkey: '0'.repeat(64) },
+    amount: 1_000_000n,
+    destination: 'g.toon.swap.test',
+    toonDecoder: () => {
+      throw new Error('not used');
+    },
+  });
+}
+
+describe('withMaxRateAge gate', () => {
+  const recipientSecretKey = generateSecretKey();
+
+  function innerSpy(): { handler: Handler; calls: HandlerContext[] } {
+    const calls: HandlerContext[] = [];
+    const handler: Handler = async (ctx) => {
+      calls.push(ctx);
+      return ctx.accept({ inner: true });
+    };
+    return { handler, calls };
+  }
+
+  it('stale pair → T99 stale_rate reject; the inner handler NEVER runs', async () => {
+    const t = 100_000;
+    const guard = guardWith({
+      maxRateAge: { defaultMs: 1000 },
+      provider: () => ({ rate: '0.0004', at: 90_000 }),
+      now: () => t,
+    });
+    const { handler, calls } = innerSpy();
+    const gated = withMaxRateAge(handler, {
+      guard,
+      recipientSecretKey,
+      swapPairs: [PAIR_EVM],
+    });
+
+    const res = await gated(buildWrappedSwapCtx({ recipientSecretKey }));
+    expect(res.accept).toBe(false);
+    if (!res.accept) {
+      expect(res.code).toBe(STALE_RATE_REJECT_CODE);
+      expect(res.message).toBe(STALE_RATE_REJECT_MESSAGE);
+      const data = decodeRejectData((res as { data?: string }).data as string);
+      expect(data.reason).toBe(STALE_RATE_REASON);
+      expect(data.maxRateAgeMs).toBe(1000);
+      expect(data.lastRateAt).toBe(90_000);
+      expect(data.pair).toBe(pairKey(PAIR_EVM));
+    }
+    expect(calls.length).toBe(0);
+  });
+
+  it('fresh pair → delegates to the inner handler untouched', async () => {
+    const t = 100_000;
+    const guard = guardWith({
+      maxRateAge: { defaultMs: 1000 },
+      provider: () => ({ rate: '0.0004', at: t - 100 }),
+      now: () => t,
+    });
+    const { handler, calls } = innerSpy();
+    const gated = withMaxRateAge(handler, {
+      guard,
+      recipientSecretKey,
+      swapPairs: [PAIR_EVM],
+    });
+    const res = await gated(buildWrappedSwapCtx({ recipientSecretKey }));
+    expect(res.accept).toBe(true);
+    expect(calls.length).toBe(1);
+  });
+
+  it('non-1059 / malformed wrap / unsupported pair all fall through to the inner handler', async () => {
+    const guard = guardWith({
+      maxRateAge: { defaultMs: 1 },
+      provider: () => ({ rate: '1', at: 0 }),
+      now: () => 1_000_000, // everything would be stale IF the gate applied
+    });
+    const { handler, calls } = innerSpy();
+    const gated = withMaxRateAge(handler, {
+      guard,
+      recipientSecretKey,
+      swapPairs: [PAIR_EVM],
+    });
+
+    // non-1059 kind
+    await gated(buildWrappedSwapCtx({ recipientSecretKey, kind: 1 }));
+    // malformed gift wrap (garbage TOON)
+    await gated(
+      buildWrappedSwapCtx({
+        recipientSecretKey,
+        toonOverride: Buffer.from([0xde, 0xad, 0xbe, 0xef]).toString('base64'),
+      })
+    );
+    // valid wrap, pair not advertised → inner's canonical F06 territory
+    await gated(buildWrappedSwapCtx({ recipientSecretKey, pair: PAIR_MINA }));
+
+    expect(calls.length).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config validation
+// ---------------------------------------------------------------------------
+
+describe('validateMaxRateAgeConfig / SwapNodeConfig.maxRateAge validation', () => {
+  it('accepts well-formed configs', () => {
+    expect(() =>
+      validateMaxRateAgeConfig({
+        defaultMs: 3000,
+        perChain: { mina: 15_000 },
+        perPair: { [pairKey(PAIR_MINA)]: 10_000 },
+      })
+    ).not.toThrow();
+  });
+
+  it.each([
+    [{ defaultMs: 0 }],
+    [{ defaultMs: -5 }],
+    [{ defaultMs: Number.NaN }],
+    [{ perChain: { mina: Infinity } }],
+    [{ perPair: { x: '10' as unknown as number } }],
+  ])('rejects malformed bounds %j', (cfg) => {
+    expect(() => validateMaxRateAgeConfig(cfg)).toThrow();
+  });
+
+  it('SwapNodeConfig.maxRateAge without a rateProvider fails validateConfig with INVALID_CONFIG', () => {
+    const config = {
+      mnemonic: 'test test test test test test test test test test test junk',
+      swapPairs: [PAIR_EVM],
+      chains: ['evm'],
+      channels: {
+        'evm:31337': [
+          {
+            channelId: '0x' + '01'.repeat(32),
+            cumulativeAmount: 0n,
+            nonce: 0n,
+            updatedAt: 0,
+          },
+        ],
+      },
+      inventory: { 'evm:31337': 10n ** 18n },
+      relayUrls: ['ws://localhost:0'],
+      maxRateAge: { defaultMs: 1000 },
+    } as unknown as SwapNodeConfig;
+    expect(() => validateConfig(config)).toThrow(/rateProvider/);
+    expect(() =>
+      validateConfig({
+        ...config,
+        rateProvider: () => ({ rate: '1', at: Date.now() }),
+      })
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Recommended defaults sanity (full derivation in the calibration harness)
+// ---------------------------------------------------------------------------
+
+describe('RECOMMENDED_MAX_RATE_AGE_MS', () => {
+  it('covers the three chain families with maker-tunable (non-protocol) bounds', () => {
+    expect(Object.keys(RECOMMENDED_MAX_RATE_AGE_MS).sort()).toEqual([
+      'evm',
+      'mina',
+      'solana',
+    ]);
+    // Slow-feed classes need looser bounds: evm < solana < mina.
+    expect(RECOMMENDED_MAX_RATE_AGE_MS['evm']!).toBeLessThan(
+      RECOMMENDED_MAX_RATE_AGE_MS['solana']!
+    );
+    expect(RECOMMENDED_MAX_RATE_AGE_MS['solana']!).toBeLessThan(
+      RECOMMENDED_MAX_RATE_AGE_MS['mina']!
+    );
+  });
+});

--- a/packages/swap/src/rate-staleness.ts
+++ b/packages/swap/src/rate-staleness.ts
@@ -1,0 +1,519 @@
+/**
+ * Maker-side staleness reject (`maxRateAge`) — toon-protocol/swap#48.
+ *
+ * Rolling-swap prototype (toon-protocol/toon-meta#145, spec
+ * `toon-meta/docs/rolling-swap.md` §4): if the maker's rate source has not
+ * ticked within `maxRateAge`, the maker MUST reject incoming fill packets
+ * rather than fill at the stale rate — otherwise a sender who observes the
+ * market moving faster than the maker's feed farms the difference packet by
+ * packet.
+ *
+ * ## Placement (prototype)
+ *
+ * The spec's final placement is the connector's inbound gate
+ * (`InboundClaimValidatorFn`, before leg-A claim ingestion). This prototype
+ * enforces the bound at the nearest seam the swap repo owns: a decorator
+ * around the SDK's kind:1059 swap handler ({@link withMaxRateAge}), which
+ * runs BEFORE the handler's replay-reservation, rate application, and claim
+ * issuance — so a staleness reject leaves no `seenPacketIds` entry, no
+ * inventory debit, and no issued leg-B claim. What it CANNOT undo (and the
+ * connector gate ultimately must) is the leg-A claim watermark already
+ * ingested by the connector on the inbound hop. That gap is a placement
+ * finding for the epic, not silently papered over here.
+ *
+ * The decorator has to unwrap the NIP-59 gift wrap itself to learn the pair
+ * (the connector-visible packet is opaque by design — same problem the final
+ * inbound-gate placement will face). The unwrap is only paid when
+ * `maxRateAge` is configured; unguarded swap nodes are byte-identical in behavior.
+ *
+ * ## Reject contract (consumed by the sender-side story)
+ *
+ * A staleness reject is benign — "re-quote and retry", never a failure:
+ *
+ * - handler-level `code`: {@link STALE_RATE_REJECT_CODE} (`'T99'`, per spec —
+ *   T-class = temporary, retry later)
+ * - `message`: {@link STALE_RATE_REJECT_MESSAGE} (`'stale_rate'`)
+ * - `data`: base64 JSON {@link StaleRateRejectData} —
+ *   `{"reason":"stale_rate","maxRateAgeMs":…,"lastRateAt":…,"pair":…}`
+ * - `rejectReason.code`: {@link STALE_RATE_SEMANTIC_REASON} (`'timeout'`).
+ *   WIRE GOTCHA: the published connector (3.20.1, highest on npm) re-encodes
+ *   `rejectReason.code` through its `REJECT_CODE_MAP`, which has no
+ *   `stale_rate`/T99 entry — an unknown semantic collapses to F99 (F-class,
+ *   "don't retry"), which would invert the benign-retry contract. `'timeout'`
+ *   maps to wire code T00 (T-class), preserving retry semantics; `message`
+ *   and `data` pass through verbatim, so the sender's authoritative
+ *   discriminator is `data.reason === 'stale_rate'` (fallback:
+ *   `message === 'stale_rate'`), NOT the wire code. Once the connector's
+ *   `REJECT_CODE_MAP` gains `stale_rate: 'T99'`, flip
+ *   {@link STALE_RATE_SEMANTIC_REASON} to `'stale_rate'` for native T99.
+ *
+ * ## Knob semantics
+ *
+ * `maxRateAge` is a MAKER-owned, per-chain/per-pair config knob (like the
+ * spread; advertised alongside it in the future RFQ response) — NOT a
+ * protocol constant. It requires a `rateProvider` that returns TIMESTAMPED
+ * quotes (`{ rate, at }`): the bound is on the maker's OWN feed tick, so a
+ * static `pair.rate` (or an untimestamped provider) gives the guard nothing
+ * to measure. Configuring `maxRateAge` without a `rateProvider` is rejected
+ * at boot ({@link validateMaxRateAgeConfig} callers); an untimestamped
+ * provider return is warned once per pair and treated as fresh.
+ *
+ * See `max-rate-age.calibration.test.ts` for the reject-rate vs
+ * staleness-exposure calibration behind {@link RECOMMENDED_MAX_RATE_AGE_MS}.
+ */
+
+import { unwrapSwapPacketFromToon, findSwapPair } from '@toon-protocol/sdk';
+import type { Handler, HandlerContext } from '@toon-protocol/sdk';
+import type {
+  HandlePacketRejectResponse,
+  HandlePacketResponse,
+  SwapPair,
+} from '@toon-protocol/core';
+
+// ---------------------------------------------------------------------------
+// Reject contract constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Handler-level ILP reject code for a staleness reject (rolling-swap spec §4).
+ * T-class: temporary, application layer — "retry later", as opposed to the
+ * F-class "don't retry".
+ */
+export const STALE_RATE_REJECT_CODE = 'T99';
+
+/**
+ * Machine-matchable reject message. Deliberately the bare reason token (not
+ * prose) so message-only surfaces can discriminate even if the reject `data`
+ * field is dropped somewhere on the return path.
+ */
+export const STALE_RATE_REJECT_MESSAGE = 'stale_rate';
+
+/** `data.reason` discriminator — the sender's authoritative marker. */
+export const STALE_RATE_REASON = 'stale_rate';
+
+/**
+ * Semantic reject reason fed to the connector's PaymentHandlerAdapter.
+ *
+ * `'timeout'` → wire code T00 on connector <=3.20.1 (`REJECT_CODE_MAP`),
+ * keeping the reject T-class on today's wire. Flip to `'stale_rate'` when the
+ * connector's map gains a `stale_rate: 'T99'` entry (connector follow-up).
+ */
+export const STALE_RATE_SEMANTIC_REASON = 'timeout';
+
+/**
+ * Structured reject payload, base64-JSON-encoded into the ILP reject `data`
+ * field. Key names are normative per rolling-swap.md §4.
+ */
+export interface StaleRateRejectData {
+  reason: typeof STALE_RATE_REASON;
+  /** The maker's freshness bound that was exceeded, in ms. */
+  maxRateAgeMs: number;
+  /**
+   * ms-epoch of the maker's rate feed's last tick for the pair, or `null`
+   * if the feed has never ticked (e.g. feed unreachable since boot).
+   */
+  lastRateAt: number | null;
+  /** Pair key (`{@link pairKey}` format) the bound was evaluated for. */
+  pair: string;
+}
+
+/**
+ * Build the staleness reject response. Exported so tests and future
+ * placements (connector inbound gate) emit the byte-identical contract.
+ *
+ * The extra `data` / `rejectReason` fields are consumed by the connector's
+ * PaymentHandlerAdapter (`response.data` → ILP reject data;
+ * `response.rejectReason.code` → wire code via `REJECT_CODE_MAP`). Setting
+ * `rejectReason` here also prevents `startSwapNode()`'s generic
+ * `ilpCodeToSemantic` reverse-map from collapsing the unknown code T99 to
+ * `invalid_request` (wire F00 — a fatal class that would invert the
+ * benign-retry contract).
+ */
+export function buildStaleRateReject(
+  data: StaleRateRejectData
+): HandlePacketRejectResponse & {
+  data: string;
+  rejectReason: { code: string; message: string };
+} {
+  return {
+    accept: false,
+    code: STALE_RATE_REJECT_CODE,
+    message: STALE_RATE_REJECT_MESSAGE,
+    data: Buffer.from(JSON.stringify(data), 'utf8').toString('base64'),
+    rejectReason: {
+      code: STALE_RATE_SEMANTIC_REASON,
+      message: STALE_RATE_REJECT_MESSAGE,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Timestamped quotes + config types
+// ---------------------------------------------------------------------------
+
+/** A rate quote carrying the ms-epoch timestamp of the feed tick behind it. */
+export interface TimestampedRate {
+  /** Decimal-string rate, `SwapPair.rate` format (`/^(0|[1-9]\d*)(\.\d+)?$/`). */
+  rate: string;
+  /** ms-epoch of the rate source's tick this quote was derived from. */
+  at: number;
+}
+
+/** What a swap-node rate provider may return. Bare strings are untimestamped. */
+export type SwapRateQuote = string | TimestampedRate;
+
+/**
+ * Swap-node-level rate provider. A widening of the SDK's
+ * `CreateSwapHandlerConfig['rateProvider']` (which only accepts strings):
+ * return {@link TimestampedRate} to make quote age measurable — required for
+ * the `maxRateAge` staleness guard to bite.
+ */
+export type SwapRateProvider = (
+  pair: SwapPair
+) => SwapRateQuote | Promise<SwapRateQuote>;
+
+/**
+ * Maker-owned per-chain / per-pair freshness bounds, in milliseconds.
+ * Resolution precedence (see {@link RateFreshnessGuard.resolveMaxRateAgeMs}):
+ *
+ *   1. `perPair[pairKey(pair)]` — exact pair
+ *   2. `min()` of matching `perChain` entries — exact chain ids
+ *      (`'mina:devnet'`) and chain families (`'mina'`) of BOTH legs; the
+ *      minimum wins because a pair is only as fresh as its slowest-priced leg
+ *   3. `defaultMs`
+ *
+ * No match → the pair is unguarded.
+ */
+export interface MaxRateAgeConfig {
+  /** Fallback bound applied to every pair without a more specific entry. */
+  defaultMs?: number;
+  /** Keyed by exact chain id (`'evm:8453'`) or chain family (`'evm'`). */
+  perChain?: Record<string, number>;
+  /** Keyed by {@link pairKey} output. */
+  perPair?: Record<string, number>;
+}
+
+/**
+ * Calibrated per-chain-class starting points (NOT protocol constants — a
+ * maker SHOULD tune these to its own feed cadence; the operative rule of
+ * thumb from the calibration harness is `maxRateAge ≈ 4-6 × the feed's
+ * median tick interval, >= its p99 gap`). Derived in
+ * `max-rate-age.calibration.test.ts`, which asserts each value keeps the
+ * simulated reject rate under its target for the modeled feed class.
+ */
+export const RECOMMENDED_MAX_RATE_AGE_MS: Readonly<Record<string, number>> = {
+  /** Base-class EVM: sub-second CEX feed (median tick ~250 ms). */
+  evm: 1_500,
+  /** Solana-class: ~500 ms feed cadence. */
+  solana: 3_000,
+  /** Mina-class: seconds-scale feed with heavy gap tail (spec §9 example). */
+  mina: 15_000,
+};
+
+/** Canonical pair key: `FROMASSET:fromChain->TOASSET:toChain`. */
+export function pairKey(pair: SwapPair): string {
+  return `${pair.from.assetCode}:${pair.from.chain}->${pair.to.assetCode}:${pair.to.chain}`;
+}
+
+function chainFamily(chain: string): string {
+  const idx = chain.indexOf(':');
+  return idx === -1 ? chain : chain.slice(0, idx);
+}
+
+/**
+ * Thrown by the guard-wrapped SDK rate provider when the quote backing a
+ * fill is already past the bound at pricing time (the race backstop behind
+ * the gate check — see {@link RateFreshnessGuard.toSdkRateProvider}).
+ */
+export class StaleRateError extends Error {
+  public readonly code = 'STALE_RATE';
+  public readonly data: StaleRateRejectData;
+
+  constructor(data: StaleRateRejectData) {
+    super(
+      `stale_rate: quote for ${data.pair} is older than maxRateAge=${data.maxRateAgeMs}ms (lastRateAt=${String(data.lastRateAt)})`
+    );
+    this.name = 'StaleRateError';
+    this.data = data;
+  }
+}
+
+/**
+ * Validate a {@link MaxRateAgeConfig} shape. Throws `Error` with an
+ * actionable message on the first violation; callers (`validateConfig` in
+ * swap-node.ts) wrap it in their domain error.
+ */
+export function validateMaxRateAgeConfig(cfg: MaxRateAgeConfig): void {
+  if (typeof cfg !== 'object' || cfg === null || Array.isArray(cfg)) {
+    throw new Error('maxRateAge MUST be an object');
+  }
+  const checkMs = (v: unknown, label: string): void => {
+    if (typeof v !== 'number' || !Number.isFinite(v) || v <= 0) {
+      throw new Error(`${label} MUST be a positive finite number of ms`);
+    }
+  };
+  if (cfg.defaultMs !== undefined)
+    checkMs(cfg.defaultMs, 'maxRateAge.defaultMs');
+  for (const [k, v] of Object.entries(cfg.perChain ?? {})) {
+    checkMs(v, `maxRateAge.perChain["${k}"]`);
+  }
+  for (const [k, v] of Object.entries(cfg.perPair ?? {})) {
+    checkMs(v, `maxRateAge.perPair["${k}"]`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// RateFreshnessGuard
+// ---------------------------------------------------------------------------
+
+/** Minimal logger surface the guard needs (subset of SwapNodeLogger). */
+export interface RateStalenessLogger {
+  debug?: (...args: unknown[]) => void;
+  info?: (...args: unknown[]) => void;
+  warn?: (...args: unknown[]) => void;
+  error?: (...args: unknown[]) => void;
+}
+
+export interface RateFreshnessGuardConfig {
+  maxRateAge: MaxRateAgeConfig;
+  /** The maker's own feed. REQUIRED — the bound is on this feed's ticks. */
+  rateProvider: SwapRateProvider;
+  logger?: RateStalenessLogger;
+  /** Injectable clock (ms epoch). Tests pin this; defaults to `Date.now`. */
+  now?: () => number;
+}
+
+/** Verdict returned by {@link RateFreshnessGuard.check}. */
+export type FreshnessVerdict =
+  | { stale: false }
+  | { stale: true; data: StaleRateRejectData };
+
+/**
+ * Tracks the maker's feed ticks per pair and evaluates the `maxRateAge`
+ * bound: `now − lastRateUpdate > maxRateAge` → stale (rolling-swap §4).
+ * The bound is on the maker's OWN feed; nothing the sender claims is
+ * consulted.
+ */
+export class RateFreshnessGuard {
+  readonly #cfg: MaxRateAgeConfig;
+  readonly #provider: SwapRateProvider;
+  readonly #logger: RateStalenessLogger;
+  readonly #now: () => number;
+  /** pairKey → ms-epoch of the last observed feed tick. */
+  readonly #lastTickAt = new Map<string, number>();
+  /** pairs already warned for untimestamped quotes (warn once per pair). */
+  readonly #warnedUntimestamped = new Set<string>();
+
+  constructor(config: RateFreshnessGuardConfig) {
+    validateMaxRateAgeConfig(config.maxRateAge);
+    if (typeof config.rateProvider !== 'function') {
+      throw new Error(
+        "RateFreshnessGuard requires a rateProvider: maxRateAge bounds the age of the maker's own feed ticks, so a static pair.rate gives it nothing to measure"
+      );
+    }
+    this.#cfg = config.maxRateAge;
+    this.#provider = config.rateProvider;
+    this.#logger = config.logger ?? {};
+    this.#now = config.now ?? Date.now;
+  }
+
+  /**
+   * Resolve the effective bound for a pair, or `undefined` (unguarded).
+   * Precedence: perPair, then the MINIMUM matching perChain entry across
+   * both legs' exact chain ids and families, then defaultMs.
+   */
+  resolveMaxRateAgeMs(pair: SwapPair): number | undefined {
+    const byPair = this.#cfg.perPair?.[pairKey(pair)];
+    if (byPair !== undefined) return byPair;
+    const perChain = this.#cfg.perChain;
+    if (perChain) {
+      const candidates = [
+        perChain[pair.to.chain],
+        perChain[pair.from.chain],
+        perChain[chainFamily(pair.to.chain)],
+        perChain[chainFamily(pair.from.chain)],
+      ].filter((v): v is number => v !== undefined);
+      if (candidates.length > 0) return Math.min(...candidates);
+    }
+    return this.#cfg.defaultMs;
+  }
+
+  /** ms-epoch of the last observed tick for a pair (test/ops introspection). */
+  lastRateAt(pair: SwapPair): number | null {
+    return this.#lastTickAt.get(pairKey(pair)) ?? null;
+  }
+
+  /**
+   * Gate check: consult the feed and evaluate the bound for this pair.
+   *
+   * - Timestamped quote → tick recorded; stale iff `now − at > bound`.
+   * - Untimestamped (bare string) quote → age unmeasurable; warned once per
+   *   pair and treated as fresh (guard is inert for that provider shape).
+   * - Provider THROWS → aged against the last recorded good tick: a feed
+   *   that is down AND past the bound is exactly the farmable condition, so
+   *   it rejects `stale_rate` (with `lastRateAt: null` if it never ticked);
+   *   within the bound the packet proceeds and the pricing path decides.
+   */
+  async check(pair: SwapPair): Promise<FreshnessVerdict> {
+    const bound = this.resolveMaxRateAgeMs(pair);
+    if (bound === undefined) return { stale: false };
+    const key = pairKey(pair);
+
+    let quote: SwapRateQuote;
+    try {
+      quote = await this.#provider(pair);
+    } catch (err) {
+      const lastRateAt = this.#lastTickAt.get(key) ?? null;
+      const now = this.#now();
+      if (lastRateAt === null || now - lastRateAt > bound) {
+        this.#logger.warn?.('swap.rate_staleness.feed_unreachable_stale', {
+          pair: key,
+          maxRateAgeMs: bound,
+          lastRateAt,
+          err: err instanceof Error ? err.message : String(err),
+        });
+        return {
+          stale: true,
+          data: {
+            reason: STALE_RATE_REASON,
+            maxRateAgeMs: bound,
+            lastRateAt,
+            pair: key,
+          },
+        };
+      }
+      // Last tick still within the bound — let the pricing path decide
+      // (a second provider failure there surfaces as the SDK's T00).
+      return { stale: false };
+    }
+
+    const now = this.#now();
+    if (typeof quote === 'string') {
+      if (!this.#warnedUntimestamped.has(key)) {
+        this.#warnedUntimestamped.add(key);
+        this.#logger.warn?.('swap.rate_staleness.untimestamped_quote', {
+          pair: key,
+          hint: 'rateProvider returned a bare string; maxRateAge cannot measure quote age. Return { rate, at } to arm the staleness guard for this pair.',
+        });
+      }
+      this.#lastTickAt.set(key, now);
+      return { stale: false };
+    }
+
+    this.#lastTickAt.set(key, quote.at);
+    if (now - quote.at > bound) {
+      return {
+        stale: true,
+        data: {
+          reason: STALE_RATE_REASON,
+          maxRateAgeMs: bound,
+          lastRateAt: quote.at,
+          pair: key,
+        },
+      };
+    }
+    return { stale: false };
+  }
+
+  /**
+   * SDK-shaped rate provider (`(pair) => Promise<string>`) for
+   * `createSwapHandler`, normalizing {@link TimestampedRate} returns and
+   * re-checking freshness at PRICING time. This is the invariant's last
+   * line: the gate check and the fill are separate provider calls, so a feed
+   * that goes stale in between still cannot price a fill. A violation throws
+   * {@link StaleRateError}, which the SDK handler surfaces as its generic
+   * T00 "Rate provider error" — acceptable for the rare race window; the
+   * distinct T99 contract is the gate's job.
+   */
+  toSdkRateProvider(): (pair: SwapPair) => Promise<string> {
+    return async (pair: SwapPair): Promise<string> => {
+      const quote = await this.#provider(pair);
+      if (typeof quote === 'string') return quote;
+      const key = pairKey(pair);
+      this.#lastTickAt.set(key, quote.at);
+      const bound = this.resolveMaxRateAgeMs(pair);
+      if (bound !== undefined && this.#now() - quote.at > bound) {
+        throw new StaleRateError({
+          reason: STALE_RATE_REASON,
+          maxRateAgeMs: bound,
+          lastRateAt: quote.at,
+          pair: key,
+        });
+      }
+      return quote.rate;
+    };
+  }
+}
+
+/**
+ * Normalize a {@link SwapRateProvider} to the SDK's string-only shape,
+ * for swap nodes with timestamped providers but no `maxRateAge` configured.
+ */
+export function normalizeRateProvider(
+  provider: SwapRateProvider
+): (pair: SwapPair) => Promise<string> {
+  return async (pair: SwapPair): Promise<string> => {
+    const quote = await provider(pair);
+    return typeof quote === 'string' ? quote : quote.rate;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// withMaxRateAge — the staleness gate (handler decorator)
+// ---------------------------------------------------------------------------
+
+export interface WithMaxRateAgeOptions {
+  guard: RateFreshnessGuard;
+  /** Swap-node identity secret key — same key the SDK swap handler unwraps with. */
+  recipientSecretKey: Uint8Array;
+  swapPairs: readonly SwapPair[];
+  logger?: RateStalenessLogger;
+}
+
+/**
+ * Wrap the SDK swap handler with the maker staleness gate.
+ *
+ * For kind:1059 packets the gate unwraps the gift wrap (the packet is
+ * opaque without it — the same pair-resolution problem the final
+ * connector-inbound-gate placement will face), resolves the pair, and
+ * rejects `stale_rate` BEFORE the inner handler runs — i.e. before the
+ * replay reservation is taken, the rate is applied, and any leg-B claim or
+ * inventory debit happens. Malformed wraps and unknown pairs fall through
+ * to the inner handler so its canonical F01/F06 ladder is preserved
+ * byte-for-byte.
+ */
+export function withMaxRateAge(
+  inner: Handler,
+  options: WithMaxRateAgeOptions
+): Handler {
+  const { guard, recipientSecretKey, swapPairs } = options;
+  const logger = options.logger ?? {};
+  const pairs = [...swapPairs];
+
+  return async (ctx: HandlerContext): Promise<HandlePacketResponse> => {
+    if (ctx.kind !== 1059) return inner(ctx);
+    if (typeof ctx.toon !== 'string' || ctx.toon.length === 0) {
+      return inner(ctx); // inner emits its canonical F01
+    }
+
+    let pair: SwapPair | null = null;
+    try {
+      const toonData = new Uint8Array(Buffer.from(ctx.toon, 'base64'));
+      const { rumor } = unwrapSwapPacketFromToon({
+        toonData,
+        recipientSecretKey,
+      });
+      pair = findSwapPair(rumor, pairs);
+    } catch {
+      return inner(ctx); // malformed gift wrap → inner's canonical F01
+    }
+    if (!pair) return inner(ctx); // unsupported pair → inner's canonical F06
+
+    const verdict = await guard.check(pair);
+    if (verdict.stale) {
+      logger.info?.('swap.rate_staleness.reject', verdict.data);
+      return buildStaleRateReject(verdict.data);
+    }
+    return inner(ctx);
+  };
+}

--- a/packages/swap/src/swap-node.ts
+++ b/packages/swap/src/swap-node.ts
@@ -76,6 +76,13 @@ import {
   PersistentSeenPacketIds,
 } from './state-store.js';
 import type { SwapStateStore, PersistedSwapState } from './state-store.js';
+import {
+  RateFreshnessGuard,
+  normalizeRateProvider,
+  validateMaxRateAgeConfig,
+  withMaxRateAge,
+} from './rate-staleness.js';
+import type { MaxRateAgeConfig, SwapRateProvider } from './rate-staleness.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -233,7 +240,30 @@ export interface SwapNodeConfig {
   channels: Record<string, readonly ChannelEntry[]>;
   inventory: Record<string, bigint>;
 
-  rateProvider?: CreateSwapHandlerConfig['rateProvider'];
+  /**
+   * Optional live-rate hook, widened from the SDK's string-only shape:
+   * return `{ rate, at }` ({@link SwapRateProvider} / `TimestampedRate`)
+   * so quote age is measurable — REQUIRED for `maxRateAge` to bite. Bare
+   * string returns remain valid (and are what the SDK handler ultimately
+   * consumes; the swap node normalizes).
+   */
+  rateProvider?: SwapRateProvider;
+  /**
+   * Maker staleness bound(s) — toon-protocol/swap#48, rolling-swap §4.
+   *
+   * When set, any kind:1059 fill packet whose pair's rate feed has not
+   * ticked within the resolved bound is rejected BENIGNLY before pricing
+   * and claim issuance (handler-level code `T99`, `message: 'stale_rate'`,
+   * base64-JSON `data` — see `rate-staleness.ts` for the full reject
+   * contract). Maker-owned, per-chain/per-pair — NOT a protocol constant;
+   * see `RECOMMENDED_MAX_RATE_AGE_MS` for calibrated per-chain-class
+   * starting points.
+   *
+   * Requires {@link rateProvider} (the bound is on the maker's own feed
+   * ticks; a static `pair.rate` gives it nothing to measure) — enforced at
+   * boot with `INVALID_CONFIG`.
+   */
+  maxRateAge?: MaxRateAgeConfig;
   /**
    * Optional operator-supplied replay-protection set for the swap handler.
    *
@@ -622,6 +652,23 @@ export function validateConfig(config: SwapNodeConfig): void {
     }
   }
 
+  if (config.maxRateAge !== undefined) {
+    try {
+      validateMaxRateAgeConfig(config.maxRateAge);
+    } catch (err) {
+      throw new SwapNodeStartError(
+        'INVALID_CONFIG',
+        `SwapNodeConfig.maxRateAge invalid: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+    if (typeof config.rateProvider !== 'function') {
+      throw new SwapNodeStartError(
+        'INVALID_CONFIG',
+        "SwapNodeConfig.maxRateAge requires a rateProvider: the staleness bound applies to the age of the maker's own rate-feed ticks, so a static pair.rate gives the guard nothing to measure. Supply a rateProvider that returns { rate, at } timestamped quotes."
+      );
+    }
+  }
+
   if (config.chainProviders !== undefined) {
     if (!Array.isArray(config.chainProviders)) {
       throw new SwapNodeStartError(
@@ -956,12 +1003,32 @@ export async function startSwapNode(
     },
   });
 
-  // 8. Swap handler.
+  // 8. Swap handler (+ optional maxRateAge staleness guard — swap#48).
+  //
+  // The guard owns the timestamped-quote normalization: the SDK handler only
+  // accepts `(pair) => string` providers, so the swap node's widened
+  // SwapRateProvider (`{ rate, at }` returns) is adapted here. With
+  // `maxRateAge` set, the SDK-facing provider also re-checks freshness at
+  // pricing time (race backstop behind the gate below).
+  const stalenessGuard = config.maxRateAge
+    ? new RateFreshnessGuard({
+        maxRateAge: config.maxRateAge,
+        // validateConfig() guarantees rateProvider is present with maxRateAge.
+        rateProvider: config.rateProvider as SwapRateProvider,
+        logger: { warn: logger.warn, info: logger.info },
+      })
+    : undefined;
+  const sdkRateProvider = stalenessGuard
+    ? stalenessGuard.toSdkRateProvider()
+    : config.rateProvider
+      ? normalizeRateProvider(config.rateProvider)
+      : undefined;
+
   const swapHandler = createSwapHandler({
     recipientSecretKey: identity.secretKey,
     swapPairs: [...config.swapPairs],
     claimIssuer,
-    ...(config.rateProvider && { rateProvider: config.rateProvider }),
+    ...(sdkRateProvider && { rateProvider: sdkRateProvider }),
     // Issue #46 — prefer the operator's set (verbatim, SDK contract), else
     // the swap-node-owned persistent replay set when persistence is enabled,
     // else the SDK's default in-memory LRU.
@@ -978,10 +1045,24 @@ export async function startSwapNode(
     },
   });
 
+  // Staleness gate (rolling-swap §4): reject `stale_rate` BEFORE the inner
+  // handler takes its replay reservation, prices the packet, or issues a
+  // leg-B claim. Decorating the handler (rather than gating only in
+  // handlePacket below) puts the guard on EVERY dispatch path into the
+  // registry. No maxRateAge → the handler is registered untouched.
+  const gatedSwapHandler = stalenessGuard
+    ? withMaxRateAge(swapHandler, {
+        guard: stalenessGuard,
+        recipientSecretKey: identity.secretKey,
+        swapPairs: config.swapPairs,
+        logger: { info: logger.info, warn: logger.warn },
+      })
+    : swapHandler;
+
   // 9/10. HandlerRegistry — register on kind:1059 (NIP-59 gift-wrap).
   const registry = new HandlerRegistry();
   try {
-    registry.on(1059, swapHandler);
+    registry.on(1059, gatedSwapHandler);
   } catch (err) {
     throw new SwapNodeStartError(
       'HANDLER_REGISTRATION_FAILED',

--- a/packages/swap/tests/integration/helpers/fixture-topology.ts
+++ b/packages/swap/tests/integration/helpers/fixture-topology.ts
@@ -151,8 +151,10 @@ export interface BuildFixtureSwapNodeOptions {
   readonly swapPairs?: readonly SwapPair[];
   /** Inject a capturing publisher (AC-2). */
   readonly publisher?: Publisher;
-  /** Override swap-node-side rate provider (AC-4.3). */
+  /** Override swap-node-side rate provider (AC-4.3; timestamped for swap#48). */
   readonly rateProvider?: SwapNodeConfig['rateProvider'];
+  /** Maker staleness bound(s) — swap#48 staleness-reject tests. */
+  readonly maxRateAge?: SwapNodeConfig['maxRateAge'];
   /** Provide multiple channels for AC-7 two-sender tests. */
   readonly channelCount?: number;
 }
@@ -191,6 +193,7 @@ export async function buildFixtureSwapNode(
     btpEndpoint: 'ws://localhost:0/fixture',
     ...(options.publisher && { publisher: options.publisher }),
     ...(options.rateProvider && { rateProvider: options.rateProvider }),
+    ...(options.maxRateAge && { maxRateAge: options.maxRateAge }),
   };
 
   return startSwapNode(config);
@@ -289,11 +292,15 @@ export async function buildFixtureSender(
       const dataB64 = Buffer.from(JSON.stringify(metadata)).toString('base64');
       shimmed = { accepted: true, data: dataB64 };
     } else {
-      const rej = response as HandlePacketRejectResponse;
+      const rej = response as HandlePacketRejectResponse & { data?: string };
       shimmed = {
         accepted: false,
         code: rej.code,
         message: rej.message,
+        // Pass structured reject payloads (e.g. the swap#48 stale_rate
+        // base64-JSON) through, mirroring the connector adapter's reject
+        // path (`response.data` → ILP reject data).
+        ...(rej.data !== undefined && { data: rej.data }),
       };
     }
 

--- a/packages/swap/tests/integration/staleness-reject.integration.test.ts
+++ b/packages/swap/tests/integration/staleness-reject.integration.test.ts
@@ -1,0 +1,222 @@
+/**
+ * swap#48 — maker staleness-reject (`maxRateAge`) integration tests.
+ *
+ * Exercises the full fixture topology (real `createSwapHandler` +
+ * `MultiChainClaimIssuer` + `withMaxRateAge` gate, wired by `startSwapNode()`)
+ * against the issue's acceptance criteria:
+ *
+ *   - stale packet → distinct benign reject code with a sender-visible
+ *     reason (T99 / 'stale_rate' / base64-JSON data)
+ *   - the sender can re-request (feed ticks again) and continue
+ *   - fresh packets are unaffected — a full streamSwap under an armed guard
+ *     completes exactly as without one
+ *   - a staleness reject leaves NO replay reservation and NO inventory debit
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getPublicKey } from 'nostr-tools/pure';
+import type { UnsignedEvent } from 'nostr-tools/pure';
+import { encodeEventToToon } from '@toon-protocol/core';
+import { streamSwap, wrapSwapPacket } from '@toon-protocol/sdk';
+import {
+  STALE_RATE_REJECT_CODE,
+  STALE_RATE_REJECT_MESSAGE,
+  STALE_RATE_REASON,
+  pairKey,
+  type StaleRateRejectData,
+  type SwapNodeInstance,
+  type TimestampedRate,
+} from '@toon-protocol/swap';
+
+import {
+  buildFixtureSwapNode,
+  buildFixtureSender,
+  fixtureSwapPair,
+} from './helpers/fixture-topology.js';
+
+const FIXTURE_EVM_RECIPIENT = '0x' + '11'.repeat(20);
+const FIXTURE_SWAP_NODE_ILP_ADDRESS = 'g.toon.swap.fixture';
+
+/** A controllable timestamped feed: tests move `at` to age the quote. */
+function makeFeed(initialAt: number): {
+  provider: () => TimestampedRate;
+  tick: (at: number) => void;
+} {
+  let at = initialAt;
+  return {
+    provider: () => ({ rate: '0.0004', at }),
+    tick: (next: number) => {
+      at = next;
+    },
+  };
+}
+
+/** Build a raw wrapped swap PREPARE for the fixture pair (bypasses streamSwap
+ *  so a single packet's reject surface can be asserted precisely). */
+function buildWrappedPacket(swapNode: SwapNodeInstance, senderSecretKey: Uint8Array): Uint8Array {
+  const pair = fixtureSwapPair();
+  const rumor: UnsignedEvent = {
+    kind: 30_078,
+    pubkey: getPublicKey(senderSecretKey),
+    created_at: Math.floor(Date.now() / 1000),
+    content: '',
+    tags: [
+      ['swap-from', `${pair.from.assetCode}:${pair.from.chain}`],
+      ['swap-to', `${pair.to.assetCode}:${pair.to.chain}`],
+      ['chain-recipient', FIXTURE_EVM_RECIPIENT],
+    ],
+  };
+  const { giftWrap } = wrapSwapPacket({
+    rumor,
+    senderSecretKey,
+    recipientPubkey: swapNode.identity.pubkey,
+  });
+  return new Uint8Array(encodeEventToToon(giftWrap));
+}
+
+describe('swap#48 — maker staleness reject (maxRateAge)', () => {
+  it('stale feed → T99 stale_rate reject with structured data; fresh tick → same sender continues', async () => {
+    const feed = makeFeed(Date.now());
+    const swapNode = await buildFixtureSwapNode({
+      rateProvider: feed.provider,
+      maxRateAge: { perChain: { evm: 1_500 } },
+    });
+    const sender = await buildFixtureSender(swapNode, new Uint8Array(32).fill(21));
+    try {
+      // Age the feed past the bound.
+      feed.tick(Date.now() - 5_000);
+
+      const stale = await sender.client.sendSwapPacket({
+        destination: FIXTURE_SWAP_NODE_ILP_ADDRESS,
+        amount: 1_000_000n,
+        toonData: buildWrappedPacket(swapNode, sender.secretKey),
+      });
+
+      // AC: distinct benign reject code with a sender-visible reason.
+      expect(stale.accepted).toBe(false);
+      expect(stale.code).toBe(STALE_RATE_REJECT_CODE);
+      expect(stale.message).toBe(STALE_RATE_REJECT_MESSAGE);
+      const data = JSON.parse(
+        Buffer.from(stale.data!, 'base64').toString('utf8')
+      ) as StaleRateRejectData;
+      expect(data.reason).toBe(STALE_RATE_REASON);
+      expect(data.maxRateAgeMs).toBe(1_500);
+      expect(typeof data.lastRateAt).toBe('number');
+      expect(data.pair).toBe(pairKey(fixtureSwapPair()));
+
+      // No inventory was debited by the reject.
+      const healthAfterReject = swapNode.health();
+      expect(healthAfterReject.inventoryAvailable['evm:31337']).toBe(
+        healthAfterReject.inventory['evm:31337']
+      );
+
+      // AC: the sender re-requests once the feed ticks and CONTINUES — a
+      // full streamSwap completes against the same swapNode.
+      feed.tick(Date.now());
+      const result = await streamSwap({
+        client: sender.client,
+        swapPubkey: swapNode.identity.pubkey,
+        swapIlpAddress: FIXTURE_SWAP_NODE_ILP_ADDRESS,
+        pair: fixtureSwapPair(),
+        senderSecretKey: sender.secretKey,
+        chainRecipient: FIXTURE_EVM_RECIPIENT,
+        totalAmount: 1_000_000n,
+        packetCount: 1,
+      });
+      expect(result.state).toBe('completed');
+      expect(result.claims.length).toBe(1);
+    } finally {
+      await sender.close();
+      await swapNode.stop();
+    }
+  });
+
+  it('a staleness reject takes NO replay reservation: the identical packet fulfills after a feed tick', async () => {
+    const feed = makeFeed(Date.now() - 60_000); // stale from the start
+    const swapNode = await buildFixtureSwapNode({
+      rateProvider: feed.provider,
+      maxRateAge: { defaultMs: 1_500 },
+    });
+    const sender = await buildFixtureSender(swapNode, new Uint8Array(32).fill(22));
+    try {
+      const packet = buildWrappedPacket(swapNode, sender.secretKey);
+
+      const stale = await sender.client.sendSwapPacket({
+        destination: FIXTURE_SWAP_NODE_ILP_ADDRESS,
+        amount: 1_000_000n,
+        toonData: packet,
+      });
+      expect(stale.accepted).toBe(false);
+      expect(stale.code).toBe(STALE_RATE_REJECT_CODE);
+
+      // Replaying the SAME bytes after a fresh tick must fulfill — proving
+      // the gate rejected before the handler's seenPacketIds reservation
+      // (an F04 here would mean the reject burned the packet id).
+      feed.tick(Date.now());
+      const retry = await sender.client.sendSwapPacket({
+        destination: FIXTURE_SWAP_NODE_ILP_ADDRESS,
+        amount: 1_000_000n,
+        toonData: packet,
+      });
+      expect(retry.accepted).toBe(true);
+    } finally {
+      await sender.close();
+      await swapNode.stop();
+    }
+  });
+
+  it('fresh packets unaffected: multi-packet streamSwap under an armed guard completes', async () => {
+    const feed = makeFeed(Date.now());
+    const refresher = setInterval(() => feed.tick(Date.now()), 100);
+    const swapNode = await buildFixtureSwapNode({
+      rateProvider: feed.provider,
+      maxRateAge: { perChain: { evm: 1_500 }, defaultMs: 60_000 },
+    });
+    const sender = await buildFixtureSender(swapNode, new Uint8Array(32).fill(23));
+    try {
+      const result = await streamSwap({
+        client: sender.client,
+        swapPubkey: swapNode.identity.pubkey,
+        swapIlpAddress: FIXTURE_SWAP_NODE_ILP_ADDRESS,
+        pair: fixtureSwapPair(),
+        senderSecretKey: sender.secretKey,
+        chainRecipient: FIXTURE_EVM_RECIPIENT,
+        totalAmount: 5_000_000n,
+        packetCount: 5,
+      });
+      expect(result.state).toBe('completed');
+      expect(result.claims.length).toBe(5);
+      // Monotonic nonces — the guarded path still threads settlement context.
+      const nonces = result.claims.map((c) => BigInt(c.nonce!));
+      for (let i = 1; i < nonces.length; i++) {
+        expect(nonces[i]! > nonces[i - 1]!).toBe(true);
+      }
+    } finally {
+      clearInterval(refresher);
+      await sender.close();
+      await swapNode.stop();
+    }
+  });
+
+  it('no maxRateAge → behavior is untouched even with an ancient timestamped quote', async () => {
+    const feed = makeFeed(Date.now() - 3_600_000);
+    const swapNode = await buildFixtureSwapNode({ rateProvider: feed.provider });
+    const sender = await buildFixtureSender(swapNode, new Uint8Array(32).fill(24));
+    try {
+      const result = await streamSwap({
+        client: sender.client,
+        swapPubkey: swapNode.identity.pubkey,
+        swapIlpAddress: FIXTURE_SWAP_NODE_ILP_ADDRESS,
+        pair: fixtureSwapPair(),
+        senderSecretKey: sender.secretKey,
+        chainRecipient: FIXTURE_EVM_RECIPIENT,
+        totalAmount: 1_000_000n,
+        packetCount: 1,
+      });
+      expect(result.state).toBe('completed');
+    } finally {
+      await sender.close();
+      await swapNode.stop();
+    }
+  });
+});


### PR DESCRIPTION
Maker-side staleness reject (`maxRateAge`) — prototype + calibration, per rolling-swap spec §4 ("the newest behavior in the stack and the hinge the fairness argument hangs on"; prototype-first).

Part of toon-protocol/toon-meta#145. Closes #48. Stacked on #51.

## What this adds

- **`packages/swap/src/rate-staleness.ts`** — the guard + gate:
  - `RateFreshnessGuard`: per-pair feed-tick tracking; bound resolution `perPair` → `min(perChain across BOTH legs, exact chain id or family)` → `defaultMs`; provider-failure fallback (a feed that is down AND past the bound is exactly the farmable condition → reject); pricing-time `StaleRateError` backstop (the gate check and the fill are separate provider calls — a feed that goes stale in between still cannot price a fill).
  - `withMaxRateAge`: a decorator around the SDK's kind:1059 swap handler. It unwraps the gift wrap itself to resolve the pair (the packet is opaque without it — the exact pair-resolution problem the final connector-inbound-gate placement will face), and rejects **before** the handler's replay reservation, rate application, inventory debit, and leg-B claim issuance. Malformed wraps / unknown pairs fall through so the inner handler's canonical F01/F06 ladder is byte-identical.
- **`MillConfig.maxRateAge`** (`{ defaultMs?, perChain?, perPair? }`, all ms) + **`MillConfig.rateProvider` widened** to return timestamped quotes `{ rate, at }` (bare strings still valid, but leave the guard inert — warned once per pair). `maxRateAge` without a `rateProvider` fails boot with `INVALID_CONFIG`: the bound is on the maker's *own feed ticks*, and a static `pair.rate` has no age to measure.
- **Env/CLI knobs** (mirroring the repo's existing env-overlay style): `MILL_MAX_RATE_AGE` (full JSON structure) and `MILL_MAX_RATE_AGE_MS` (defaultMs shorthand; composes with the JSON).
- **Calibration harness** `max-rate-age.calibration.test.ts` (kept in-repo, seeded/deterministic; `CALIBRATE=1` prints the full curves) + unit suite + fixture-topology integration suite.
- Unconfigured mills are behavior-identical (guard entirely absent).

## Reject contract (sender-side story consumes this)

A staleness reject is **benign**: "re-quote and retry", never a failure. Sender SHOULD back off ≥ one `maxRateAgeMs`, MAY re-issue the RFQ, MUST count a controller shrink signal (spec §6).

| layer | field | value |
|---|---|---|
| handler response | `code` | `T99` (`STALE_RATE_REJECT_CODE`) |
| handler response | `message` | `stale_rate` (`STALE_RATE_REJECT_MESSAGE` — bare token, so message-only surfaces can discriminate) |
| handler response | `data` | base64 JSON `{"reason":"stale_rate","maxRateAgeMs":<number>,"lastRateAt":<ms-epoch \| null>,"pair":"USDC:evm:8453->MINA:mina:devnet"}` (`StaleRateRejectData`; `lastRateAt: null` = feed never ticked) |
| handler response | `rejectReason` | `{ code: 'timeout', message: 'stale_rate' }` |
| ILP wire (connector ≤3.20.1) | code | **T00** — see gotcha below |
| ILP wire | message / data | pass through verbatim |

**Wire gotcha (important for the sender-side implementation):** the published connector (3.20.1 — highest on npm; the publish pipeline is broken past it) re-encodes `rejectReason.code` through its `REJECT_CODE_MAP`, which has **no `stale_rate`/T99 entry**. An unknown semantic collapses to **F99** (F-class, "don't retry") and letting the mill's generic `ilpCodeToSemantic` reverse-map handle T99 would collapse it to `invalid_request` → **F00** — either would invert the benign-retry contract. So the prototype pins `rejectReason.code: 'timeout'` → wire **T00** (T-class, retryable) and the sender's **authoritative discriminator is `data.reason === 'stale_rate'`** (fallback: `message === 'stale_rate'`), *not* the wire code. Connector follow-up: add `stale_rate: 'T99'` to `REJECT_CODE_MAP`, then flip `STALE_RATE_SEMANTIC_REASON` to `'stale_rate'` for native T99. All of this is asserted in `rate-staleness.test.ts` ("pins rejectReason so the connector adapter does NOT collapse T99 to a fatal class").

## Calibration findings

Model (seeded, deterministic — `max-rate-age.calibration.test.ts`): maker feed = renewal process with lognormal tick intervals + occasional lognormal gaps; Poisson fill arrivals; reject iff quote age > A at arrival; staleness exposure of an accepted fill ≈ σ·√age bps (calm σ = 1 bps/√s ≈ 60% annualized; burst = 10×, which is when farming actually pays); stall = longest feed blackout beyond A.

**evm (Base-class: median tick 250 ms, rare ~2 s gaps)**

| A (ms) | reject % | p99 fill age (ms) | max stall (ms) | worst burst exposure (bps) |
|---|---|---|---|---|
| 100 | 64.78 | 99 | 4737 | 3.2 |
| 250 | 24.83 | 246 | 4587 | 5.0 |
| 500 | 4.62 | 471 | 4337 | 7.1 |
| 1000 | 0.53 | 704 | 3837 | 10.0 |
| **1500** | **0.22** | **755** | **3337** | **12.2** |
| 3000 | 0.02 | 787 | 1837 | 17.3 |

**solana (median tick 500 ms)**

| A (ms) | reject % | p99 fill age (ms) | max stall (ms) | worst burst exposure (bps) |
|---|---|---|---|---|
| 500 | 25.85 | 492 | 14138 | 7.1 |
| 1500 | 1.87 | 1260 | 13138 | 12.2 |
| **3000** | **0.62** | **1623** | **11638** | **17.3** |
| 5000 | 0.22 | 1865 | 9638 | 22.4 |

**mina (median tick 4 s, heavy gap tail — the spec §9 regime, 12.6 s gaps routine)**

| A (ms) | reject % | p99 fill age (ms) | max stall (ms) | worst burst exposure (bps) |
|---|---|---|---|---|
| 4000 | 33.09 | 3930 | 47842 | 20.0 |
| 8000 | 10.09 | 7710 | 43842 | 28.3 |
| 10000 | 5.85 | 9412 | 41842 | 31.6 |
| **15000** | **1.51** | **13223** | **36842** | **38.7** |
| 20000 | 0.48 | 15105 | 31842 | 44.7 |
| 60000 | 0.00 | 16561 | 0 | 77.5 |

**Recommended defaults** (exported as `RECOMMENDED_MAX_RATE_AGE_MS`, pinned by assertions): **evm 1500 ms · solana 3000 ms · mina 15000 ms.**

Key findings:

1. **The spec's "low hundreds of ms on Base-class" indicative starting point is too tight** for a realistic ~250 ms feed: A = 100 ms is a 65% reject storm; even 2× the median cadence (500 ms) bounces ~5% of fresh traffic. **Rule of thumb: A ≈ 4–6× the feed's median tick interval, ≈ its p99 gap** — the knee of every curve.
2. **10 s on Mina-class (the spec's worked example) rejects ~4× more than 15 s** (5.85% vs 1.51%) — the §9 "12.6 s gap trips the 10 s bound" story is a routine event in that regime, not a fluke. 15 s clears the AC's "no reject storm under Mina-class latency".
3. **Diminishing returns past the gap tail:** loosening mina 20 s → 60 s buys 0.48% → ~0% rejects but grows the farmable worst-case budget √A-linearly (44.7 → 77.5 bps burst). Loose bounds are pure adversary subsidy.
4. **maxRateAge alone cannot make slow chains safe:** even at the recommended mina bound, burst-vol worst-case staleness (~39 bps) exceeds a typical 10–30 bps half-spread. The residual must be priced by the advertised spread and absorbed by the §6 controller shrinking δ on `stale_rate` signals — confirming `maxRateAge` is a maker-owned knob co-tuned with the spread, **not** a protocol constant.
5. **Stall behavior is bounded, not fatal:** at recommended settings the worst stall equals the worst feed blackout beyond the bound (seconds), and the spec's sender backoff (≥ one maxRateAge) rides through it.

Placement finding for the epic: at the connector inbound gate, the packet is an opaque gift wrap — the gate either needs the mill's unwrap capability (as this prototype does), a coarser per-destination scope, or the future on-wire rate-timestamp tag (toon#82). Also note: rejecting at the handler seam still leaves the leg-A claim watermark ingested by the connector on the inbound hop (spec R8) — the reason the final placement must move into the connector's `InboundClaimValidatorFn` once the connector is publishable again.

## Test results

- `pnpm -r build` ✅
- `pnpm -r test` ✅ 167 passed | 2 skipped (13 files; includes 24 new rate-staleness unit tests + 12 calibration assertions)
- `pnpm --filter @toon-protocol/swap test:integration` ✅ 22 passed | 1 skipped (4 new: T99+data contract end-to-end, no-replay-burn retry-same-bytes, 5-packet streamSwap under an armed guard, ancient-timestamp no-op without maxRateAge)
- `pnpm lint` ✅ 0 errors (only the repo's pre-existing non-null-assertion warnings in tests) · `pnpm format:check` ✅

(Repo-root `pnpm test` is pre-existing-broken on the base branch too — the root `vitest.config.ts` still references `packages/townhouse-web/` from before the repo split; not touched here.)

## Notes

- Changeset: minor.
- Does NOT include #52 (mill state persistence, separate stack off main); a merge conflict between the stacks is expected.
- Connector stays `^3.20.1` (highest published); no 3.28.x references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
