### PR TITLE
Rolling swap engine: coupled shared-condition packet legs (replace issueClaim-in-FULFILL)

### DIFF
--- a/.changeset/rolling-coupled-legs.md
+++ b/.changeset/rolling-coupled-legs.md
@@ -1,0 +1,15 @@
+---
+'@toon-protocol/swap': major
+---
+
+Rolling swap engine: coupled shared-condition packet legs (swap#47, rolling-swap spec §3, toon-meta#145).
+
+Each fill packet's two legs now share ONE sender-minted execution condition `C_i = sha256(P_i)`: the connector delivers `C_i` to the swap node (local-delivery fulfillment contract, connector 3.29.x), the engine issues the chain-B cumulative claim as an outbound leg-B PREPARE under the SAME `C_i`, and can only FULFILL leg A by relaying the preimage the sender reveals after verifying that claim — value-atomic per packet, replacing claim-in-FULFILL on the rolling path. Legacy zero-condition gift-wrap fills keep the pre-existing claim-in-FULFILL behavior byte-for-byte.
+
+Major because:
+
+- `SwapNodeInstance` gains a required `registerRollingSession()` member (breaking for structural implementations/test doubles).
+- Packets carrying a sender-chosen (non-zero) execution condition with a legacy gift-wrap payload are now rejected F99 up front instead of being dispatched (the legacy handler cannot mint the preimage; dispatching would debit inventory only for the connector to F99 the FULFILL with nothing recorded).
+- `STALE_RATE_SEMANTIC_REASON` flips `'timeout'` → `'stale_rate'` (native wire T99), which requires `@toon-protocol/connector` >= 3.29.0 — the dependency floors move to connector ^3.29.1 / sdk ^2.1.0 / core ^2.1.0.
+
+Also new: `RollingSwapEngine`/`RollingSessionStore` + wire payload types (`rolling/1` fill/advance/accept), `MultiChainClaimIssuer.rollbackClaim()` full-unwind for failed coupled packets, `createHttpRateProvider` + `SWAP_RATE_URL`/`SWAP_RATE_TIMEOUT_MS` CLI wiring so deployed makers finally price per packet via `rateProvider` instead of the config-frozen `pair.rate`.

--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -57,9 +57,9 @@
     "@noble/hashes": "^2.0.0",
     "@scure/bip32": "^2.0.0",
     "@scure/bip39": "^2.0.0",
-    "@toon-protocol/connector": "^3.20.1",
-    "@toon-protocol/core": "^2.0.0",
-    "@toon-protocol/sdk": "^2.0.0",
+    "@toon-protocol/connector": "^3.29.1",
+    "@toon-protocol/core": "^2.1.0",
+    "@toon-protocol/sdk": "^2.1.0",
     "ed25519-hd-key": "^1.3.0",
     "hono": "^4.11.10",
     "nostr-tools": "^2.20.0"

--- a/packages/swap/src/claim-issuer.ts
+++ b/packages/swap/src/claim-issuer.ts
@@ -20,6 +20,7 @@ import type {
   IssueClaimParams,
   IssueClaimResult,
 } from '@toon-protocol/sdk';
+import type { SwapPair } from '@toon-protocol/core';
 
 import type { SwapInventory } from './inventory.js';
 import type { SwapChannelState, Reservation } from './channel-state.js';
@@ -313,5 +314,53 @@ export class MultiChainClaimIssuer implements ClaimIssuer {
       result.swapSignerAddress = swapSignerAddress;
     }
     return result;
+  }
+
+  /**
+   * Rolling-engine unwind (swap#47 AC-4): fully reverse a previously issued
+   * claim's inventory debit and channel reservation after the coupled leg-B
+   * PREPARE failed (reject / timeout / withheld preimage). Mirrors the
+   * signer-failure rollback in {@link issueClaim} step 4 byte-for-byte:
+   * credit + release + best-effort re-persist.
+   *
+   * Safety: per rolling-swap §3 R8, a channel claim attached to a PREPARE
+   * that terminates in a REJECT MUST NOT advance the redeemable watermark on
+   * the receiving side — so reusing the released nonce is protocol-correct.
+   * The residual exposure to a Byzantine counterparty that banks the voided
+   * claim anyway is the spec's designed per-window bound (§3.1), not a gap
+   * introduced here. If the re-persist fails (or the process crashes before
+   * it), disk keeps the pre-rollback snapshot — a safe over-reservation
+   * (state-store crash rule 3).
+   */
+  rollbackClaim(params: {
+    pair: SwapPair;
+    senderPubkey: string;
+    targetAmount: bigint;
+  }): void {
+    const targetChain = params.pair.to.chain;
+    const targetAsset = params.pair.to.assetCode;
+    this.inventory.credit(targetAsset, targetChain, params.targetAmount);
+    this.channelState.release({
+      assetCode: targetAsset,
+      chain: targetChain,
+      senderPubkey: params.senderPubkey,
+      cumulativeDelta: params.targetAmount,
+    });
+    if (this.persistState) {
+      try {
+        this.persistState();
+      } catch (persistErr) {
+        this.logger?.error?.('swap.rollbackClaim.persist_failed', {
+          err: persistErr,
+          chain: targetChain,
+          asset: targetAsset,
+        });
+      }
+    }
+    this.logger?.info?.('swap.rollbackClaim.ok', {
+      chain: targetChain,
+      asset: targetAsset,
+      targetAmount: params.targetAmount.toString(),
+    });
   }
 }

--- a/packages/swap/src/cli.test.ts
+++ b/packages/swap/src/cli.test.ts
@@ -368,3 +368,91 @@ describe('issue #46 — SWAP_STATE_PATH env overlay', () => {
     }
   });
 });
+
+// ===========================================================================
+// Issue #47 AC-3 — SWAP_RATE_URL wires the per-packet rateProvider
+// ===========================================================================
+
+describe('issue #47 — SWAP_RATE_URL rateProvider wiring', () => {
+  const rateFixturePath = resolve(
+    __dirname,
+    '..',
+    'fixtures',
+    'swap.config.json'
+  );
+
+  async function withEnvVars<T>(
+    overrides: Record<string, string | undefined>,
+    fn: () => Promise<T>
+  ): Promise<T> {
+    const prev: Record<string, string | undefined> = {};
+    for (const k of Object.keys(overrides)) prev[k] = process.env[k];
+    try {
+      for (const [k, v] of Object.entries(overrides)) {
+        if (v === undefined) {
+          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+          delete process.env[k];
+        } else process.env[k] = v;
+      }
+      return await fn();
+    } finally {
+      for (const [k, v] of Object.entries(prev)) {
+        if (v === undefined) {
+          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+          delete process.env[k];
+        } else process.env[k] = v;
+      }
+    }
+  }
+
+  it('[P1] SWAP_RATE_URL + SWAP_MAX_RATE_AGE_MS boots — proving the provider was wired (maxRateAge without a rateProvider is INVALID_CONFIG)', async () => {
+    const mod = (await import('./cli.js')) as {
+      main: (argv: string[]) => Promise<{ stop: () => Promise<void> }>;
+    };
+    const instance = await withEnvVars(
+      {
+        SWAP_RATE_URL: 'http://127.0.0.1:9/rates',
+        SWAP_MAX_RATE_AGE_MS: '1500',
+      },
+      () => mod.main(['--config', rateFixturePath])
+    );
+    try {
+      expect(instance).toBeDefined();
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('[P1] SWAP_MAX_RATE_AGE_MS WITHOUT SWAP_RATE_URL still fails INVALID_CONFIG (control)', async () => {
+    const mod = (await import('./cli.js')) as {
+      main: (argv: string[]) => Promise<unknown>;
+    };
+    await withEnvVars(
+      { SWAP_RATE_URL: undefined, SWAP_MAX_RATE_AGE_MS: '1500' },
+      async () => {
+        await expect(
+          mod.main(['--config', rateFixturePath])
+        ).rejects.toMatchObject({ code: 'INVALID_CONFIG' });
+      }
+    );
+  });
+
+  it('[P2] invalid SWAP_RATE_URL / SWAP_RATE_TIMEOUT_MS throw before boot', async () => {
+    const mod = (await import('./cli.js')) as {
+      main: (argv: string[]) => Promise<unknown>;
+    };
+    await withEnvVars({ SWAP_RATE_URL: 'not-a-url' }, async () => {
+      await expect(mod.main(['--config', rateFixturePath])).rejects.toThrow(
+        /http\(s\) URL/
+      );
+    });
+    await withEnvVars(
+      { SWAP_RATE_URL: 'http://feed.local/rates', SWAP_RATE_TIMEOUT_MS: '-5' },
+      async () => {
+        await expect(mod.main(['--config', rateFixturePath])).rejects.toThrow(
+          /SWAP_RATE_TIMEOUT_MS/
+        );
+      }
+    );
+  });
+});

--- a/packages/swap/src/cli.ts
+++ b/packages/swap/src/cli.ts
@@ -28,12 +28,22 @@
  *   SWAP_MAX_RATE_AGE      — full per-chain/per-pair maxRateAge config as JSON,
  *                            e.g. '{"defaultMs":3000,"perChain":{"mina":15000}}'
  *                            (SWAP_MAX_RATE_AGE_MS still overrides defaultMs)
+ *   SWAP_RATE_URL          — HTTP JSON rate feed (issue #47 AC-3): wires the
+ *                            per-packet `rateProvider` so deployed swap nodes
+ *                            price every fill at the feed's current tick
+ *                            instead of the config-frozen pair.rate. Accepted
+ *                            response shapes: {"rate":"0.0004","at":<unix-ms>}
+ *                            or a map keyed by pairKey (optionally under
+ *                            "rates"). Timestamped ("at") responses arm the
+ *                            SWAP_MAX_RATE_AGE staleness guard.
+ *   SWAP_RATE_TIMEOUT_MS   — per-request feed timeout (default 1500)
  *
  * NOTE on maxRateAge (swap#48): the staleness bound applies to the maker's
  * own rate-feed ticks, so it REQUIRES a `rateProvider` returning timestamped
- * quotes — which only programmatic `startSwapNode()` embeddings can supply.
- * Setting it on a static-rate JSON-config swap node fails boot with
- * INVALID_CONFIG (loud by design; a static rate has no age to measure).
+ * quotes — set SWAP_RATE_URL (timestamped responses) or use a programmatic
+ * `startSwapNode()` embedding. Setting it on a static-rate JSON-config swap
+ * node fails boot with INVALID_CONFIG (loud by design; a static rate has no
+ * age to measure).
  */
 
 import { parseArgs } from 'node:util';
@@ -43,6 +53,7 @@ import { pathToFileURL } from 'node:url';
 
 import { startSwapNode } from './swap-node.js';
 import type { SwapNodeConfig, SwapNodeInstance } from './swap-node.js';
+import { createHttpRateProvider } from './rate-provider.js';
 
 interface CliRawConfig {
   mnemonic?: string;
@@ -262,6 +273,25 @@ function applyEnvOverlay(cfg: SwapNodeConfig): SwapNodeConfig {
       throw new Error('SWAP_MAX_RATE_AGE_MS must be a positive integer (ms)');
     }
     out.maxRateAge = { ...(out.maxRateAge ?? {}), defaultMs: ms };
+  }
+  // Fresh per-packet rate feed (issue #47 AC-3). Deployed swap nodes have
+  // always priced at the config-frozen pair.rate because nothing wired the
+  // SDK's per-packet rateProvider hook; SWAP_RATE_URL closes that gap.
+  if (env['SWAP_RATE_URL']) {
+    let timeoutMs: number | undefined;
+    if (env['SWAP_RATE_TIMEOUT_MS']) {
+      timeoutMs = Number(env['SWAP_RATE_TIMEOUT_MS']);
+      if (
+        !Number.isFinite(timeoutMs) ||
+        !Number.isInteger(timeoutMs) ||
+        timeoutMs <= 0
+      ) {
+        throw new Error('SWAP_RATE_TIMEOUT_MS must be a positive integer (ms)');
+      }
+    }
+    out.rateProvider = createHttpRateProvider(env['SWAP_RATE_URL'], {
+      ...(timeoutMs !== undefined && { timeoutMs }),
+    });
   }
   return out;
 }

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -108,6 +108,46 @@ export type {
   RateStalenessLogger,
 } from './rate-staleness.js';
 
+// Rolling coupled-leg engine (issue #47 — rolling-swap §3)
+export {
+  RollingSwapEngine,
+  RollingSessionStore,
+  createConnectorLegBSender,
+  parseRollingFillPayload,
+  buildRollingReject,
+  ROLLING_PROTOCOL,
+  ROLLING_REJECT_REASONS,
+  ROLLING_FILL_CONTEXT_KIND,
+  DEFAULT_ROLLING_SESSION_TTL_MS,
+  DEFAULT_ROLLING_MAX_SESSIONS,
+  DEFAULT_LEG_B_BUDGET_MS,
+  DEFAULT_LEG_B_EXPIRY_MARGIN_MS,
+  DEFAULT_MIN_LEG_B_TIME_MS,
+} from './rolling-engine.js';
+export type {
+  RollingSwapEngineConfig,
+  RollingSession,
+  RollingSessionStoreConfig,
+  RollingFillPayload,
+  RollingAdvancePayload,
+  RollingAcceptRecord,
+  RollingFillRequest,
+  RollingFillResponse,
+  RollingRejectReason,
+  RollingSeenPacketIds,
+  LegBPrepare,
+  LegBResult,
+  LegBSender,
+  ConnectorLegBSenderOptions,
+} from './rolling-engine.js';
+
+// HTTP rate provider — CLI `rateProvider` wiring (issue #47 AC-3)
+export {
+  createHttpRateProvider,
+  DEFAULT_RATE_FETCH_TIMEOUT_MS,
+} from './rate-provider.js';
+export type { HttpRateProviderOptions } from './rate-provider.js';
+
 // Convenience re-export for operators (Story 12.7 AC-1) — do not wrap.
 export { createSwapHandler } from '@toon-protocol/sdk';
 export type { CreateSwapHandlerConfig } from '@toon-protocol/sdk';

--- a/packages/swap/src/rate-provider.test.ts
+++ b/packages/swap/src/rate-provider.test.ts
@@ -1,0 +1,115 @@
+/**
+ * `createHttpRateProvider` tests (issue #47 AC-3 — CLI rateProvider wiring).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { SwapPair } from '@toon-protocol/core';
+
+import { createHttpRateProvider } from './rate-provider.js';
+import { pairKey } from './rate-staleness.js';
+
+const PAIR: SwapPair = {
+  from: { assetCode: 'USDC', assetScale: 6, chain: 'evm:8453' },
+  to: { assetCode: 'ETH', assetScale: 18, chain: 'evm:8453' },
+  rate: '0.0004',
+};
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('createHttpRateProvider', () => {
+  it('rejects non-http URLs, bad timeouts, and missing fetch up front', () => {
+    expect(() => createHttpRateProvider('ftp://feed')).toThrowError(/http/);
+    expect(() =>
+      createHttpRateProvider('http://feed', { timeoutMs: 0 })
+    ).toThrowError(/positive/);
+  });
+
+  it('shape 1: single timestamped quote → {rate, at}', async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ rate: '0.0004', at: 1_783_936_201_437 })
+    );
+    const provider = createHttpRateProvider('http://feed.local/rate', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    await expect(provider(PAIR)).resolves.toEqual({
+      rate: '0.0004',
+      at: 1_783_936_201_437,
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('shape 1 untimestamped: bare {rate} → string (guard stays inert)', async () => {
+    const provider = createHttpRateProvider('http://feed.local/rate', {
+      fetchImpl: (async () =>
+        jsonResponse({ rate: '0.0004' })) as unknown as typeof fetch,
+    });
+    await expect(provider(PAIR)).resolves.toBe('0.0004');
+  });
+
+  it('shape 2: map keyed by pairKey; shape 3: nested under rates', async () => {
+    const key = pairKey(PAIR);
+    const mapProvider = createHttpRateProvider('http://feed.local/rates', {
+      fetchImpl: (async () =>
+        jsonResponse({
+          [key]: { rate: '0.0005', at: 42 },
+        })) as unknown as typeof fetch,
+    });
+    await expect(mapProvider(PAIR)).resolves.toEqual({
+      rate: '0.0005',
+      at: 42,
+    });
+
+    const nestedProvider = createHttpRateProvider('http://feed.local/rates', {
+      fetchImpl: (async () =>
+        jsonResponse({
+          rates: { [key]: { rate: '0.0006', at: 43 } },
+        })) as unknown as typeof fetch,
+    });
+    await expect(nestedProvider(PAIR)).resolves.toEqual({
+      rate: '0.0006',
+      at: 43,
+    });
+  });
+
+  it('throws on HTTP errors, malformed rates, and missing pairs (feed-down = guard-visible)', async () => {
+    const err500 = createHttpRateProvider('http://feed.local/rate', {
+      fetchImpl: (async () =>
+        jsonResponse({}, false, 500)) as unknown as typeof fetch,
+    });
+    await expect(err500(PAIR)).rejects.toThrowError(/HTTP 500/);
+
+    const badRate = createHttpRateProvider('http://feed.local/rate', {
+      fetchImpl: (async () =>
+        jsonResponse({ rate: 'not-a-rate', at: 1 })) as unknown as typeof fetch,
+    });
+    await expect(badRate(PAIR)).rejects.toThrowError(/no quote/);
+
+    const missingPair = createHttpRateProvider('http://feed.local/rates', {
+      fetchImpl: (async () =>
+        jsonResponse({
+          'X:1->Y:2': { rate: '1', at: 1 },
+        })) as unknown as typeof fetch,
+    });
+    await expect(missingPair(PAIR)).rejects.toThrowError(
+      new RegExp(pairKey(PAIR).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    );
+  });
+
+  it('aborts a hung feed after timeoutMs', async () => {
+    const provider = createHttpRateProvider('http://feed.local/rate', {
+      timeoutMs: 20,
+      fetchImpl: ((_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () =>
+            reject(new Error('aborted'))
+          );
+        })) as unknown as typeof fetch,
+    });
+    await expect(provider(PAIR)).rejects.toThrowError(/aborted/);
+  });
+});

--- a/packages/swap/src/rate-provider.ts
+++ b/packages/swap/src/rate-provider.ts
@@ -1,0 +1,115 @@
+/**
+ * HTTP rate provider — the CLI's `rateProvider` wiring (swap#47 AC-3).
+ *
+ * Deployed swap nodes have always priced at the config-frozen `pair.rate`
+ * because the SDK's per-packet `rateProvider` hook was wired by nothing. This
+ * factory turns an operator-supplied HTTP feed URL (`SWAP_RATE_URL`) into a
+ * {@link SwapRateProvider}: ONE GET per invocation — the engine/handler calls
+ * it per packet, so every fill re-prices at the feed's current tick ("fresh
+ * rate per packet"). No caching here by design; the feed endpoint is the
+ * place to cache.
+ *
+ * ## Accepted response shapes (Content-Type: application/json)
+ *
+ * 1. Single-pair feed: `{"rate":"0.0004","at":1783936201437}`
+ *    (`at` = unix-ms tick time of the rate SOURCE — this is what arms the
+ *    swap#48 `maxRateAge` staleness guard; a bare `{"rate":"0.0004"}` is
+ *    accepted but leaves the guard inert for the pair, warned once).
+ * 2. Multi-pair map keyed by {@link pairKey}:
+ *    `{"USDC:evm:8453->ETH:evm:8453":{"rate":"0.0004","at":…}, …}`
+ * 3. The same map nested under `"rates"`.
+ *
+ * Failures (non-2xx, timeout, malformed body, missing pair) THROW — the
+ * staleness guard treats a throwing feed that is past its bound as the
+ * farmable condition and rejects `stale_rate` (see `rate-staleness.ts`).
+ */
+
+import type { SwapPair } from '@toon-protocol/core';
+
+import { pairKey } from './rate-staleness.js';
+import type { SwapRateProvider, SwapRateQuote } from './rate-staleness.js';
+
+/** `SwapPair.rate` format (same regex the SDK's applyRate enforces). */
+const RATE_REGEX = /^(0|[1-9]\d*)(\.\d+)?$/;
+
+export interface HttpRateProviderOptions {
+  /** Per-request timeout. Default 1500 ms — a slow feed IS a stale feed. */
+  timeoutMs?: number;
+  /** Injectable fetch (tests). Defaults to `globalThis.fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+export const DEFAULT_RATE_FETCH_TIMEOUT_MS = 1_500;
+
+function parseQuote(entry: unknown): SwapRateQuote | null {
+  if (typeof entry !== 'object' || entry === null) return null;
+  const rec = entry as Record<string, unknown>;
+  const rate = rec['rate'];
+  if (typeof rate !== 'string' || !RATE_REGEX.test(rate)) return null;
+  const at = rec['at'];
+  if (typeof at === 'number' && Number.isFinite(at) && at > 0) {
+    return { rate, at };
+  }
+  // Untimestamped: valid, but the maxRateAge guard cannot measure it.
+  return rate;
+}
+
+/**
+ * Build a per-call HTTP {@link SwapRateProvider} for `url`.
+ */
+export function createHttpRateProvider(
+  url: string,
+  options: HttpRateProviderOptions = {}
+): SwapRateProvider {
+  if (typeof url !== 'string' || !/^https?:\/\//.test(url)) {
+    throw new Error(
+      `createHttpRateProvider requires an http(s) URL (got ${JSON.stringify(url)})`
+    );
+  }
+  const timeoutMs = options.timeoutMs ?? DEFAULT_RATE_FETCH_TIMEOUT_MS;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error('createHttpRateProvider timeoutMs must be positive');
+  }
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('createHttpRateProvider requires a fetch implementation');
+  }
+
+  return async (pair: SwapPair): Promise<SwapRateQuote> => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    (timer as { unref?: () => void }).unref?.();
+    let body: unknown;
+    try {
+      const res = await fetchImpl(url, {
+        method: 'GET',
+        headers: { accept: 'application/json' },
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        throw new Error(`rate feed responded HTTP ${res.status}`);
+      }
+      body = await res.json();
+    } finally {
+      clearTimeout(timer);
+    }
+
+    // Shape 1: single quote object.
+    const direct = parseQuote(body);
+    if (direct !== null) return direct;
+
+    // Shapes 2/3: map keyed by pairKey (optionally nested under `rates`).
+    const key = pairKey(pair);
+    if (typeof body === 'object' && body !== null) {
+      const rec = body as Record<string, unknown>;
+      const fromMap = parseQuote(rec[key]);
+      if (fromMap !== null) return fromMap;
+      const rates = rec['rates'];
+      if (typeof rates === 'object' && rates !== null) {
+        const nested = parseQuote((rates as Record<string, unknown>)[key]);
+        if (nested !== null) return nested;
+      }
+    }
+    throw new Error(`rate feed has no quote for pair ${key}`);
+  };
+}

--- a/packages/swap/src/rate-staleness.test.ts
+++ b/packages/swap/src/rate-staleness.test.ts
@@ -249,9 +249,10 @@ describe('buildStaleRateReject — the reject contract', () => {
       code: STALE_RATE_SEMANTIC_REASON,
       message: STALE_RATE_REJECT_MESSAGE,
     });
-    // 'timeout' → T00 in connector <=3.20.1 REJECT_CODE_MAP (T-class,
-    // retryable). Flip to 'stale_rate' when the connector maps it to T99.
-    expect(STALE_RATE_SEMANTIC_REASON).toBe('timeout');
+    // 'stale_rate' → native wire T99 since connector 3.29.0 added the
+    // REJECT_CODE_MAP entry (this package pins ^3.29.1). Still T-class,
+    // retryable — the benign contract is preserved with the exact code.
+    expect(STALE_RATE_SEMANTIC_REASON).toBe('stale_rate');
   });
 });
 

--- a/packages/swap/src/rate-staleness.ts
+++ b/packages/swap/src/rate-staleness.ts
@@ -36,16 +36,13 @@
  * - `data`: base64 JSON {@link StaleRateRejectData} —
  *   `{"reason":"stale_rate","maxRateAgeMs":…,"lastRateAt":…,"pair":…}`
  * - `rejectReason.code`: {@link STALE_RATE_SEMANTIC_REASON} (`'timeout'`).
- *   WIRE GOTCHA: the published connector (3.20.1, highest on npm) re-encodes
- *   `rejectReason.code` through its `REJECT_CODE_MAP`, which has no
- *   `stale_rate`/T99 entry — an unknown semantic collapses to F99 (F-class,
- *   "don't retry"), which would invert the benign-retry contract. `'timeout'`
- *   maps to wire code T00 (T-class), preserving retry semantics; `message`
- *   and `data` pass through verbatim, so the sender's authoritative
- *   discriminator is `data.reason === 'stale_rate'` (fallback:
- *   `message === 'stale_rate'`), NOT the wire code. Once the connector's
- *   `REJECT_CODE_MAP` gains `stale_rate: 'T99'`, flip
- *   {@link STALE_RATE_SEMANTIC_REASON} to `'stale_rate'` for native T99.
+ *   Since connector 3.29.0 (this package pins ^3.29.1) the connector's
+ *   `REJECT_CODE_MAP` carries `stale_rate: 'T99'`, so the semantic reason
+ *   re-encodes to native wire code T99 (T-class, retryable) end-to-end —
+ *   the historical `'timeout'`→T00 workaround for ≤3.20.1 is retired.
+ *   `message` and `data` pass through verbatim; the sender's authoritative
+ *   discriminator remains `data.reason === 'stale_rate'` (fallback:
+ *   `message === 'stale_rate'`), NOT the wire code.
  *
  * ## Knob semantics
  *
@@ -94,11 +91,14 @@ export const STALE_RATE_REASON = 'stale_rate';
 /**
  * Semantic reject reason fed to the connector's PaymentHandlerAdapter.
  *
- * `'timeout'` → wire code T00 on connector <=3.20.1 (`REJECT_CODE_MAP`),
- * keeping the reject T-class on today's wire. Flip to `'stale_rate'` when the
- * connector's map gains a `stale_rate: 'T99'` entry (connector follow-up).
+ * `'stale_rate'` → wire code T99 since connector 3.29.0 added the
+ * `stale_rate: 'T99'` `REJECT_CODE_MAP` entry (this package pins ^3.29.1),
+ * closing the swap#48 wire gotcha: the reject is now natively T-class T99
+ * end-to-end. Senders' authoritative discriminator remains
+ * `data.reason === 'stale_rate'` (fallback: `message === 'stale_rate'`),
+ * never the wire code.
  */
-export const STALE_RATE_SEMANTIC_REASON = 'timeout';
+export const STALE_RATE_SEMANTIC_REASON = 'stale_rate';
 
 /**
  * Structured reject payload, base64-JSON-encoded into the ILP reject `data`

--- a/packages/swap/src/rolling-engine.test.ts
+++ b/packages/swap/src/rolling-engine.test.ts
@@ -1,0 +1,844 @@
+/**
+ * Rolling swap engine unit tests (swap#47).
+ *
+ * Covers the issue's acceptance criteria at the engine seam:
+ *   - coupled happy path: condition in → SAME condition on leg B → correct
+ *     preimage out → claim advance consistent (AC-1)
+ *   - the coupling property at the CONTRACT level, with the connector's
+ *     local-delivery enforcement mocked byte-for-byte per
+ *     `connector/docs/local-delivery-fulfillment-contract.md`: a maker that
+ *     cannot present the sender-revealed preimage collects NOTHING (AC-1/AC-2)
+ *   - wrong/withheld preimage → benign leg-A failure, nothing stays debited
+ *     (AC-2, AC-4 full unwind)
+ *   - staleness reject still benign + byte-identical (swap#48 contract)
+ *   - replay rejected; crash between debit and fulfill leaves the persisted
+ *     safe state (state-store crash rules 2/4)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { sha256 } from '@noble/hashes/sha2.js';
+import type { SwapPair } from '@toon-protocol/core';
+
+import { SwapInventory } from './inventory.js';
+import { SwapChannelState } from './channel-state.js';
+import { MultiChainClaimIssuer } from './claim-issuer.js';
+import { EvmPaymentChannelSigner } from './payment-channel-signer.js';
+import { SwapStatePersister, PersistentSeenPacketIds } from './state-store.js';
+import type { PersistedSwapState, SwapStateStore } from './state-store.js';
+import {
+  RateFreshnessGuard,
+  STALE_RATE_REJECT_CODE,
+  STALE_RATE_REJECT_MESSAGE,
+  STALE_RATE_REASON,
+  STALE_RATE_SEMANTIC_REASON,
+} from './rate-staleness.js';
+import type { TimestampedRate } from './rate-staleness.js';
+import {
+  RollingSessionStore,
+  RollingSwapEngine,
+  ROLLING_PROTOCOL,
+  ROLLING_REJECT_REASONS,
+  parseRollingFillPayload,
+} from './rolling-engine.js';
+import type {
+  LegBPrepare,
+  LegBResult,
+  LegBSender,
+  RollingAdvancePayload,
+  RollingAcceptRecord,
+  RollingFillPayload,
+  RollingFillResponse,
+} from './rolling-engine.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CHAIN = 'evm:31337';
+const ASSET = 'ETH';
+const INVENTORY_KEY = `${ASSET}:${CHAIN}`;
+const CHANNEL_ID = '0x' + 'ab'.repeat(32);
+const CHANNEL_KEY = `${ASSET}:${CHAIN}:${CHANNEL_ID}`;
+const CHAIN_RECIPIENT = '0x' + '11'.repeat(20);
+const SENDER_PUBKEY = 'f'.repeat(64);
+const SENDER_ILP = 'g.toon.client.sender01';
+const STREAM_NONCE = '9f'.repeat(16);
+const INITIAL_INVENTORY = 10n ** 18n; // 1 ETH in wei
+
+function fixturePair(): SwapPair {
+  return {
+    from: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+    to: { assetCode: ASSET, assetScale: 18, chain: CHAIN },
+    rate: '0.0004',
+  };
+}
+
+/** δ = 1 USDC → ⌊δ·0.0004⌋ = 4e14 wei at the static rate. */
+const DELTA = 1_000_000n;
+const TARGET_PER_DELTA = 400_000_000_000_000n;
+
+function mintPacket(): { preimage: Uint8Array; condition: Uint8Array } {
+  const preimage = new Uint8Array(32);
+  globalThis.crypto.getRandomValues(preimage);
+  return { preimage, condition: sha256(preimage) };
+}
+
+function fillPayload(
+  seq: number,
+  streamNonce = STREAM_NONCE
+): RollingFillPayload {
+  return { proto: ROLLING_PROTOCOL, type: 'fill', streamNonce, seq };
+}
+
+function decodeRejectData(dataB64?: string): Record<string, unknown> {
+  expect(dataB64).toBeTypeOf('string');
+  return JSON.parse(Buffer.from(dataB64!, 'base64').toString('utf8')) as Record<
+    string,
+    unknown
+  >;
+}
+
+function decodeAdvance(prepare: LegBPrepare): RollingAdvancePayload {
+  return JSON.parse(prepare.data.toString('utf8')) as RollingAdvancePayload;
+}
+
+interface Stack {
+  engine: RollingSwapEngine;
+  inventory: SwapInventory;
+  channelState: SwapChannelState;
+  seen: PersistentSeenPacketIds;
+  sessions: RollingSessionStore;
+  saved: () => PersistedSwapState | null;
+  legB: CapturingLegB;
+}
+
+interface CapturingLegB {
+  sender: LegBSender;
+  received: LegBPrepare[];
+  /** Per-call behavior override; default reveals the matching preimage. */
+  respond: (prepare: LegBPrepare) => Promise<LegBResult> | LegBResult;
+}
+
+/**
+ * The default leg-B counterpart: a compliant sender daemon that "reveals"
+ * the preimage matching the condition it received (tests hand it the mint
+ * map). Overridable per test for withhold/wrong-preimage/reject behavior.
+ */
+function makeLegB(preimageByCondition: Map<string, Uint8Array>): CapturingLegB {
+  const legB: CapturingLegB = {
+    received: [],
+    respond: (prepare) => {
+      const key = Buffer.from(prepare.executionCondition).toString('base64');
+      const preimage = preimageByCondition.get(key);
+      if (!preimage) {
+        return { type: 'reject', code: 'F99', message: 'unknown condition' };
+      }
+      return { type: 'fulfill', fulfillment: preimage };
+    },
+    sender: async (prepare) => {
+      legB.received.push(prepare);
+      return legB.respond(prepare);
+    },
+  };
+  return legB;
+}
+
+function buildStack(options?: {
+  rateProvider?: () => TimestampedRate | string;
+  maxRateAgeMs?: number;
+  now?: () => number;
+  rehydrateFrom?: PersistedSwapState;
+  minLegBTimeMs?: number;
+  legBExpiryMarginMs?: number;
+  legBBudgetMs?: number;
+}): Stack {
+  const persisted = options?.rehydrateFrom ?? null;
+
+  const inventory = new SwapInventory({
+    balances: persisted
+      ? Object.fromEntries(
+          Object.entries(persisted.inventory).map(([k, v]) => [
+            k,
+            { available: BigInt(v.available), total: BigInt(v.total) },
+          ])
+        )
+      : {
+          [INVENTORY_KEY]: {
+            available: INITIAL_INVENTORY,
+            total: INITIAL_INVENTORY,
+          },
+        },
+  });
+  const channelState = new SwapChannelState({
+    channels: persisted
+      ? Object.fromEntries(
+          Object.entries(persisted.channels).map(([k, v]) => [
+            k,
+            {
+              channelId: v.channelId,
+              cumulativeAmount: BigInt(v.cumulativeAmount),
+              nonce: BigInt(v.nonce),
+              updatedAt: v.updatedAt,
+            },
+          ])
+        )
+      : {
+          [CHANNEL_KEY]: {
+            channelId: CHANNEL_ID,
+            cumulativeAmount: 0n,
+            nonce: 0n,
+            updatedAt: 0,
+          },
+        },
+    ...(persisted && { bindings: persisted.bindings }),
+  });
+
+  let savedState: PersistedSwapState | null = null;
+  const store: SwapStateStore = {
+    load: () => savedState,
+    save: (s) => {
+      savedState = s;
+    },
+  };
+  const seen = new PersistentSeenPacketIds(persisted?.seenPacketIds ?? []);
+  const persister = new SwapStatePersister({
+    store,
+    inventory,
+    channelState,
+    seenPacketIds: seen,
+  });
+  seen.setOnMutate(() => persister.persist());
+
+  const claimIssuer = new MultiChainClaimIssuer({
+    inventory,
+    channelState,
+    signers: {
+      [CHAIN]: new EvmPaymentChannelSigner({
+        chain: CHAIN,
+        privateKey: new Uint8Array(32).fill(7),
+      }),
+    },
+    signerAddresses: { [CHAIN]: '0x' + '22'.repeat(20) },
+    persistState: () => persister.persist(),
+  });
+
+  const preimageByCondition = new Map<string, Uint8Array>();
+  const legB = makeLegB(preimageByCondition);
+  // Expose the mint map through the legB object for tests.
+  (legB as CapturingLegB & { preimages: Map<string, Uint8Array> }).preimages =
+    preimageByCondition;
+
+  const sessions = new RollingSessionStore({ now: options?.now });
+  sessions.register({
+    streamNonce: STREAM_NONCE,
+    pair: fixturePair(),
+    chainRecipient: CHAIN_RECIPIENT,
+    senderIlpAddress: SENDER_ILP,
+    senderPubkey: SENDER_PUBKEY,
+  });
+
+  const guard =
+    options?.maxRateAgeMs !== undefined
+      ? new RateFreshnessGuard({
+          maxRateAge: { defaultMs: options.maxRateAgeMs },
+          rateProvider: options.rateProvider ?? (() => fixturePair().rate),
+          ...(options.now && { now: options.now }),
+        })
+      : undefined;
+
+  const engine = new RollingSwapEngine({
+    sessions,
+    claimIssuer,
+    legBSender: legB.sender,
+    seenPacketIds: seen,
+    ...(options?.rateProvider && { rateProvider: options.rateProvider }),
+    ...(guard && { stalenessGuard: guard }),
+    ...(options?.now && { now: options.now }),
+    ...(options?.minLegBTimeMs !== undefined && {
+      minLegBTimeMs: options.minLegBTimeMs,
+    }),
+    ...(options?.legBExpiryMarginMs !== undefined && {
+      legBExpiryMarginMs: options.legBExpiryMarginMs,
+    }),
+    ...(options?.legBBudgetMs !== undefined && {
+      legBBudgetMs: options.legBBudgetMs,
+    }),
+  });
+
+  return {
+    engine,
+    inventory,
+    channelState,
+    seen,
+    sessions,
+    saved: () => savedState,
+    legB,
+  };
+}
+
+function stackPreimages(stack: Stack): Map<string, Uint8Array> {
+  return (stack.legB as CapturingLegB & { preimages: Map<string, Uint8Array> })
+    .preimages;
+}
+
+async function sendFill(
+  stack: Stack,
+  seq: number,
+  opts?: {
+    condition?: Uint8Array;
+    amount?: string;
+    expiresAt?: string;
+    streamNonce?: string;
+  }
+): Promise<{
+  response: RollingFillResponse;
+  preimage: Uint8Array;
+  condition: Uint8Array;
+}> {
+  const { preimage, condition } = mintPacket();
+  const cond = opts?.condition ?? condition;
+  stackPreimages(stack).set(Buffer.from(cond).toString('base64'), preimage);
+  const response = await stack.engine.handleFill({
+    amount: opts?.amount ?? DELTA.toString(),
+    destination: 'g.toon.swap.fixture',
+    executionCondition: cond,
+    payload: fillPayload(seq, opts?.streamNonce),
+    ...(opts?.expiresAt !== undefined && { expiresAt: opts.expiresAt }),
+  });
+  return { response, preimage, condition: cond };
+}
+
+// ---------------------------------------------------------------------------
+// Connector local-delivery enforcement, mocked per the contract doc
+// ---------------------------------------------------------------------------
+
+/**
+ * `connector/docs/local-delivery-fulfillment-contract.md` rule 3, verbatim:
+ * before FULFILLing upstream the connector enforces
+ * `sha256(fulfillment) === executionCondition`; on a missing, malformed, or
+ * mismatching preimage the fulfill is converted into an F99 REJECT and
+ * NOTHING is recorded as delivered.
+ */
+function connectorEnforce(
+  response: RollingFillResponse,
+  condition: Uint8Array
+):
+  | { delivered: true; fulfillment: Uint8Array }
+  | { delivered: false; code: string } {
+  if (!response.accept) {
+    return { delivered: false, code: response.code };
+  }
+  const f = response.fulfillment
+    ? new Uint8Array(Buffer.from(response.fulfillment, 'base64'))
+    : undefined;
+  if (
+    !f ||
+    f.length !== 32 ||
+    Buffer.compare(Buffer.from(sha256(f)), Buffer.from(condition)) !== 0
+  ) {
+    return { delivered: false, code: 'F99' };
+  }
+  return { delivered: true, fulfillment: f };
+}
+
+// ---------------------------------------------------------------------------
+// Happy path (AC-1)
+// ---------------------------------------------------------------------------
+
+describe('rolling engine — coupled happy path', () => {
+  it('condition in → SAME condition on leg B → correct preimage out → claim advance consistent', async () => {
+    const stack = buildStack({
+      rateProvider: () => ({ rate: '0.0004', at: Date.now() }),
+    });
+
+    const { response, preimage, condition } = await sendFill(stack, 1);
+
+    // Leg B carried the SAME sender-minted condition (spec R4) to the
+    // session's ILP address, priced at the fresh rate.
+    expect(stack.legB.received).toHaveLength(1);
+    const legB = stack.legB.received[0]!;
+    expect(Buffer.from(legB.executionCondition)).toEqual(
+      Buffer.from(condition)
+    );
+    expect(legB.destination).toBe(SENDER_ILP);
+    expect(legB.amount).toBe(TARGET_PER_DELTA);
+
+    // The leg-B advance payload carries the chain-B claim + quote tape.
+    const advance = decodeAdvance(legB);
+    expect(advance.proto).toBe(ROLLING_PROTOCOL);
+    expect(advance.type).toBe('advance');
+    expect(advance.streamNonce).toBe(STREAM_NONCE);
+    expect(advance.seq).toBe(1);
+    expect(advance.claim.length).toBeGreaterThan(0);
+    expect(advance.channelId).toBe(CHANNEL_ID);
+    expect(advance.nonce).toBe('1');
+    expect(advance.cumulativeAmount).toBe(TARGET_PER_DELTA.toString());
+    expect(advance.recipient).toBe(CHAIN_RECIPIENT);
+    expect(advance.rate).toBe('0.0004');
+    expect(advance.rateTimestamp).toBeTypeOf('number');
+    expect(advance.sourceAmount).toBe(DELTA.toString());
+    expect(advance.targetAmount).toBe(TARGET_PER_DELTA.toString());
+
+    // Leg A accepted WITH the revealed preimage (spec R6) — and the mocked
+    // connector enforcement (contract rule 3) verifies and delivers it.
+    expect(response.accept).toBe(true);
+    const enforced = connectorEnforce(response, condition);
+    expect(enforced.delivered).toBe(true);
+    if (response.accept) {
+      expect(Buffer.from(response.fulfillment, 'base64')).toEqual(
+        Buffer.from(preimage)
+      );
+      // The leg-A FULFILL data is the compact accept record — the claim
+      // itself traveled on leg B, not here (the headline change vs legacy).
+      const record = JSON.parse(
+        Buffer.from(response.data, 'base64').toString('utf8')
+      ) as RollingAcceptRecord;
+      expect(record.type).toBe('accept');
+      expect(record.rate).toBe('0.0004');
+      expect(record.targetAmount).toBe(TARGET_PER_DELTA.toString());
+      expect(record.nonce).toBe('1');
+      expect(record.cumulativeAmount).toBe(TARGET_PER_DELTA.toString());
+      expect(JSON.stringify(record)).not.toContain(advance.claim);
+    }
+
+    // State: debit + watermark advance stand.
+    expect(stack.inventory.get(ASSET, CHAIN)!.available).toBe(
+      INITIAL_INVENTORY - TARGET_PER_DELTA
+    );
+    const entry = stack.channelState.get({
+      assetCode: ASSET,
+      chain: CHAIN,
+      senderPubkey: SENDER_PUBKEY,
+    })!;
+    expect(entry.nonce).toBe(1n);
+    expect(entry.cumulativeAmount).toBe(TARGET_PER_DELTA);
+  });
+
+  it('multi-packet stream: cumulative claims are monotone and per-packet priced', async () => {
+    let tick = 0;
+    const rates = ['0.0004', '0.0005', '0.0003'];
+    const stack = buildStack({
+      rateProvider: () => ({ rate: rates[tick++ % 3]!, at: Date.now() }),
+    });
+
+    // ⌊1 USDC · R_i⌋ in wei per quoted rate.
+    const deltaByRate: Record<string, bigint> = {
+      '0.0004': 4n * 10n ** 14n,
+      '0.0005': 5n * 10n ** 14n,
+      '0.0003': 3n * 10n ** 14n,
+    };
+    let expectedCumulative = 0n;
+    for (let seq = 1; seq <= 3; seq++) {
+      const { response, condition } = await sendFill(stack, seq);
+      expect(connectorEnforce(response, condition).delivered).toBe(true);
+      const advance = decodeAdvance(stack.legB.received[seq - 1]!);
+      const rate = rates[seq - 1]!;
+      expect(advance.rate).toBe(rate);
+      expectedCumulative += deltaByRate[rate]!;
+      expect(advance.nonce).toBe(String(seq));
+      expect(advance.cumulativeAmount).toBe(expectedCumulative.toString());
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The coupling property (AC-1/AC-2), at the contract level
+// ---------------------------------------------------------------------------
+
+describe('rolling engine — maker cannot collect leg A while withholding leg B', () => {
+  it('sender withholds the reveal (leg B rejected) → leg A fails benignly, full unwind', async () => {
+    const stack = buildStack();
+    stack.legB.respond = () => ({
+      type: 'reject',
+      code: 'T00',
+      message: 'sender declined to reveal',
+    });
+
+    const { response, condition } = await sendFill(stack, 1);
+
+    expect(response.accept).toBe(false);
+    if (!response.accept) {
+      expect(response.code).toBe('T00'); // T-class leg-B failure stays T-class
+      const data = decodeRejectData(response.data);
+      expect(data['reason']).toBe(ROLLING_REJECT_REASONS.LEG_B_FAILED);
+    }
+    // Contract: the connector records nothing for a reject.
+    expect(connectorEnforce(response, condition).delivered).toBe(false);
+
+    // AC-4: the failed packet fully unwound inventory + channel reservation.
+    expect(stack.inventory.get(ASSET, CHAIN)!.available).toBe(
+      INITIAL_INVENTORY
+    );
+    const entry = stack.channelState.get({
+      assetCode: ASSET,
+      chain: CHAIN,
+      senderPubkey: SENDER_PUBKEY,
+    })!;
+    expect(entry.nonce).toBe(0n);
+    expect(entry.cumulativeAmount).toBe(0n);
+  });
+
+  it('leg B "fulfills" with a WRONG preimage → engine unwinds and rejects; even a Byzantine accept could not pass the connector check', async () => {
+    const stack = buildStack();
+    const wrong = new Uint8Array(32).fill(9);
+    stack.legB.respond = () => ({ type: 'fulfill', fulfillment: wrong });
+
+    const { response, condition } = await sendFill(stack, 1);
+
+    expect(response.accept).toBe(false);
+    if (!response.accept) {
+      expect(response.code).toBe('F99');
+      expect(decodeRejectData(response.data)['reason']).toBe(
+        ROLLING_REJECT_REASONS.LEG_B_FULFILLMENT_INVALID
+      );
+    }
+    expect(stack.inventory.get(ASSET, CHAIN)!.available).toBe(
+      INITIAL_INVENTORY
+    );
+
+    // Byzantine-maker simulation: even if a maker implementation tried to
+    // accept anyway (with the wrong preimage, or none), the connector's
+    // enforcement — mocked per contract rule 3 — converts it to F99 and
+    // records nothing. The maker structurally cannot collect leg A without
+    // the sender's reveal.
+    const byzantineWithWrong: RollingFillResponse = {
+      accept: true,
+      data: '',
+      fulfillment: Buffer.from(wrong).toString('base64'),
+    };
+    expect(connectorEnforce(byzantineWithWrong, condition)).toEqual({
+      delivered: false,
+      code: 'F99',
+    });
+    const byzantineWithout = {
+      accept: true,
+      data: '',
+    } as unknown as RollingFillResponse;
+    expect(connectorEnforce(byzantineWithout, condition)).toEqual({
+      delivered: false,
+      code: 'F99',
+    });
+  });
+
+  it('leg B fails F-class → leg-A reject is F-class (F99) with leg-B detail', async () => {
+    const stack = buildStack();
+    stack.legB.respond = () => ({
+      type: 'reject',
+      code: 'F02',
+      message: 'no route to sender',
+    });
+    const { response } = await sendFill(stack, 1);
+    expect(response.accept).toBe(false);
+    if (!response.accept) {
+      expect(response.code).toBe('F99');
+      const data = decodeRejectData(response.data);
+      expect(data['reason']).toBe(ROLLING_REJECT_REASONS.LEG_B_FAILED);
+      expect((data['legB'] as Record<string, unknown>)['code']).toBe('F02');
+    }
+  });
+
+  it('leg-B sender that throws → unwound + benign reject', async () => {
+    const stack = buildStack();
+    stack.legB.respond = () => {
+      throw new Error('socket exploded');
+    };
+    const { response } = await sendFill(stack, 1);
+    expect(response.accept).toBe(false);
+    expect(stack.inventory.get(ASSET, CHAIN)!.available).toBe(
+      INITIAL_INVENTORY
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guards: session, replay, staleness, amount, expiry
+// ---------------------------------------------------------------------------
+
+describe('rolling engine — guards', () => {
+  it('unknown streamNonce → benign F06 unknown_session, no state change', async () => {
+    const stack = buildStack();
+    const { response } = await sendFill(stack, 1, {
+      streamNonce: 'aa'.repeat(16),
+    });
+    expect(response.accept).toBe(false);
+    if (!response.accept) {
+      expect(response.code).toBe('F06');
+      expect(response.rejectReason.code).toBe('unexpected_payment');
+      expect(decodeRejectData(response.data)['reason']).toBe(
+        ROLLING_REJECT_REASONS.UNKNOWN_SESSION
+      );
+    }
+    expect(stack.legB.received).toHaveLength(0);
+    expect(stack.seen.size).toBe(0);
+    expect(stack.inventory.get(ASSET, CHAIN)!.available).toBe(
+      INITIAL_INVENTORY
+    );
+  });
+
+  it('replay of a fulfilled (streamNonce, seq) → F04 duplicate; exactly one claim issued', async () => {
+    const stack = buildStack();
+    const first = await sendFill(stack, 1);
+    expect(first.response.accept).toBe(true);
+
+    // Same seq again — even with a FRESH condition — is a replay.
+    const second = await sendFill(stack, 1);
+    expect(second.response.accept).toBe(false);
+    if (!second.response.accept) {
+      expect(second.response.code).toBe('F04');
+      expect(decodeRejectData(second.response.data)['reason']).toBe(
+        ROLLING_REJECT_REASONS.DUPLICATE_PACKET
+      );
+    }
+    expect(stack.legB.received).toHaveLength(1);
+    const entry = stack.channelState.get({
+      assetCode: ASSET,
+      chain: CHAIN,
+      senderPubkey: SENDER_PUBKEY,
+    })!;
+    expect(entry.nonce).toBe(1n);
+  });
+
+  it('stale feed → byte-identical swap#48 T99 stale_rate reject BEFORE any reservation or debit', async () => {
+    let feedAt = 1_000_000;
+    let now = 1_000_100;
+    const stack = buildStack({
+      rateProvider: () => ({ rate: '0.0004', at: feedAt }),
+      maxRateAgeMs: 1_500,
+      now: () => now,
+    });
+
+    // Age the feed past the bound.
+    now = feedAt + 5_000;
+    const stale = await sendFill(stack, 1);
+    expect(stale.response.accept).toBe(false);
+    if (!stale.response.accept) {
+      expect(stale.response.code).toBe(STALE_RATE_REJECT_CODE);
+      expect(stale.response.message).toBe(STALE_RATE_REJECT_MESSAGE);
+      expect(stale.response.rejectReason.code).toBe(STALE_RATE_SEMANTIC_REASON);
+      const data = decodeRejectData(stale.response.data);
+      expect(data['reason']).toBe(STALE_RATE_REASON);
+      expect(data['maxRateAgeMs']).toBe(1_500);
+    }
+    // Benign: NO replay reservation, NO debit, NO leg B (spec §4 / R8).
+    expect(stack.seen.size).toBe(0);
+    expect(stack.legB.received).toHaveLength(0);
+    expect(stack.inventory.get(ASSET, CHAIN)!.available).toBe(
+      INITIAL_INVENTORY
+    );
+
+    // Feed ticks again → the SAME seq retries fine (no reservation burned).
+    feedAt = now;
+    const retry = await sendFill(stack, 1);
+    expect(retry.response.accept).toBe(true);
+  });
+
+  it('invalid and non-positive amounts → F03, nothing debited', async () => {
+    const stack = buildStack();
+    for (const amount of ['0', '-5', 'not-a-number']) {
+      const { response } = await sendFill(stack, 1, { amount });
+      expect(response.accept).toBe(false);
+      if (!response.accept) expect(response.code).toBe('F03');
+    }
+    expect(stack.legB.received).toHaveLength(0);
+    expect(stack.inventory.get(ASSET, CHAIN)!.available).toBe(
+      INITIAL_INVENTORY
+    );
+  });
+
+  it('insufficient leg-A time budget → R00 before any debit (spec R7)', async () => {
+    const now = 1_000_000_000;
+    const stack = buildStack({ now: () => now, minLegBTimeMs: 2_000 });
+    const { response } = await sendFill(stack, 1, {
+      expiresAt: new Date(now + 1_500).toISOString(),
+    });
+    expect(response.accept).toBe(false);
+    if (!response.accept) {
+      expect(response.code).toBe('R00');
+      expect(decodeRejectData(response.data)['reason']).toBe(
+        ROLLING_REJECT_REASONS.INSUFFICIENT_TIMEOUT
+      );
+    }
+    expect(stack.legB.received).toHaveLength(0);
+    expect(stack.inventory.get(ASSET, CHAIN)!.available).toBe(
+      INITIAL_INVENTORY
+    );
+  });
+
+  it('leg-B expiry is capped strictly under leg-A expiry (spec R7)', async () => {
+    const now = 1_000_000_000;
+    const stack = buildStack({
+      now: () => now,
+      legBExpiryMarginMs: 1_000,
+      legBBudgetMs: 60_000,
+    });
+    const legAExpiry = now + 10_000;
+    const { response } = await sendFill(stack, 1, {
+      expiresAt: new Date(legAExpiry).toISOString(),
+    });
+    expect(response.accept).toBe(true);
+    expect(stack.legB.received[0]!.expiresAt.getTime()).toBe(
+      legAExpiry - 1_000
+    );
+  });
+
+  it('insufficient inventory → T04 insufficient_funds, replay seq burned', async () => {
+    const stack = buildStack();
+    // 1 ETH inventory; ask for a fill needing 4000 ETH (10^7 USDC * 0.0004).
+    const { response } = await sendFill(stack, 1, {
+      amount: (10n ** 13n).toString(),
+    });
+    expect(response.accept).toBe(false);
+    if (!response.accept) {
+      expect(response.code).toBe('T04');
+      expect(response.rejectReason.code).toBe('insufficient_funds');
+    }
+    expect(stack.inventory.get(ASSET, CHAIN)!.available).toBe(
+      INITIAL_INVENTORY
+    );
+    // The reservation is fail-closed: same seq cannot be retried.
+    expect(stack.seen.has(`rolling:${STREAM_NONCE}:1`)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Crash consistency (state-store rules 1/2/4)
+// ---------------------------------------------------------------------------
+
+describe('rolling engine — crash between debit and fulfill', () => {
+  it('persisted snapshot at leg-B time is the safe state; restart continues monotonically and rejects the replay', async () => {
+    const stack = buildStack();
+    let crashSnapshot: PersistedSwapState | null = null;
+    stack.legB.respond = () => {
+      // The instant leg B is in flight IS the crash window: the write-ahead
+      // persist has already happened (crash rule 1). Capture disk state,
+      // then die before any response/unwind.
+      crashSnapshot = structuredClone(stack.saved());
+      throw new Error('simulated crash');
+    };
+    await sendFill(stack, 1).catch(() => undefined);
+
+    expect(crashSnapshot).not.toBeNull();
+    const snap = crashSnapshot! as PersistedSwapState;
+    // Watermark advanced + inventory debited + replay seq reserved — all
+    // BEFORE the claim could have left the process.
+    expect(snap.channels[CHANNEL_KEY]!.nonce).toBe('1');
+    expect(snap.channels[CHANNEL_KEY]!.cumulativeAmount).toBe(
+      TARGET_PER_DELTA.toString()
+    );
+    expect(BigInt(snap.inventory[INVENTORY_KEY]!.available)).toBe(
+      INITIAL_INVENTORY - TARGET_PER_DELTA
+    );
+    expect(snap.seenPacketIds).toContain(`rolling:${STREAM_NONCE}:1`);
+
+    // "Reboot" from the crash snapshot.
+    const rebooted = buildStack({ rehydrateFrom: snap });
+
+    // Replay of the aborted fill → F04 (crash rule 4, fail-closed).
+    const replay = await sendFill(rebooted, 1);
+    expect(replay.response.accept).toBe(false);
+    if (!replay.response.accept) expect(replay.response.code).toBe('F04');
+
+    // The next fill continues ABOVE the aborted reservation (crash rule 2):
+    // nonce 2, cumulative stacked on the aborted watermark — never behind
+    // any claim a counterparty could hold.
+    const next = await sendFill(rebooted, 2);
+    expect(next.response.accept).toBe(true);
+    const advance = decodeAdvance(rebooted.legB.received[0]!);
+    expect(advance.nonce).toBe('2');
+    expect(advance.cumulativeAmount).toBe((TARGET_PER_DELTA * 2n).toString());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sessions + payload parsing
+// ---------------------------------------------------------------------------
+
+describe('RollingSessionStore', () => {
+  it('normalizes streamNonce case, enforces shape, TTL-expires, and bounds size', () => {
+    let now = 1_000;
+    const store = new RollingSessionStore({
+      ttlMs: 100,
+      maxSessions: 2,
+      now: () => now,
+    });
+    const base = {
+      pair: fixturePair(),
+      chainRecipient: CHAIN_RECIPIENT,
+      senderIlpAddress: SENDER_ILP,
+      senderPubkey: SENDER_PUBKEY,
+    };
+    expect(() => store.register({ ...base, streamNonce: 'xyz' })).toThrowError(
+      /32 lowercase hex/
+    );
+
+    store.register({ ...base, streamNonce: 'AB'.repeat(16) });
+    expect(store.get('ab'.repeat(16))).not.toBeNull();
+    expect(store.get('AB'.repeat(16))).not.toBeNull();
+
+    store.register({ ...base, streamNonce: 'cd'.repeat(16) });
+    expect(() =>
+      store.register({ ...base, streamNonce: 'ef'.repeat(16) })
+    ).toThrowError(/full/);
+
+    // TTL expiry frees capacity and get() returns null.
+    now += 200;
+    expect(store.get('ab'.repeat(16))).toBeNull();
+    store.register({ ...base, streamNonce: 'ef'.repeat(16) });
+    expect(store.get('ef'.repeat(16))).not.toBeNull();
+  });
+});
+
+describe('parseRollingFillPayload', () => {
+  const encode = (v: unknown): string =>
+    Buffer.from(JSON.stringify(v), 'utf8').toString('base64');
+
+  it('accepts a well-formed fill', () => {
+    expect(parseRollingFillPayload(encode(fillPayload(7)))).toEqual(
+      fillPayload(7)
+    );
+  });
+
+  it('returns null for non-rolling traffic (TOON, JSON without the proto tag, garbage)', () => {
+    expect(parseRollingFillPayload('')).toBeNull();
+    expect(
+      parseRollingFillPayload(Buffer.from('not json').toString('base64'))
+    ).toBeNull();
+    expect(parseRollingFillPayload(encode({ hello: 'world' }))).toBeNull();
+  });
+
+  it("returns 'malformed' for rolling/1 traffic violating the fill shape", () => {
+    expect(
+      parseRollingFillPayload(encode({ proto: ROLLING_PROTOCOL, type: 'fill' }))
+    ).toBe('malformed');
+    expect(
+      parseRollingFillPayload(
+        encode({
+          proto: ROLLING_PROTOCOL,
+          type: 'fill',
+          streamNonce: 'Z'.repeat(32),
+          seq: 1,
+        })
+      )
+    ).toBe('malformed');
+    expect(
+      parseRollingFillPayload(
+        encode({
+          proto: ROLLING_PROTOCOL,
+          type: 'fill',
+          streamNonce: STREAM_NONCE,
+          seq: 0,
+        })
+      )
+    ).toBe('malformed');
+    expect(
+      parseRollingFillPayload(
+        encode({
+          proto: ROLLING_PROTOCOL,
+          type: 'advance',
+          streamNonce: STREAM_NONCE,
+          seq: 1,
+        })
+      )
+    ).toBe('malformed');
+  });
+});

--- a/packages/swap/src/rolling-engine.ts
+++ b/packages/swap/src/rolling-engine.ts
@@ -1,0 +1,1038 @@
+/**
+ * Rolling swap engine — coupled shared-condition packet legs (swap#47).
+ *
+ * Implements the maker side of toon-meta `docs/rolling-swap.md` §3: each fill
+ * packet's two legs — sender→maker on chain A, maker→sender chain-B channel
+ * advance — share ONE sender-minted execution condition `C_i = sha256(P_i)`,
+ * so the legs commit or fail together, packet by packet. This replaces the
+ * legacy `issueClaim`-in-FULFILL response shape ON THE ROLLING PATH ONLY (the
+ * legacy gift-wrap path is preserved byte-for-byte for zero-condition
+ * packets — see the dispatch matrix in `swap-node.ts`).
+ *
+ * ## The coupling, as implemented (spec §3 R1–R8)
+ *
+ *   sender ─ PREPARE(δ, condition C_i, fill {streamNonce, seq}) ─▶ maker connector
+ *   maker connector ─ LocalDeliveryRequest{executionCondition: b64(C_i)} ─▶ THIS ENGINE
+ *   engine: staleness gate → replay reservation → fresh rate R_i →
+ *           issueClaim (debit + watermark advance + WRITE-AHEAD PERSIST) →
+ *           leg-B PREPARE(⌊δ·R_i⌋, SAME C_i, advance payload w/ chain-B claim) → sender
+ *   sender (toon-client#352): verifies the leg-B claim BEFORE revealing —
+ *           FULFILLs leg B with P_i iff the claim checks out (spec R5)
+ *   engine: learns P_i from the leg-B FULFILL, verifies sha256(P_i) == C_i,
+ *           returns { accept, fulfillment: b64(P_i) } (spec R6)
+ *   maker connector: enforces sha256(fulfillment) == C_i before FULFILLing
+ *           leg A upstream; mismatch/missing → F99, nothing recorded
+ *           (connector `docs/local-delivery-fulfillment-contract.md` rule 3)
+ *
+ * The engine can therefore only collect leg A by relaying the preimage the
+ * sender revealed on leg B — and the sender only reveals after verifying the
+ * chain-B claim. That inversion (verify-before-reveal) is the value-atomicity
+ * core; a stalling/withholding maker fails the packet and collects nothing.
+ *
+ * ## Failure unwinding (issue #47 AC-4)
+ *
+ * `issueClaim` debits inventory, advances the channel watermark, and persists
+ * write-ahead BEFORE the leg-B PREPARE is sent (state-store crash rule 1: no
+ * claim a counterparty can hold is ever ahead of the stored watermark). If
+ * leg B then rejects, times out, or fulfills without the correct preimage,
+ * the engine fully unwinds via `MultiChainClaimIssuer.rollbackClaim` (the
+ * same credit+release+re-persist pattern as the signer-failure rollback) and
+ * rejects leg A benignly. Per spec R8 the sender MUST NOT treat a claim from
+ * a REJECTed packet as redeemable; the residual Byzantine exposure is the
+ * designed `δ·W` in-flight bound (spec §3.1/§8), not a new gap.
+ *
+ * A crash between the write-ahead persist and the leg-A response leaves the
+ * safe state on disk: watermark advanced, inventory debited, replay seq
+ * reserved — the restart continues monotonically above the aborted
+ * reservation and replays of the fill are rejected F04 (crash rules 2 and 4).
+ *
+ * ## Sessions (spec §2.2)
+ *
+ * Fill packets are deliberately tiny — `{streamNonce, seq}` plus the ILP
+ * amount and condition. Session-scoped fields (pair, chainRecipient, the
+ * sender's leg-B ILP address, sender pubkey) arrive once via the RFQ round
+ * trip (kind:20033/20034 — its transport story registers sessions through
+ * {@link RollingSessionStore.register} / `SwapNodeInstance.registerRollingSession`).
+ * An unknown `streamNonce` is a benign F06 reject.
+ */
+
+import { sha256 } from '@noble/hashes/sha2.js';
+import type { UnsignedEvent } from 'nostr-tools/pure';
+
+import { applyRate } from '@toon-protocol/sdk';
+import type { IssueClaimResult } from '@toon-protocol/sdk';
+import type { SwapPair } from '@toon-protocol/core';
+
+import type { MultiChainClaimIssuer } from './claim-issuer.js';
+import {
+  buildStaleRateReject,
+  StaleRateError,
+  pairKey,
+} from './rate-staleness.js';
+import type {
+  RateFreshnessGuard,
+  RateStalenessLogger,
+  SwapRateProvider,
+} from './rate-staleness.js';
+
+// ---------------------------------------------------------------------------
+// Wire payloads (consumed by toon-client#352 sender-side and swap#49/#50)
+// ---------------------------------------------------------------------------
+
+/**
+ * Protocol tag for the rolling coupled-leg wire format (spec §10.3 step 2 —
+ * the RFQ advertises this; every rolling payload carries it).
+ */
+export const ROLLING_PROTOCOL = 'rolling/1';
+
+/** `streamNonce` — 16 random bytes, lowercase hex (spec §2.1). */
+const STREAM_NONCE_REGEX = /^[0-9a-f]{32}$/;
+
+/**
+ * Leg-A fill payload: the ILP PREPARE `data` of a rolling fill packet,
+ * UTF-8 JSON (base64 on the local-delivery wire). Everything else rides the
+ * packet itself: amount δ = ILP `amount`, `C_i` = `executionCondition`, the
+ * leg-A channel claim = `ILP-Payment-Channel-Claim` protocolData as today.
+ */
+export interface RollingFillPayload {
+  proto: typeof ROLLING_PROTOCOL;
+  type: 'fill';
+  /** Session id minted at RFQ — 16 bytes, lowercase hex. */
+  streamNonce: string;
+  /** Per-session fill sequence, starting at 1. Never reused (spec §4). */
+  seq: number;
+}
+
+/**
+ * Leg-B advance payload: the `data` of the maker→sender PREPARE that carries
+ * the chain-B cumulative claim for this fill, priced at the maker's fresh
+ * quote. UTF-8 JSON. The sender verifies this (spec R5: signature over the
+ * canonical hash layout, recipient equality, monotone nonce/cumulative,
+ * effective rate ≥ its floor) BEFORE revealing the preimage.
+ *
+ * All bigints are decimal strings. `claim` is the base64 of the signed
+ * balance-proof bytes (chain-specific format, same bytes the legacy FULFILL
+ * metadata carried).
+ */
+export interface RollingAdvancePayload {
+  proto: typeof ROLLING_PROTOCOL;
+  type: 'advance';
+  streamNonce: string;
+  seq: number;
+  /** Base64 signed chain-B balance proof. */
+  claim: string;
+  claimId?: string;
+  channelId?: string;
+  /** Balance-proof nonce (decimal string). */
+  nonce?: string;
+  /** Cumulative transferred amount on the chain-B channel (decimal string). */
+  cumulativeAmount?: string;
+  /** The session `chainRecipient` the proof was signed for. */
+  recipient?: string;
+  /** The maker's on-chain signer address for `pair.to.chain`. */
+  swapSignerAddress?: string;
+  /** Quote tape (spec §7.1): the rate actually applied to this fill. */
+  rate: string;
+  /** Unix-ms tick time of the maker's rate source for `rate`. */
+  rateTimestamp: number;
+  /** Leg-A source amount δ (decimal string). */
+  sourceAmount: string;
+  /** ⌊δ·R_i⌋ in chain-B units (decimal string) — this fill's claim delta. */
+  targetAmount: string;
+}
+
+/**
+ * Leg-A FULFILL `data` on the rolling path: a compact accept record. The
+ * chain-B claim itself travels on LEG B (this is the headline change vs the
+ * legacy path, whose FULFILL data carried the signed claim); the leg-A
+ * FULFILL carries only the quote-tape record and watermark echo so the
+ * sender's controller can cross-check without re-parsing leg B.
+ */
+export interface RollingAcceptRecord {
+  proto: typeof ROLLING_PROTOCOL;
+  type: 'accept';
+  streamNonce: string;
+  seq: number;
+  rate: string;
+  rateTimestamp: number;
+  targetAmount: string;
+  channelId?: string;
+  nonce?: string;
+  cumulativeAmount?: string;
+}
+
+/**
+ * Parse an ILP `data` field (base64) as a rolling fill payload.
+ *
+ * Returns the payload when it is a well-formed rolling fill, `'malformed'`
+ * when it self-identifies as `rolling/1` but violates the shape (so the
+ * dispatcher can reject F01 instead of letting it fall through to the legacy
+ * TOON parser), and `null` when it is not rolling traffic at all.
+ */
+export function parseRollingFillPayload(
+  dataB64: string
+): RollingFillPayload | 'malformed' | null {
+  if (typeof dataB64 !== 'string' || dataB64.length === 0) return null;
+  let text: string;
+  try {
+    text = Buffer.from(dataB64, 'base64').toString('utf8');
+  } catch {
+    return null;
+  }
+  if (!text.includes(ROLLING_PROTOCOL)) return null; // cheap pre-filter
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const rec = parsed as Record<string, unknown>;
+  if (rec['proto'] !== ROLLING_PROTOCOL) return null;
+  if (rec['type'] !== 'fill') return 'malformed';
+  const streamNonce = rec['streamNonce'];
+  const seq = rec['seq'];
+  if (typeof streamNonce !== 'string' || !STREAM_NONCE_REGEX.test(streamNonce))
+    return 'malformed';
+  if (typeof seq !== 'number' || !Number.isSafeInteger(seq) || seq < 1)
+    return 'malformed';
+  return {
+    proto: ROLLING_PROTOCOL,
+    type: 'fill',
+    streamNonce,
+    seq,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sessions
+// ---------------------------------------------------------------------------
+
+/**
+ * One rolling-swap session, established by the RFQ round trip (spec §2.2).
+ * Everything the engine needs that is NOT on the per-fill wire.
+ */
+export interface RollingSession {
+  /** Session id — 16 bytes, lowercase hex (normalized on register). */
+  streamNonce: string;
+  /** The pair every fill in this session is priced against. */
+  pair: SwapPair;
+  /**
+   * The sender's chain-specific payout address on `pair.to.chain` — the
+   * balance-proof `recipient` for every leg-B claim in the session.
+   */
+  chainRecipient: string;
+  /** ILP address the leg-B PREPAREs are sent to (the sender's daemon). */
+  senderIlpAddress: string;
+  /** Sender Nostr pubkey — inventory/channel sticky-binding key. */
+  senderPubkey: string;
+  /** ms-epoch after which fills for this session are rejected. */
+  expiresAt?: number;
+}
+
+export interface RollingSessionStoreConfig {
+  /** Default session lifetime when `RollingSession.expiresAt` is unset. */
+  ttlMs?: number;
+  /** Bound on concurrently registered sessions (expired ones are pruned first). */
+  maxSessions?: number;
+  now?: () => number;
+}
+
+export const DEFAULT_ROLLING_SESSION_TTL_MS = 3_600_000;
+export const DEFAULT_ROLLING_MAX_SESSIONS = 1_024;
+
+/** Bounded, TTL'd registry of active rolling sessions, keyed by streamNonce. */
+export class RollingSessionStore {
+  readonly #sessions = new Map<string, RollingSession>();
+  readonly #ttlMs: number;
+  readonly #maxSessions: number;
+  readonly #now: () => number;
+
+  constructor(config: RollingSessionStoreConfig = {}) {
+    this.#ttlMs = config.ttlMs ?? DEFAULT_ROLLING_SESSION_TTL_MS;
+    this.#maxSessions = config.maxSessions ?? DEFAULT_ROLLING_MAX_SESSIONS;
+    this.#now = config.now ?? Date.now;
+    if (!Number.isFinite(this.#ttlMs) || this.#ttlMs <= 0) {
+      throw new Error('RollingSessionStore ttlMs must be a positive number');
+    }
+    if (!Number.isInteger(this.#maxSessions) || this.#maxSessions <= 0) {
+      throw new Error(
+        'RollingSessionStore maxSessions must be a positive integer'
+      );
+    }
+  }
+
+  /**
+   * Register (or refresh) a session. Throws on a malformed streamNonce or
+   * when the store is full after pruning expired sessions.
+   */
+  register(session: RollingSession): void {
+    const nonce = session.streamNonce.toLowerCase();
+    if (!STREAM_NONCE_REGEX.test(nonce)) {
+      throw new Error(
+        'RollingSession.streamNonce must be 16 bytes as 32 lowercase hex chars'
+      );
+    }
+    this.prune();
+    if (
+      !this.#sessions.has(nonce) &&
+      this.#sessions.size >= this.#maxSessions
+    ) {
+      throw new Error(
+        `RollingSessionStore is full (${this.#maxSessions} sessions)`
+      );
+    }
+    this.#sessions.set(nonce, {
+      ...session,
+      streamNonce: nonce,
+      expiresAt: session.expiresAt ?? this.#now() + this.#ttlMs,
+    });
+  }
+
+  /** Live session for a streamNonce, or `null` (unknown or expired). */
+  get(streamNonce: string): RollingSession | null {
+    const s = this.#sessions.get(streamNonce.toLowerCase());
+    if (!s) return null;
+    if (s.expiresAt !== undefined && s.expiresAt <= this.#now()) {
+      this.#sessions.delete(s.streamNonce);
+      return null;
+    }
+    return s;
+  }
+
+  delete(streamNonce: string): boolean {
+    return this.#sessions.delete(streamNonce.toLowerCase());
+  }
+
+  get size(): number {
+    return this.#sessions.size;
+  }
+
+  private prune(): void {
+    const now = this.#now();
+    for (const [k, s] of this.#sessions) {
+      if (s.expiresAt !== undefined && s.expiresAt <= now) {
+        this.#sessions.delete(k);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Leg-B egress seam
+// ---------------------------------------------------------------------------
+
+/** Outbound leg-B PREPARE the engine asks the connector to originate. */
+export interface LegBPrepare {
+  destination: string;
+  amount: bigint;
+  expiresAt: Date;
+  /** The SAME `C_i` the leg-A PREPARE carried (spec R4 — never re-minted). */
+  executionCondition: Uint8Array;
+  /** UTF-8 JSON {@link RollingAdvancePayload}. */
+  data: Buffer;
+}
+
+/** Normalized leg-B outcome. */
+export type LegBResult =
+  | { type: 'fulfill'; fulfillment?: Uint8Array; data?: Uint8Array }
+  | { type: 'reject'; code: string; message: string; data?: Uint8Array };
+
+/**
+ * Sends one leg-B PREPARE and resolves with its FULFILL/REJECT. Production
+ * wiring is {@link createConnectorLegBSender}; tests inject fakes that model
+ * the sender-side verify-before-reveal contract.
+ */
+export type LegBSender = (prepare: LegBPrepare) => Promise<LegBResult>;
+
+/** Numeric ILP packet-type discriminants (`@toon-protocol/shared` PacketType). */
+const PACKET_TYPE_PREPARE = 12;
+const PACKET_TYPE_FULFILL = 13;
+
+/**
+ * Minimal slice of the connector's internal packet handler the leg-B egress
+ * needs. `ConnectorNode.sendPacket` (connector 3.29.1) strips
+ * `executionCondition` when building the PREPARE, so the engine calls the
+ * SAME underlying entrypoint `sendPacket` wraps — `handlePreparePacket` —
+ * with the condition attached. The connector's forward path passes a non-zero
+ * condition through unchanged (spec R3) and verifies the returned fulfillment
+ * hop-side. Runtime-guarded and fail-closed: when the seam is absent the leg
+ * B is NOT sent unconditioned (that would sever the coupling, R4) — the fill
+ * is rejected instead. Follow-up: add `executionCondition` to the connector's
+ * public `SendPacketParams` and drop this reach-in.
+ */
+interface ConditionCapablePacketHandler {
+  handlePreparePacket(
+    packet: {
+      type: number;
+      destination: string;
+      amount: bigint;
+      expiresAt: Date;
+      executionCondition: Uint8Array;
+      data: Buffer;
+    },
+    sourcePeerId: string
+  ): Promise<{
+    type: number;
+    fulfillment?: Uint8Array;
+    data?: Buffer | Uint8Array;
+    code?: string;
+    message?: string;
+  }>;
+}
+
+export interface ConnectorLegBSenderOptions {
+  /** sourcePeerId for the origination hop — the connector's own nodeId. */
+  nodeId: string;
+  logger?: RateStalenessLogger;
+}
+
+/**
+ * Build the production {@link LegBSender} over an embedded ConnectorNode.
+ * See {@link ConditionCapablePacketHandler} for why this reaches one level
+ * below `sendPacket` (and why it fails closed when it cannot).
+ */
+export function createConnectorLegBSender(
+  connector: unknown,
+  options: ConnectorLegBSenderOptions
+): LegBSender {
+  const logger = options.logger ?? {};
+  return async (prepare: LegBPrepare): Promise<LegBResult> => {
+    const c = connector as {
+      _packetHandler?: Partial<ConditionCapablePacketHandler>;
+      _config?: { nodeId?: string };
+    };
+    const handler = c._packetHandler;
+    if (!handler || typeof handler.handlePreparePacket !== 'function') {
+      logger.warn?.('swap.rolling.leg_b_egress_unavailable', {
+        reason:
+          'connector exposes no conditioned-PREPARE origination seam (handlePreparePacket); leg B NOT sent — sending it without the shared condition would sever the coupling (rolling-swap §3 R4)',
+      });
+      return {
+        type: 'reject',
+        code: 'T00',
+        message:
+          'leg-B egress unavailable: cannot originate conditioned PREPARE',
+      };
+    }
+    const sourcePeerId = c._config?.nodeId ?? options.nodeId;
+    let response: Awaited<
+      ReturnType<ConditionCapablePacketHandler['handlePreparePacket']>
+    >;
+    try {
+      response = await (
+        handler as ConditionCapablePacketHandler
+      ).handlePreparePacket(
+        {
+          type: PACKET_TYPE_PREPARE,
+          destination: prepare.destination,
+          amount: prepare.amount,
+          expiresAt: prepare.expiresAt,
+          executionCondition: prepare.executionCondition,
+          data: prepare.data,
+        },
+        sourcePeerId
+      );
+    } catch (err) {
+      return {
+        type: 'reject',
+        code: 'T00',
+        message: `leg-B send failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+    if (response.type === PACKET_TYPE_FULFILL) {
+      const result: LegBResult = { type: 'fulfill' };
+      if (response.fulfillment) {
+        result.fulfillment = new Uint8Array(response.fulfillment);
+      }
+      if (response.data) result.data = new Uint8Array(response.data);
+      return result;
+    }
+    return {
+      type: 'reject',
+      code: typeof response.code === 'string' ? response.code : 'F99',
+      message:
+        typeof response.message === 'string'
+          ? response.message
+          : 'leg B rejected',
+    };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Engine request/response shapes
+// ---------------------------------------------------------------------------
+
+/** What the swap node's dispatcher hands the engine per rolling fill. */
+export interface RollingFillRequest {
+  /** ILP amount δ (decimal string, source-chain units). */
+  amount: string;
+  /** ILP destination (the swap node's own address — informational). */
+  destination: string;
+  /** Sender-minted non-zero 32-byte condition `C_i` (decoded from base64). */
+  executionCondition: Uint8Array;
+  /** Parsed leg-A fill payload. */
+  payload: RollingFillPayload;
+  /** Leg-A PREPARE expiry (ISO 8601) when the delivery surface provides it. */
+  expiresAt?: string;
+}
+
+export interface RollingRejectReason {
+  code: string;
+  message: string;
+}
+
+/**
+ * Engine response, shaped for the connector's PaymentHandler bridge:
+ * `fulfillment` (accept) is the base64 preimage the connector verifies via
+ * `sha256(fulfillment) === executionCondition`; `rejectReason.code` is the
+ * SEMANTIC reason its `REJECT_CODE_MAP` re-encodes to the wire code.
+ */
+export type RollingFillResponse =
+  | {
+      accept: true;
+      /** Base64 JSON {@link RollingAcceptRecord}. */
+      data: string;
+      /** Base64 32-byte preimage `P_i` learned from the leg-B FULFILL. */
+      fulfillment: string;
+    }
+  | {
+      accept: false;
+      code: string;
+      message: string;
+      /** Base64 JSON structured reject payload (`data.reason` discriminator). */
+      data?: string;
+      rejectReason: RollingRejectReason;
+    };
+
+/** `data.reason` discriminators emitted by the engine's rejects. */
+export const ROLLING_REJECT_REASONS = {
+  UNKNOWN_SESSION: 'unknown_session',
+  DUPLICATE_PACKET: 'duplicate_packet',
+  INVALID_AMOUNT: 'invalid_amount',
+  FILL_TOO_SMALL: 'fill_too_small',
+  INSUFFICIENT_TIMEOUT: 'insufficient_timeout',
+  RATE_UNAVAILABLE: 'rate_unavailable',
+  INSUFFICIENT_LIQUIDITY: 'insufficient_liquidity',
+  CLAIM_ISSUE_FAILED: 'claim_issue_failed',
+  LEG_B_FAILED: 'leg_b_failed',
+  LEG_B_FULFILLMENT_INVALID: 'leg_b_fulfillment_invalid',
+  /** Dispatcher-level: payload self-identifies as rolling/1 but is malformed. */
+  MALFORMED_FILL: 'malformed_fill',
+  /** Dispatcher-level: rolling fill arrived without a sender-chosen condition. */
+  CONDITION_REQUIRED: 'condition_required',
+  /** Dispatcher-level: sender-chosen condition on a non-rolling (legacy) payload. */
+  CONDITION_UNSUPPORTED_LEGACY: 'condition_unsupported_legacy',
+} as const;
+
+/** Build a structured engine reject (rejectReason set explicitly — see type). */
+export function buildRollingReject(params: {
+  code: string;
+  semantic: string;
+  message: string;
+  reason: string;
+  detail?: Record<string, unknown>;
+}): Extract<RollingFillResponse, { accept: false }> {
+  return {
+    accept: false,
+    code: params.code,
+    message: params.message,
+    data: Buffer.from(
+      JSON.stringify({ reason: params.reason, ...params.detail }),
+      'utf8'
+    ).toString('base64'),
+    rejectReason: { code: params.semantic, message: params.message },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// RollingSwapEngine
+// ---------------------------------------------------------------------------
+
+/** Minimal replay-set contract (structural subset of the SDK's SeenPacketIdsLike). */
+export interface RollingSeenPacketIds {
+  has(value: string): boolean;
+  add(value: string): unknown;
+}
+
+export interface RollingSwapEngineConfig {
+  sessions: RollingSessionStore;
+  claimIssuer: MultiChainClaimIssuer;
+  legBSender: LegBSender;
+  /**
+   * Replay reservations, keyed `rolling:${streamNonce}:${seq}`. Shared with
+   * the persistent replay set when persistence is enabled so reservations
+   * hit disk BEFORE any claim is issued (state-store crash rule 4).
+   */
+  seenPacketIds: RollingSeenPacketIds;
+  /**
+   * The maker's live feed. Optional: without it fills price at the frozen
+   * `pair.rate` (stamped with resolution time), same as the legacy handler.
+   */
+  rateProvider?: SwapRateProvider;
+  /** The swap#48 staleness gate — runs BEFORE the replay reservation. */
+  stalenessGuard?: RateFreshnessGuard;
+  logger?: RateStalenessLogger;
+  now?: () => number;
+  /** Max leg-B round-trip budget when leg A's expiry allows it. Default 30s. */
+  legBBudgetMs?: number;
+  /** Leg-B expiry margin under leg-A expiry (spec R7). Default 1s. */
+  legBExpiryMarginMs?: number;
+  /** Reject (before any debit) when the remaining leg-A budget is below this. */
+  minLegBTimeMs?: number;
+}
+
+export const DEFAULT_LEG_B_BUDGET_MS = 30_000;
+export const DEFAULT_LEG_B_EXPIRY_MARGIN_MS = 1_000;
+export const DEFAULT_MIN_LEG_B_TIME_MS = 2_000;
+
+/**
+ * Synthetic inner-rumor kind attached to `issueClaim` calls on the rolling
+ * path (the issuer's `rumor` param is context-only). No gift wrap exists on
+ * rolling fills, so the engine synthesizes an unsigned event carrying the
+ * session context for logging/audit parity with the legacy path.
+ */
+export const ROLLING_FILL_CONTEXT_KIND = 20_035;
+
+export class RollingSwapEngine {
+  readonly #sessions: RollingSessionStore;
+  readonly #claimIssuer: MultiChainClaimIssuer;
+  readonly #legBSender: LegBSender;
+  readonly #seen: RollingSeenPacketIds;
+  readonly #rateProvider?: SwapRateProvider;
+  readonly #guard?: RateFreshnessGuard;
+  readonly #logger: RateStalenessLogger;
+  readonly #now: () => number;
+  readonly #legBBudgetMs: number;
+  readonly #legBExpiryMarginMs: number;
+  readonly #minLegBTimeMs: number;
+
+  constructor(config: RollingSwapEngineConfig) {
+    this.#sessions = config.sessions;
+    this.#claimIssuer = config.claimIssuer;
+    this.#legBSender = config.legBSender;
+    this.#seen = config.seenPacketIds;
+    if (config.rateProvider) this.#rateProvider = config.rateProvider;
+    if (config.stalenessGuard) this.#guard = config.stalenessGuard;
+    this.#logger = config.logger ?? {};
+    this.#now = config.now ?? Date.now;
+    this.#legBBudgetMs = config.legBBudgetMs ?? DEFAULT_LEG_B_BUDGET_MS;
+    this.#legBExpiryMarginMs =
+      config.legBExpiryMarginMs ?? DEFAULT_LEG_B_EXPIRY_MARGIN_MS;
+    this.#minLegBTimeMs = config.minLegBTimeMs ?? DEFAULT_MIN_LEG_B_TIME_MS;
+  }
+
+  /** Register a session (RFQ intake seam). See {@link RollingSessionStore}. */
+  registerSession(session: RollingSession): void {
+    this.#sessions.register(session);
+  }
+
+  /**
+   * Handle one coupled fill packet. See the module docblock for the flow;
+   * ordering is load-bearing:
+   *
+   *   1. session lookup            (no state change)
+   *   2. staleness gate            (no state change — spec R8/§4)
+   *   3. replay reservation        (persisted synchronously; never released)
+   *   4. leg-A expiry budget check (no debit yet)
+   *   5. fresh rate + pricing      (no debit yet)
+   *   6. issueClaim                (debit + watermark + WRITE-AHEAD persist)
+   *   7. leg-B send, SAME condition
+   *   8a. preimage verified → accept { fulfillment }
+   *   8b. anything else → rollbackClaim (full unwind) + benign reject
+   */
+  async handleFill(request: RollingFillRequest): Promise<RollingFillResponse> {
+    const { payload } = request;
+    const condition = request.executionCondition;
+    if (
+      !(condition instanceof Uint8Array) ||
+      condition.length !== 32 ||
+      condition.every((b) => b === 0)
+    ) {
+      // The dispatcher guarantees a non-zero 32-byte condition; re-assert so
+      // direct callers cannot run the coupled path uncoupled (spec R2).
+      return buildRollingReject({
+        code: 'F99',
+        semantic: 'application_error',
+        message: 'rolling fill requires a sender-chosen execution condition',
+        reason: ROLLING_REJECT_REASONS.CONDITION_REQUIRED,
+      });
+    }
+
+    // 1. Session.
+    const session = this.#sessions.get(payload.streamNonce);
+    if (!session) {
+      return buildRollingReject({
+        code: 'F06',
+        semantic: 'unexpected_payment',
+        message: 'unknown rolling-swap session',
+        reason: ROLLING_REJECT_REASONS.UNKNOWN_SESSION,
+        detail: { streamNonce: payload.streamNonce },
+      });
+    }
+    const pair = session.pair;
+
+    // Amount sanity before anything else.
+    let sourceAmount: bigint;
+    try {
+      sourceAmount = BigInt(request.amount);
+    } catch {
+      sourceAmount = -1n;
+    }
+    if (sourceAmount <= 0n) {
+      return buildRollingReject({
+        code: 'F03',
+        semantic: 'invalid_amount',
+        message: 'invalid fill amount',
+        reason: ROLLING_REJECT_REASONS.INVALID_AMOUNT,
+      });
+    }
+
+    // 2. Staleness gate (swap#48 contract, byte-identical reject) — BEFORE
+    //    the replay reservation so a stale_rate reject leaves no state.
+    if (this.#guard) {
+      const verdict = await this.#guard.check(pair);
+      if (verdict.stale) {
+        this.#logger.info?.('swap.rolling.stale_rate_reject', verdict.data);
+        const reject = buildStaleRateReject(verdict.data);
+        return reject as Extract<RollingFillResponse, { accept: false }>;
+      }
+    }
+
+    // 3. Replay reservation. Added BEFORE pricing/claim issuance and never
+    //    released — a (streamNonce, seq) is burned once seen (fail-closed,
+    //    state-store crash rule 4; the sender never reuses a seq, spec §4).
+    const replayKey = `rolling:${payload.streamNonce}:${payload.seq}`;
+    if (this.#seen.has(replayKey)) {
+      return buildRollingReject({
+        code: 'F04',
+        semantic: 'insufficient_destination_amount',
+        message: 'duplicate fill packet',
+        reason: ROLLING_REJECT_REASONS.DUPLICATE_PACKET,
+        detail: { streamNonce: payload.streamNonce, seq: payload.seq },
+      });
+    }
+    this.#seen.add(replayKey);
+
+    // 4. Leg-A expiry budget (spec R7): leg B MUST resolve before leg A
+    //    expires. Reject fills whose remaining budget cannot cover it —
+    //    BEFORE any debit.
+    const now = this.#now();
+    let legAExpiryMs: number | undefined;
+    if (request.expiresAt !== undefined) {
+      const parsed = Date.parse(request.expiresAt);
+      if (Number.isFinite(parsed)) legAExpiryMs = parsed;
+    }
+    if (
+      legAExpiryMs !== undefined &&
+      legAExpiryMs - this.#legBExpiryMarginMs - now < this.#minLegBTimeMs
+    ) {
+      return buildRollingReject({
+        code: 'R00',
+        semantic: 'expired',
+        message: 'insufficient leg-A time budget for the leg-B round trip',
+        reason: ROLLING_REJECT_REASONS.INSUFFICIENT_TIMEOUT,
+        detail: { expiresAt: request.expiresAt ?? null },
+      });
+    }
+    const legBExpiryMs = Math.min(
+      now + this.#legBBudgetMs,
+      legAExpiryMs !== undefined
+        ? legAExpiryMs - this.#legBExpiryMarginMs
+        : Number.POSITIVE_INFINITY
+    );
+
+    // 5. Fresh rate (spec §2.3 "finally wired") + pricing.
+    let rate: string;
+    let rateTimestamp: number;
+    try {
+      const quote = this.#rateProvider
+        ? await this.#rateProvider(pair)
+        : pair.rate;
+      if (typeof quote === 'string') {
+        rate = quote;
+        rateTimestamp = now;
+      } else {
+        rate = quote.rate;
+        rateTimestamp = quote.at;
+      }
+      // Race backstop (same invariant as RateFreshnessGuard.toSdkRateProvider):
+      // the gate check and this provider call are separate; a feed that went
+      // stale in between must still not price a fill.
+      if (this.#guard) {
+        const bound = this.#guard.resolveMaxRateAgeMs(pair);
+        if (bound !== undefined && this.#now() - rateTimestamp > bound) {
+          throw new StaleRateError({
+            reason: 'stale_rate',
+            maxRateAgeMs: bound,
+            lastRateAt: rateTimestamp,
+            pair: pairKey(pair),
+          });
+        }
+      }
+    } catch (err) {
+      if (err instanceof StaleRateError) {
+        const reject = buildStaleRateReject(err.data);
+        return reject as Extract<RollingFillResponse, { accept: false }>;
+      }
+      this.#logger.warn?.('swap.rolling.rate_provider_failed', {
+        pair: pairKey(pair),
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return buildRollingReject({
+        code: 'T00',
+        semantic: 'internal_error',
+        message: 'rate provider error',
+        reason: ROLLING_REJECT_REASONS.RATE_UNAVAILABLE,
+      });
+    }
+
+    let targetAmount: bigint;
+    try {
+      targetAmount = applyRate({
+        sourceAmount,
+        fromScale: pair.from.assetScale,
+        toScale: pair.to.assetScale,
+        rate,
+      });
+    } catch (err) {
+      return buildRollingReject({
+        code: 'T00',
+        semantic: 'internal_error',
+        message: 'rate conversion error',
+        reason: ROLLING_REJECT_REASONS.RATE_UNAVAILABLE,
+        detail: { err: err instanceof Error ? err.message : String(err) },
+      });
+    }
+    if (targetAmount <= 0n) {
+      return buildRollingReject({
+        code: 'F03',
+        semantic: 'invalid_amount',
+        message: 'fill too small: target amount truncates to zero',
+        reason: ROLLING_REJECT_REASONS.FILL_TOO_SMALL,
+        detail: { rate },
+      });
+    }
+
+    // 6. Issue the chain-B claim: debit + watermark advance + WRITE-AHEAD
+    //    persist (crash rule 1) — all BEFORE the claim leaves the process.
+    let issued: IssueClaimResult;
+    try {
+      issued = await this.#claimIssuer.issueClaim({
+        sourceAmount,
+        targetAmount,
+        pair,
+        senderPubkey: session.senderPubkey,
+        chainRecipient: session.chainRecipient,
+        rumor: this.#syntheticRumor(session, payload),
+      });
+    } catch (err) {
+      const code =
+        (err as { code?: string }).code === 'INSUFFICIENT_INVENTORY' ||
+        /insufficient/i.test(err instanceof Error ? err.message : '')
+          ? 'T04'
+          : 'T00';
+      return buildRollingReject({
+        code,
+        semantic: code === 'T04' ? 'insufficient_funds' : 'internal_error',
+        message:
+          code === 'T04' ? 'insufficient liquidity' : 'claim issuance failed',
+        reason:
+          code === 'T04'
+            ? ROLLING_REJECT_REASONS.INSUFFICIENT_LIQUIDITY
+            : ROLLING_REJECT_REASONS.CLAIM_ISSUE_FAILED,
+      });
+    }
+
+    // 7. Leg B: the chain-B cumulative advance under the SAME condition
+    //    (spec R4). The sender verifies BEFORE revealing (R5).
+    const advance: RollingAdvancePayload = {
+      proto: ROLLING_PROTOCOL,
+      type: 'advance',
+      streamNonce: payload.streamNonce,
+      seq: payload.seq,
+      claim: Buffer.from(issued.claim).toString('base64'),
+      ...(issued.claimId !== undefined && { claimId: issued.claimId }),
+      ...(issued.channelId !== undefined && { channelId: issued.channelId }),
+      ...(issued.nonce !== undefined && { nonce: issued.nonce.toString() }),
+      ...(issued.cumulativeAmount !== undefined && {
+        cumulativeAmount: issued.cumulativeAmount.toString(),
+      }),
+      ...(issued.recipient !== undefined && { recipient: issued.recipient }),
+      ...(issued.swapSignerAddress !== undefined && {
+        swapSignerAddress: issued.swapSignerAddress,
+      }),
+      rate,
+      rateTimestamp,
+      sourceAmount: sourceAmount.toString(),
+      targetAmount: targetAmount.toString(),
+    };
+
+    let legB: LegBResult;
+    try {
+      legB = await this.#withDeadline(
+        this.#legBSender({
+          destination: session.senderIlpAddress,
+          amount: targetAmount,
+          expiresAt: new Date(legBExpiryMs),
+          executionCondition: condition,
+          data: Buffer.from(JSON.stringify(advance), 'utf8'),
+        }),
+        legBExpiryMs
+      );
+    } catch (err) {
+      legB = {
+        type: 'reject',
+        code: 'T00',
+        message: `leg-B send failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    // 8a. Preimage learned and verified → the ONLY way leg A fulfills (R6).
+    if (legB.type === 'fulfill') {
+      const preimage = legB.fulfillment;
+      if (
+        preimage instanceof Uint8Array &&
+        preimage.length === 32 &&
+        timingSafeEqualish(sha256(preimage), condition)
+      ) {
+        const record: RollingAcceptRecord = {
+          proto: ROLLING_PROTOCOL,
+          type: 'accept',
+          streamNonce: payload.streamNonce,
+          seq: payload.seq,
+          rate,
+          rateTimestamp,
+          targetAmount: targetAmount.toString(),
+          ...(issued.channelId !== undefined && {
+            channelId: issued.channelId,
+          }),
+          ...(issued.nonce !== undefined && { nonce: issued.nonce.toString() }),
+          ...(issued.cumulativeAmount !== undefined && {
+            cumulativeAmount: issued.cumulativeAmount.toString(),
+          }),
+        };
+        this.#logger.info?.('swap.rolling.fill_fulfilled', {
+          streamNonce: payload.streamNonce,
+          seq: payload.seq,
+          sourceAmount: sourceAmount.toString(),
+          targetAmount: targetAmount.toString(),
+          rate,
+        });
+        return {
+          accept: true,
+          data: Buffer.from(JSON.stringify(record), 'utf8').toString('base64'),
+          fulfillment: Buffer.from(preimage).toString('base64'),
+        };
+      }
+      // A leg-B FULFILL without the correct preimage cannot satisfy leg A
+      // (the connector would F99 it anyway — contract rule 3). Unwind.
+      this.#unwind(session, targetAmount, payload, 'leg_b_fulfillment_invalid');
+      return buildRollingReject({
+        code: 'F99',
+        semantic: 'application_error',
+        message:
+          'leg-B FULFILL did not reveal the execution-condition preimage',
+        reason: ROLLING_REJECT_REASONS.LEG_B_FULFILLMENT_INVALID,
+      });
+    }
+
+    // 8b. Leg B rejected/timed out → full unwind + benign leg-A reject
+    //     (AC-2/AC-4: nothing stays debited on a failed packet).
+    this.#unwind(session, targetAmount, payload, legB.code);
+    const legBFClass = legB.code.startsWith('F');
+    return buildRollingReject({
+      code: legBFClass ? 'F99' : 'T00',
+      semantic: legBFClass ? 'application_error' : 'timeout',
+      message: 'leg B failed; fill not executed',
+      reason: ROLLING_REJECT_REASONS.LEG_B_FAILED,
+      detail: { legB: { code: legB.code, message: legB.message } },
+    });
+  }
+
+  #unwind(
+    session: RollingSession,
+    targetAmount: bigint,
+    payload: RollingFillPayload,
+    cause: string
+  ): void {
+    this.#logger.warn?.('swap.rolling.fill_unwound', {
+      streamNonce: payload.streamNonce,
+      seq: payload.seq,
+      targetAmount: targetAmount.toString(),
+      cause,
+    });
+    this.#claimIssuer.rollbackClaim({
+      pair: session.pair,
+      senderPubkey: session.senderPubkey,
+      targetAmount,
+    });
+  }
+
+  #syntheticRumor(
+    session: RollingSession,
+    payload: RollingFillPayload
+  ): UnsignedEvent {
+    return {
+      kind: ROLLING_FILL_CONTEXT_KIND,
+      pubkey: session.senderPubkey,
+      created_at: Math.floor(this.#now() / 1000),
+      content: '',
+      tags: [
+        [
+          'swap-from',
+          `${session.pair.from.assetCode}:${session.pair.from.chain}`,
+        ],
+        ['swap-to', `${session.pair.to.assetCode}:${session.pair.to.chain}`],
+        ['chain-recipient', session.chainRecipient],
+        ['stream-nonce', payload.streamNonce],
+        ['seq', String(payload.seq)],
+      ],
+    };
+  }
+
+  async #withDeadline(
+    promise: Promise<LegBResult>,
+    deadlineMs: number
+  ): Promise<LegBResult> {
+    const remaining = deadlineMs - this.#now();
+    if (!Number.isFinite(remaining)) return promise;
+    if (remaining <= 0) {
+      return { type: 'reject', code: 'R00', message: 'leg B timed out' };
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<LegBResult>((resolve) => {
+          timer = setTimeout(
+            () =>
+              resolve({
+                type: 'reject',
+                code: 'R00',
+                message: 'leg B timed out',
+              }),
+            remaining
+          );
+          // Do not hold the event loop open for the deadline alone.
+          (timer as { unref?: () => void }).unref?.();
+        }),
+      ]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+}
+
+/**
+ * Constant-ish 32-byte comparison. Not security-critical here (both inputs
+ * are already public on the wire), but cheap to do right.
+ */
+function timingSafeEqualish(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= (a[i] ?? 0) ^ (b[i] ?? 0);
+  }
+  return diff === 0;
+}

--- a/packages/swap/src/swap-node.rolling-dispatch.test.ts
+++ b/packages/swap/src/swap-node.rolling-dispatch.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Issue #47 — `startSwapNode()` rolling dispatch-matrix tests.
+ *
+ * Exercises the connector-facing packet handler (the `setPacketHandler`
+ * callback) across the condition-class × payload-class matrix:
+ *
+ *   - zero condition + TOON/gift-wrap  → LEGACY path, byte-for-byte
+ *   - zero condition + rolling fill    → F99 condition_required
+ *   - sender-chosen condition + fill   → rolling engine (coupled legs)
+ *   - sender-chosen condition + legacy → F99 BEFORE any legacy dispatch
+ *     (the legacy handler cannot mint the preimage; dispatching would debit
+ *     inventory only for the connector to F99 the FULFILL — contract rule 3)
+ */
+import { describe, it, expect } from 'vitest';
+import { sha256 } from '@noble/hashes/sha2.js';
+
+import { startSwapNode } from './swap-node.js';
+import type { SwapNodeConfig, SwapNodeInstance } from './swap-node.js';
+import { ROLLING_PROTOCOL, ROLLING_REJECT_REASONS } from './rolling-engine.js';
+import type { LegBPrepare, LegBResult } from './rolling-engine.js';
+
+const VALID_MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+const CHAIN = 'evm:8453';
+const STREAM_NONCE = '1f'.repeat(16);
+const CHAIN_RECIPIENT = '0x' + '11'.repeat(20);
+
+type PacketHandlerFn = (request: {
+  amount: string;
+  destination: string;
+  data: string;
+  executionCondition?: string;
+  expiresAt?: string;
+}) => Promise<{
+  accept: boolean;
+  code?: string;
+  message?: string;
+  data?: string;
+  fulfillment?: string;
+  rejectReason?: { code: string; message: string };
+}>;
+
+function capturingConnector(): {
+  connector: SwapNodeConfig['connector'];
+  handler: () => PacketHandlerFn;
+} {
+  let captured: PacketHandlerFn | undefined;
+  const connector = {
+    sendPacket: async () => ({
+      type: 'reject' as const,
+      code: 'F02',
+      message: 'no route (fixture)',
+    }),
+    registerPeer: async () => undefined,
+    removePeer: async () => undefined,
+    setPacketHandler: (h: unknown) => {
+      captured = h as PacketHandlerFn;
+    },
+    close: async () => undefined,
+  };
+  return {
+    connector: connector as unknown as SwapNodeConfig['connector'],
+    handler: () => {
+      if (!captured) throw new Error('setPacketHandler was never called');
+      return captured;
+    },
+  };
+}
+
+async function bootNode(overrides?: Partial<SwapNodeConfig>): Promise<{
+  instance: SwapNodeInstance;
+  handler: () => PacketHandlerFn;
+}> {
+  const { connector, handler } = capturingConnector();
+  const instance = await startSwapNode({
+    mnemonic: VALID_MNEMONIC,
+    connector,
+    swapPairs: [
+      {
+        from: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+        to: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+        rate: '1.0',
+      },
+    ],
+    chains: ['evm'],
+    channels: {
+      [CHAIN]: [
+        {
+          channelId: '0x' + 'cd'.repeat(32),
+          cumulativeAmount: 0n,
+          nonce: 0n,
+          updatedAt: 0,
+        },
+      ],
+    },
+    inventory: { [CHAIN]: 1_000_000_000n },
+    relayUrls: ['ws://localhost:0'],
+    blsPort: 0,
+    publisher: { publish: async () => undefined },
+    ...overrides,
+  });
+  return { instance, handler };
+}
+
+function fillDataB64(seq = 1, streamNonce = STREAM_NONCE): string {
+  return Buffer.from(
+    JSON.stringify({ proto: ROLLING_PROTOCOL, type: 'fill', streamNonce, seq }),
+    'utf8'
+  ).toString('base64');
+}
+
+function mint(): { preimage: Uint8Array; conditionB64: string } {
+  const preimage = new Uint8Array(32);
+  globalThis.crypto.getRandomValues(preimage);
+  return {
+    preimage,
+    conditionB64: Buffer.from(sha256(preimage)).toString('base64'),
+  };
+}
+
+function decodeReason(dataB64?: string): unknown {
+  return dataB64
+    ? (
+        JSON.parse(Buffer.from(dataB64, 'base64').toString('utf8')) as Record<
+          string,
+          unknown
+        >
+      )['reason']
+    : undefined;
+}
+
+describe('issue #47 — rolling dispatch matrix', () => {
+  it('zero condition + non-TOON payload → legacy F06 "Invalid TOON payload" (unchanged)', async () => {
+    const { instance, handler } = await bootNode();
+    try {
+      const res = await handler()({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: Buffer.from('junk', 'utf8').toString('base64'),
+      });
+      expect(res.accept).toBe(false);
+      expect(res.code).toBe('F06');
+      expect(res.message).toBe('Invalid TOON payload');
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('zero condition + rolling fill → F99 condition_required (no uncoupled fills)', async () => {
+    const { instance, handler } = await bootNode();
+    try {
+      const res = await handler()({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: fillDataB64(),
+      });
+      expect(res.accept).toBe(false);
+      expect(res.code).toBe('F99');
+      expect(decodeReason(res.data)).toBe(
+        ROLLING_REJECT_REASONS.CONDITION_REQUIRED
+      );
+      expect(res.rejectReason?.code).toBe('application_error');
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('all-zero (legacy-class) condition bytes are treated as absent', async () => {
+    const { instance, handler } = await bootNode();
+    try {
+      const res = await handler()({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: fillDataB64(),
+        executionCondition: Buffer.alloc(32).toString('base64'),
+      });
+      expect(res.accept).toBe(false);
+      expect(decodeReason(res.data)).toBe(
+        ROLLING_REJECT_REASONS.CONDITION_REQUIRED
+      );
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('sender-chosen condition + legacy payload → F99 BEFORE legacy dispatch; nothing debited', async () => {
+    const { instance, handler } = await bootNode();
+    try {
+      const before = instance.health().inventoryAvailable[`USDC:${CHAIN}`];
+      const res = await handler()({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: Buffer.from('any-legacy-payload', 'utf8').toString('base64'),
+        executionCondition: mint().conditionB64,
+      });
+      expect(res.accept).toBe(false);
+      expect(res.code).toBe('F99');
+      expect(decodeReason(res.data)).toBe(
+        ROLLING_REJECT_REASONS.CONDITION_UNSUPPORTED_LEGACY
+      );
+      expect(instance.health().inventoryAvailable[`USDC:${CHAIN}`]).toBe(
+        before
+      );
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('malformed rolling/1 payload → F01 malformed_fill (not the legacy F06)', async () => {
+    const { instance, handler } = await bootNode();
+    try {
+      const res = await handler()({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: Buffer.from(
+          JSON.stringify({ proto: ROLLING_PROTOCOL, type: 'fill', seq: 1 }),
+          'utf8'
+        ).toString('base64'),
+        executionCondition: mint().conditionB64,
+      });
+      expect(res.accept).toBe(false);
+      expect(res.code).toBe('F01');
+      expect(decodeReason(res.data)).toBe(
+        ROLLING_REJECT_REASONS.MALFORMED_FILL
+      );
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('sender-chosen condition + fill for an unregistered session → benign F06 unknown_session', async () => {
+    const { instance, handler } = await bootNode();
+    try {
+      const res = await handler()({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: fillDataB64(),
+        executionCondition: mint().conditionB64,
+      });
+      expect(res.accept).toBe(false);
+      expect(res.code).toBe('F06');
+      expect(decodeReason(res.data)).toBe(
+        ROLLING_REJECT_REASONS.UNKNOWN_SESSION
+      );
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('registered session + injected leg-B sender: full coupled fill through the connector-facing handler', async () => {
+    const legBCalls: LegBPrepare[] = [];
+    let revealed: Uint8Array | undefined;
+    const { instance, handler } = await bootNode({
+      rollingLegBSender: async (prepare): Promise<LegBResult> => {
+        legBCalls.push(prepare);
+        // Compliant sender daemon: reveal the preimage for this condition.
+        return { type: 'fulfill', fulfillment: revealed };
+      },
+    });
+    try {
+      instance.registerRollingSession({
+        streamNonce: STREAM_NONCE,
+        pair: {
+          from: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+          to: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+          rate: '1.0',
+        },
+        chainRecipient: CHAIN_RECIPIENT,
+        senderIlpAddress: 'g.toon.client.sender01',
+        senderPubkey: 'e'.repeat(64),
+      });
+
+      const { preimage, conditionB64 } = mint();
+      revealed = preimage;
+      const res = await handler()({
+        amount: '250000',
+        destination: 'g.toon.swap.x',
+        data: fillDataB64(1),
+        executionCondition: conditionB64,
+        expiresAt: new Date(Date.now() + 30_000).toISOString(),
+      });
+
+      // Accept carries the base64 preimage — the exact bytes the connector's
+      // sha256 check verifies before FULFILLing leg A upstream.
+      expect(res.accept).toBe(true);
+      expect(res.fulfillment).toBe(Buffer.from(preimage).toString('base64'));
+
+      // Leg B went out with the SAME condition and the session destination.
+      expect(legBCalls).toHaveLength(1);
+      expect(
+        Buffer.from(legBCalls[0]!.executionCondition).toString('base64')
+      ).toBe(conditionB64);
+      expect(legBCalls[0]!.destination).toBe('g.toon.client.sender01');
+      expect(legBCalls[0]!.amount).toBe(250_000n); // 1:1 pair, same scale
+
+      // Inventory debited by the fill.
+      expect(instance.health().inventoryAvailable[`USDC:${CHAIN}`]).toBe(
+        (1_000_000_000n - 250_000n).toString()
+      );
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('legacy gift-wrap traffic still dispatches to the registry when no condition is present', async () => {
+    // A structurally-valid TOON payload is exercised end-to-end by the
+    // existing integration suite; here we pin the dispatch-order property:
+    // zero-condition traffic reaches the legacy TOON parser (F06 for junk),
+    // NOT any rolling-engine reject.
+    const { instance, handler } = await bootNode();
+    try {
+      const res = await handler()({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: Buffer.from(JSON.stringify({ hello: 'world' }), 'utf8').toString(
+          'base64'
+        ),
+      });
+      expect(res.accept).toBe(false);
+      expect(res.code).toBe('F06');
+      expect(res.message).toBe('Invalid TOON payload');
+      expect(res.data).toBeUndefined();
+    } finally {
+      await instance.stop();
+    }
+  });
+});

--- a/packages/swap/src/swap-node.ts
+++ b/packages/swap/src/swap-node.ts
@@ -83,6 +83,15 @@ import {
   withMaxRateAge,
 } from './rate-staleness.js';
 import type { MaxRateAgeConfig, SwapRateProvider } from './rate-staleness.js';
+import {
+  RollingSessionStore,
+  RollingSwapEngine,
+  ROLLING_REJECT_REASONS,
+  buildRollingReject,
+  createConnectorLegBSender,
+  parseRollingFillPayload,
+} from './rolling-engine.js';
+import type { LegBSender, RollingSession } from './rolling-engine.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -296,6 +305,33 @@ export interface SwapNodeConfig {
    */
   stateStore?: SwapStateStore;
 
+  // --- Rolling coupled-leg engine (issue #47, rolling-swap §3) ---
+  /**
+   * Knobs for the rolling swap engine. The engine itself is ALWAYS wired
+   * (a fill for an unregistered session is a benign F06); these only tune
+   * its bounds. See `rolling-engine.ts` for semantics and defaults.
+   */
+  rolling?: {
+    /** Default session lifetime (ms) when a session has no explicit expiry. */
+    sessionTtlMs?: number;
+    /** Bound on concurrently registered sessions. */
+    maxSessions?: number;
+    /** Max leg-B round-trip budget (ms) when leg A's expiry allows it. */
+    legBBudgetMs?: number;
+    /** Leg-B expiry margin (ms) under leg-A expiry (spec R7). */
+    legBExpiryMarginMs?: number;
+    /** Reject fills whose remaining leg-A budget (ms) is below this. */
+    minLegBTimeMs?: number;
+  };
+  /**
+   * Leg-B egress override (tests / custom connectors). When omitted, the
+   * swap node wires {@link createConnectorLegBSender} over the effective
+   * connector — which requires the connector's conditioned-PREPARE
+   * origination seam; absent that, rolling fills are rejected fail-closed
+   * (never sent unconditioned — rolling-swap §3 R4).
+   */
+  rollingLegBSender?: LegBSender;
+
   // --- Shared infra ---
   relayUrls: readonly string[];
   knownPeers?: readonly { ilpAddress: string; btpUrl?: string }[];
@@ -443,8 +479,18 @@ export interface SwapNodeInstance {
   readonly connector?: EmbeddableConnectorLike;
   stop(): Promise<void>;
   health(): SwapNodeHealthResponse;
+  /**
+   * Register a rolling-swap session (issue #47) — the RFQ intake seam.
+   * Fill packets referencing an unregistered `streamNonce` are rejected
+   * benignly (F06 `unknown_session`). The RFQ transport story calls this
+   * when a kind:20033 quote request is answered; tests and operators may
+   * call it directly.
+   */
+  registerRollingSession(session: RollingSession): void;
   /** @internal — AC-10 test hook. */
   readonly _handlerRegistry?: HandlerRegistry;
+  /** @internal — issue #47 test hook (rolling-engine introspection). */
+  readonly _rollingEngine?: RollingSwapEngine;
 }
 
 export interface SwapNodeHealthResponse {
@@ -667,6 +713,35 @@ export function validateConfig(config: SwapNodeConfig): void {
         "SwapNodeConfig.maxRateAge requires a rateProvider: the staleness bound applies to the age of the maker's own rate-feed ticks, so a static pair.rate gives the guard nothing to measure. Supply a rateProvider that returns { rate, at } timestamped quotes."
       );
     }
+  }
+
+  if (config.rolling !== undefined) {
+    const knobs: readonly (keyof NonNullable<SwapNodeConfig['rolling']>)[] = [
+      'sessionTtlMs',
+      'maxSessions',
+      'legBBudgetMs',
+      'legBExpiryMarginMs',
+      'minLegBTimeMs',
+    ];
+    for (const k of knobs) {
+      const v = config.rolling[k];
+      if (v === undefined) continue;
+      if (typeof v !== 'number' || !Number.isFinite(v) || v <= 0) {
+        throw new SwapNodeStartError(
+          'INVALID_CONFIG',
+          `SwapNodeConfig.rolling.${k} MUST be a positive finite number`
+        );
+      }
+    }
+  }
+  if (
+    config.rollingLegBSender !== undefined &&
+    typeof config.rollingLegBSender !== 'function'
+  ) {
+    throw new SwapNodeStartError(
+      'INVALID_CONFIG',
+      'SwapNodeConfig.rollingLegBSender MUST be a function when set'
+    );
   }
 
   if (config.chainProviders !== undefined) {
@@ -1274,6 +1349,57 @@ export async function startSwapNode(
     }
   }
 
+  // 11a-pre. Rolling coupled-leg engine (issue #47, rolling-swap §3).
+  //
+  // Constructed unconditionally: without registered sessions every rolling
+  // fill is a benign F06, so an idle engine costs nothing. Shares the
+  // staleness guard (same feed-tick state as the legacy gate) and — when
+  // persistence is enabled — the persistent replay set, so rolling replay
+  // reservations hit disk synchronously (state-store crash rule 4) under
+  // `rolling:${streamNonce}:${seq}` keys, disjoint from gift-wrap ids.
+  const resolvedNodeId =
+    config.nodeId ?? `toon-swap-${identity.pubkey.slice(0, 16)}`;
+  const rollingLegBSender: LegBSender =
+    config.rollingLegBSender ??
+    (effectiveConnector
+      ? createConnectorLegBSender(effectiveConnector, {
+          nodeId: resolvedNodeId,
+          logger: { warn: logger.warn, info: logger.info },
+        })
+      : async () => ({
+          type: 'reject',
+          code: 'T00',
+          message: 'no connector available for leg-B egress',
+        }));
+  const rollingSessions = new RollingSessionStore({
+    ...(config.rolling?.sessionTtlMs !== undefined && {
+      ttlMs: config.rolling.sessionTtlMs,
+    }),
+    ...(config.rolling?.maxSessions !== undefined && {
+      maxSessions: config.rolling.maxSessions,
+    }),
+  });
+  const rollingSeen =
+    config.seenPacketIds ?? persistentSeen ?? new PersistentSeenPacketIds();
+  const rollingEngine = new RollingSwapEngine({
+    sessions: rollingSessions,
+    claimIssuer,
+    legBSender: rollingLegBSender,
+    seenPacketIds: rollingSeen,
+    ...(config.rateProvider && { rateProvider: config.rateProvider }),
+    ...(stalenessGuard && { stalenessGuard }),
+    logger: { info: logger.info, warn: logger.warn, error: logger.error },
+    ...(config.rolling?.legBBudgetMs !== undefined && {
+      legBBudgetMs: config.rolling.legBBudgetMs,
+    }),
+    ...(config.rolling?.legBExpiryMarginMs !== undefined && {
+      legBExpiryMarginMs: config.rolling.legBExpiryMarginMs,
+    }),
+    ...(config.rolling?.minLegBTimeMs !== undefined && {
+      minLegBTimeMs: config.rolling.minLegBTimeMs,
+    }),
+  });
+
   // 11a. Wire the HandlerRegistry to the connector's local-delivery path.
   //
   // Story 50.3 (SOL settlement leg, AC#4): inbound kind:1059 (NIP-59 gift-wrap)
@@ -1302,9 +1428,90 @@ export async function startSwapNode(
   const toonDecoder = (toon: string): NostrEvent =>
     decodeEventFromToon(Buffer.from(toon, 'base64'));
 
+  // Issue #47 dispatch matrix (condition class × payload class):
+  //
+  //   | executionCondition   | payload        | path                          |
+  //   |----------------------|----------------|-------------------------------|
+  //   | absent / all-zero    | TOON/gift-wrap | LEGACY, byte-for-byte         |
+  //   | absent / all-zero    | rolling fill   | reject F99 condition_required |
+  //   | non-zero (32B)       | rolling fill   | rolling engine (coupled legs) |
+  //   | non-zero (32B)       | anything else  | reject F99 (see below)        |
+  //
+  // The last row is load-bearing: the legacy handler cannot mint a
+  // sender-chosen preimage, so dispatching it would debit inventory and
+  // issue a claim only for the connector to convert the FULFILL into F99
+  // (contract rule 3) with nothing recorded upstream — a maker-side loss on
+  // every such packet. Rejecting BEFORE dispatch keeps the failure benign
+  // and stateless.
+  const decodeSenderCondition = (b64?: string): Uint8Array | null => {
+    if (typeof b64 !== 'string' || b64.length === 0) return null;
+    let buf: Buffer;
+    try {
+      buf = Buffer.from(b64, 'base64');
+    } catch {
+      return null;
+    }
+    if (buf.length !== 32) return null;
+    if (buf.every((b) => b === 0)) return null; // legacy class (contract §classes)
+    return new Uint8Array(buf);
+  };
+
   const handlePacket = async (
     request: HandlePacketRequest
   ): Promise<HandlePacketResponse> => {
+    const requestExt = request as HandlePacketRequest & {
+      executionCondition?: string;
+      expiresAt?: string;
+    };
+    const senderCondition = decodeSenderCondition(
+      requestExt.executionCondition
+    );
+    const rollingFill = parseRollingFillPayload(request.data);
+
+    if (rollingFill === 'malformed') {
+      // Self-identified rolling/1 traffic that violates the fill shape:
+      // reject F01 rather than letting it fall through to the legacy TOON
+      // parser's misleading F06.
+      return buildRollingReject({
+        code: 'F01',
+        semantic: 'invalid_request',
+        message: 'malformed rolling fill payload',
+        reason: ROLLING_REJECT_REASONS.MALFORMED_FILL,
+      }) as HandlePacketResponse;
+    }
+    if (senderCondition) {
+      if (rollingFill === null) {
+        return buildRollingReject({
+          code: 'F99',
+          semantic: 'application_error',
+          message:
+            'sender-chosen execution conditions are not supported on the legacy swap path',
+          reason: ROLLING_REJECT_REASONS.CONDITION_UNSUPPORTED_LEGACY,
+        }) as HandlePacketResponse;
+      }
+      return (await rollingEngine.handleFill({
+        amount: request.amount,
+        destination: request.destination,
+        executionCondition: senderCondition,
+        payload: rollingFill,
+        ...(requestExt.expiresAt !== undefined && {
+          expiresAt: requestExt.expiresAt,
+        }),
+      })) as HandlePacketResponse;
+    }
+    if (rollingFill !== null) {
+      // A rolling fill without a sender-chosen condition has NO coupling
+      // (spec R2: a zero condition is skipped by every verifier) — refuse
+      // rather than fill uncoupled.
+      return buildRollingReject({
+        code: 'F99',
+        semantic: 'application_error',
+        message: 'rolling fill requires a sender-chosen execution condition',
+        reason: ROLLING_REJECT_REASONS.CONDITION_REQUIRED,
+      }) as HandlePacketResponse;
+    }
+
+    // Legacy path (zero-condition gift-wrap) — unchanged below.
     let meta;
     try {
       meta = shallowParseToon(Buffer.from(request.data, 'base64'));
@@ -1667,6 +1874,10 @@ export async function startSwapNode(
     swapNodeKeys,
     ...(effectiveConnector !== undefined && { connector: effectiveConnector }),
     _handlerRegistry: registry,
+    _rollingEngine: rollingEngine,
+    registerRollingSession: (session: RollingSession) => {
+      rollingEngine.registerSession(session);
+    },
     health: getHealth,
     async stop() {
       if (stopped) return;

--- a/packages/swap/tests/integration/rolling-swap.integration.test.ts
+++ b/packages/swap/tests/integration/rolling-swap.integration.test.ts
@@ -1,0 +1,420 @@
+/**
+ * swap#47 — rolling coupled-leg engine integration tests.
+ *
+ * Full `startSwapNode()` topology driven through the CONNECTOR-FACING packet
+ * handler (the `setPacketHandler` callback), with the two surrounding
+ * parties modeled exactly per their published contracts:
+ *
+ *   - the maker connector's local-delivery enforcement is mocked
+ *     byte-for-byte per `connector/docs/local-delivery-fulfillment-contract.md`
+ *     rule 3: `sha256(fulfillment) === executionCondition` or F99 with
+ *     nothing recorded;
+ *   - the sender daemon (leg-B terminator, toon-client#352's role) implements
+ *     spec R5 verify-before-reveal: it checks the advance payload's
+ *     recipient, watermark monotonicity (over ACCEPTED packets only — R8:
+ *     claims from rejected packets are void), and its rate floor, and only
+ *     then reveals the preimage.
+ *
+ * Scenarios: multi-packet rolling swap (AC-1/AC-5 contract level), maker
+ * stall / sender withhold mid-stream (AC-1/AC-2), and legacy gift-wrap
+ * coexistence on the same node (zero-condition path unchanged).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { getPublicKey } from 'nostr-tools/pure';
+import type { UnsignedEvent } from 'nostr-tools/pure';
+import { encodeEventToToon } from '@toon-protocol/core';
+import { wrapSwapPacket } from '@toon-protocol/sdk';
+import { startSwapNode, ROLLING_PROTOCOL } from '@toon-protocol/swap';
+import type {
+  LegBPrepare,
+  LegBResult,
+  RollingAdvancePayload,
+  SwapNodeConfig,
+  SwapNodeInstance,
+} from '@toon-protocol/swap';
+
+const MNEMONIC = 'test test test test test test test test test test test junk';
+
+const CHAIN = 'evm:31337';
+const PAIR = {
+  from: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+  to: { assetCode: 'ETH', assetScale: 18, chain: CHAIN },
+  rate: '0.0004',
+} as const;
+const CHANNEL_ID = '0x' + '31'.repeat(32);
+const CHAIN_RECIPIENT = '0x' + '42'.repeat(20);
+const SENDER_ILP = 'g.toon.client.rollingsender';
+const STREAM_NONCE = '7e'.repeat(16);
+const INITIAL_INVENTORY = 10n ** 20n; // 100 ETH (wei)
+const INVENTORY_KEY = `ETH:${CHAIN}`;
+
+type PacketHandlerFn = (request: {
+  amount: string;
+  destination: string;
+  data: string;
+  executionCondition?: string;
+  expiresAt?: string;
+}) => Promise<{
+  accept: boolean;
+  code?: string;
+  message?: string;
+  data?: string;
+  metadata?: Record<string, unknown>;
+  fulfillment?: string;
+}>;
+
+// ---------------------------------------------------------------------------
+// The sender daemon — spec R5 verify-before-reveal (toon-client#352's role)
+// ---------------------------------------------------------------------------
+
+interface SenderDaemon {
+  legBSender: LegBSender;
+  /** Mint a packet: fresh 32-byte preimage, condition = sha256(P). */
+  mint(): { preimage: Uint8Array; conditionB64: string };
+  advances: RollingAdvancePayload[];
+  /** Toggle: when false the sender withholds every reveal (maker-stall sim). */
+  reveal: boolean;
+  /** Sender's session floor — R5(d). */
+  minExchangeRate: number;
+}
+
+type LegBSender = (prepare: LegBPrepare) => Promise<LegBResult>;
+
+function makeSenderDaemon(): SenderDaemon {
+  const preimages = new Map<string, Uint8Array>();
+  let lastAcceptedNonce = 0n;
+  let lastAcceptedCumulative = 0n;
+
+  const daemon: SenderDaemon = {
+    advances: [],
+    reveal: true,
+    minExchangeRate: 0.00035,
+    mint() {
+      const preimage = new Uint8Array(32);
+      globalThis.crypto.getRandomValues(preimage);
+      const conditionB64 = Buffer.from(sha256(preimage)).toString('base64');
+      preimages.set(conditionB64, preimage);
+      return { preimage, conditionB64 };
+    },
+    legBSender: async (prepare) => {
+      const advance = JSON.parse(
+        prepare.data.toString('utf8')
+      ) as RollingAdvancePayload;
+      daemon.advances.push(advance);
+
+      // R5 verification, BEFORE any reveal. (Chain-signature verification is
+      // R5(a) via the sdk settlement verifier — structural checks here; the
+      // real daemon story toon-client#352 wires the full verifier.)
+      if (
+        advance.proto !== ROLLING_PROTOCOL ||
+        advance.type !== 'advance' ||
+        advance.claim.length === 0
+      ) {
+        return { type: 'reject', code: 'F99', message: 'malformed advance' };
+      }
+      // (b) recipient equals the session chainRecipient (EVM: case-insensitive).
+      if (advance.recipient?.toLowerCase() !== CHAIN_RECIPIENT.toLowerCase()) {
+        return { type: 'reject', code: 'F99', message: 'recipient mismatch' };
+      }
+      // (c) nonce + cumulative strictly monotone over ACCEPTED packets. A
+      // claim from a packet the sender rejected is void (R8), so a re-used
+      // nonce after a maker-side unwind is legitimate.
+      const nonce = BigInt(advance.nonce ?? '0');
+      const cumulative = BigInt(advance.cumulativeAmount ?? '0');
+      if (nonce <= lastAcceptedNonce || cumulative <= lastAcceptedCumulative) {
+        return { type: 'reject', code: 'F99', message: 'non-monotone claim' };
+      }
+      // (d) effective rate ≥ the session floor (Δcumulative / δ).
+      const delta = cumulative - lastAcceptedCumulative;
+      const sourceAmount = BigInt(advance.sourceAmount);
+      const effectiveRate =
+        Number(delta) /
+        10 ** PAIR.to.assetScale /
+        (Number(sourceAmount) / 10 ** PAIR.from.assetScale);
+      if (effectiveRate < daemon.minExchangeRate) {
+        return {
+          type: 'reject',
+          code: 'F99',
+          message: 'below_floor',
+        };
+      }
+
+      if (!daemon.reveal) {
+        // Withhold: the commit act never happens (maker-stall scenario).
+        return { type: 'reject', code: 'T00', message: 'reveal withheld' };
+      }
+
+      const key = Buffer.from(prepare.executionCondition).toString('base64');
+      const preimage = preimages.get(key);
+      if (!preimage) {
+        return { type: 'reject', code: 'F99', message: 'unknown condition' };
+      }
+      // The reveal IS the commit: only now update the accepted watermarks.
+      lastAcceptedNonce = nonce;
+      lastAcceptedCumulative = cumulative;
+      return { type: 'fulfill', fulfillment: preimage };
+    },
+  };
+  return daemon;
+}
+
+// ---------------------------------------------------------------------------
+// Maker-connector enforcement, per the local-delivery fulfillment contract
+// ---------------------------------------------------------------------------
+
+function connectorEnforce(
+  response: Awaited<ReturnType<PacketHandlerFn>>,
+  conditionB64: string
+):
+  | { wire: 'FULFILL'; fulfillment: Uint8Array }
+  | { wire: 'REJECT'; code: string } {
+  if (!response.accept) {
+    return { wire: 'REJECT', code: response.code ?? 'F99' };
+  }
+  const condition = new Uint8Array(Buffer.from(conditionB64, 'base64'));
+  const f = response.fulfillment
+    ? new Uint8Array(Buffer.from(response.fulfillment, 'base64'))
+    : undefined;
+  if (
+    !f ||
+    f.length !== 32 ||
+    Buffer.compare(Buffer.from(sha256(f)), Buffer.from(condition)) !== 0
+  ) {
+    // Contract rule 3: F99, nothing recorded as delivered.
+    return { wire: 'REJECT', code: 'F99' };
+  }
+  return { wire: 'FULFILL', fulfillment: f };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+async function bootRollingNode(daemon: SenderDaemon): Promise<{
+  instance: SwapNodeInstance;
+  handler: PacketHandlerFn;
+}> {
+  let captured: PacketHandlerFn | undefined;
+  const connector = {
+    sendPacket: async () => ({
+      type: 'reject' as const,
+      code: 'F02',
+      message: 'no route (fixture)',
+    }),
+    registerPeer: async () => undefined,
+    removePeer: async () => undefined,
+    setPacketHandler: (h: unknown) => {
+      captured = h as PacketHandlerFn;
+    },
+    close: async () => undefined,
+  };
+
+  const instance = await startSwapNode({
+    mnemonic: MNEMONIC,
+    connector: connector as unknown as SwapNodeConfig['connector'],
+    swapPairs: [PAIR],
+    chains: ['evm'],
+    channels: {
+      [CHAIN]: [
+        {
+          channelId: CHANNEL_ID,
+          cumulativeAmount: 0n,
+          nonce: 0n,
+          updatedAt: 0,
+        },
+      ],
+    },
+    inventory: { [CHAIN]: INITIAL_INVENTORY },
+    relayUrls: ['ws://localhost:0'],
+    blsPort: 0,
+    publisher: { publish: async () => undefined },
+    rateProvider: () => ({ rate: '0.0004', at: Date.now() }),
+    rollingLegBSender: daemon.legBSender,
+  });
+  if (!captured) {
+    await instance.stop();
+    throw new Error('setPacketHandler was never called');
+  }
+
+  instance.registerRollingSession({
+    streamNonce: STREAM_NONCE,
+    pair: { ...PAIR },
+    chainRecipient: CHAIN_RECIPIENT,
+    senderIlpAddress: SENDER_ILP,
+    senderPubkey: getPublicKey(new Uint8Array(32).fill(21)),
+  });
+
+  return { instance, handler: captured };
+}
+
+function fillData(seq: number): string {
+  return Buffer.from(
+    JSON.stringify({
+      proto: ROLLING_PROTOCOL,
+      type: 'fill',
+      streamNonce: STREAM_NONCE,
+      seq,
+    }),
+    'utf8'
+  ).toString('base64');
+}
+
+async function driveFill(
+  handler: PacketHandlerFn,
+  daemon: SenderDaemon,
+  seq: number,
+  deltaMicroUsdc: bigint
+): Promise<ReturnType<typeof connectorEnforce>> {
+  const { conditionB64 } = daemon.mint();
+  const response = await handler({
+    amount: deltaMicroUsdc.toString(),
+    destination: 'g.toon.swap.rolling-fixture',
+    data: fillData(seq),
+    executionCondition: conditionB64,
+    expiresAt: new Date(Date.now() + 30_000).toISOString(),
+  });
+  return connectorEnforce(response, conditionB64);
+}
+
+const DELTA = 2_000_000n; // 2 USDC per packet
+const DELTA_WEI = 8n * 10n ** 14n; // ⌊2 USDC · 0.0004⌋ = 8e14 wei
+
+// ---------------------------------------------------------------------------
+
+describe('swap#47 — rolling coupled-leg engine (integration)', () => {
+  it('multi-packet rolling swap: every fill couples, prices fresh, and nets to one cumulative claim stream', async () => {
+    const daemon = makeSenderDaemon();
+    const { instance, handler } = await bootRollingNode(daemon);
+    try {
+      const packets = 5;
+      for (let seq = 1; seq <= packets; seq++) {
+        const outcome = await driveFill(handler, daemon, seq, DELTA);
+        expect(outcome.wire).toBe('FULFILL');
+      }
+
+      // The sender daemon saw one advance per packet, cumulative and
+      // strictly monotone — N advances netting to ONE final watermark.
+      expect(daemon.advances).toHaveLength(packets);
+      for (let i = 0; i < packets; i++) {
+        const advance = daemon.advances[i]!;
+        expect(advance.streamNonce).toBe(STREAM_NONCE);
+        expect(advance.seq).toBe(i + 1);
+        expect(advance.rate).toBe('0.0004');
+        expect(BigInt(advance.nonce!)).toBe(BigInt(i + 1));
+        expect(BigInt(advance.cumulativeAmount!)).toBe(
+          DELTA_WEI * BigInt(i + 1)
+        );
+        expect(advance.channelId).toBe(CHANNEL_ID);
+      }
+
+      // Maker inventory reflects exactly the delivered total.
+      expect(instance.health().inventoryAvailable[INVENTORY_KEY]).toBe(
+        (INITIAL_INVENTORY - DELTA_WEI * BigInt(packets)).toString()
+      );
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('maker stall / withheld reveal mid-stream: the failed packet collects NOTHING and the stream recovers', async () => {
+    const daemon = makeSenderDaemon();
+    const { instance, handler } = await bootRollingNode(daemon);
+    try {
+      // Packets 1-2 fill normally.
+      expect((await driveFill(handler, daemon, 1, DELTA)).wire).toBe('FULFILL');
+      expect((await driveFill(handler, daemon, 2, DELTA)).wire).toBe('FULFILL');
+      const availableAfter2 =
+        instance.health().inventoryAvailable[INVENTORY_KEY];
+
+      // Packet 3: the sender withholds the reveal (equivalently: the maker
+      // cannot learn the preimage). Leg A MUST fail upstream — no
+      // committed-A-without-B.
+      daemon.reveal = false;
+      const stalled = await driveFill(handler, daemon, 3, DELTA);
+      expect(stalled.wire).toBe('REJECT');
+
+      // Nothing stayed debited for the failed packet (full unwind).
+      expect(instance.health().inventoryAvailable[INVENTORY_KEY]).toBe(
+        availableAfter2
+      );
+
+      // Recovery: sender resumes with a NEW seq (spec: seq never reused).
+      // The maker re-issues from the unwound watermark — nonce 3 again —
+      // and the sender's R8-aware monotone check (over accepted packets)
+      // admits it.
+      daemon.reveal = true;
+      expect((await driveFill(handler, daemon, 4, DELTA)).wire).toBe('FULFILL');
+      const last = daemon.advances[daemon.advances.length - 1]!;
+      expect(BigInt(last.nonce!)).toBe(3n);
+      expect(BigInt(last.cumulativeAmount!)).toBe(DELTA_WEI * 3n);
+      expect(instance.health().inventoryAvailable[INVENTORY_KEY]).toBe(
+        (INITIAL_INVENTORY - DELTA_WEI * 3n).toString()
+      );
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('legacy zero-condition gift-wrap flow still fills claim-in-FULFILL on the SAME node', async () => {
+    const daemon = makeSenderDaemon();
+    const { instance, handler } = await bootRollingNode(daemon);
+    try {
+      const senderSecretKey = new Uint8Array(32).fill(23);
+      const rumor: UnsignedEvent = {
+        kind: 30_078,
+        pubkey: getPublicKey(senderSecretKey),
+        created_at: Math.floor(Date.now() / 1000),
+        content: '',
+        tags: [
+          ['swap-from', `${PAIR.from.assetCode}:${PAIR.from.chain}`],
+          ['swap-to', `${PAIR.to.assetCode}:${PAIR.to.chain}`],
+          ['chain-recipient', CHAIN_RECIPIENT],
+        ],
+      };
+      const { giftWrap } = wrapSwapPacket({
+        rumor,
+        senderSecretKey,
+        recipientPubkey: instance.identity.pubkey,
+      });
+      const toonB64 = Buffer.from(encodeEventToToon(giftWrap)).toString(
+        'base64'
+      );
+
+      const before = instance.health().inventoryAvailable[INVENTORY_KEY];
+      const res = await handler({
+        amount: '1000000', // 1 USDC
+        destination: 'g.toon.swap.rolling-fixture',
+        data: toonB64,
+        // NO executionCondition: legacy class, byte-for-byte pre-#309 path.
+      });
+
+      // Legacy shape: accept with the claim in the FULFILL data/metadata —
+      // and NO app-supplied fulfillment (the connector injects its NIP-59
+      // preimage on this class).
+      expect(res.accept).toBe(true);
+      expect(res.fulfillment).toBeUndefined();
+      const metadata = res.data
+        ? (JSON.parse(
+            Buffer.from(res.data, 'base64').toString('utf8')
+          ) as Record<string, unknown>)
+        : res.metadata!;
+      expect(metadata['claim']).toBeTypeOf('string');
+      expect((metadata['claim'] as string).length).toBeGreaterThan(0);
+      expect(metadata['recipient']).toBe(CHAIN_RECIPIENT);
+      // Quote tape (sdk 2.1.0, toon#82) still emitted on legacy accepts.
+      expect(metadata['rate']).toBe('0.0004');
+      expect(metadata['rateTimestamp']).toBeTypeOf('number');
+
+      // Legacy fill debits inventory as before (1 USDC · 0.0004 = 4e14 wei).
+      expect(instance.health().inventoryAvailable[INVENTORY_KEY]).toBe(
+        (BigInt(before!) - 4n * 10n ** 14n).toString()
+      );
+      // And no leg-B traffic was generated for it.
+      expect(daemon.advances).toHaveLength(0);
+    } finally {
+      await instance.stop();
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,14 +119,14 @@ importers:
         specifier: ^2.0.0
         version: 2.0.1
       '@toon-protocol/connector':
-        specifier: ^3.20.1
-        version: 3.20.1(@types/node@20.19.32)(typescript@5.9.3)
+        specifier: ^3.29.1
+        version: 3.29.1(@types/node@20.19.32)(typescript@5.9.3)
       '@toon-protocol/core':
-        specifier: ^2.0.0
-        version: 2.0.1(@toon-protocol/connector@3.20.1)(typescript@5.9.3)
+        specifier: ^2.1.0
+        version: 2.1.0(@toon-protocol/connector@3.29.1)(typescript@5.9.3)
       '@toon-protocol/sdk':
-        specifier: ^2.0.0
-        version: 2.0.1(@toon-protocol/connector@3.20.1)(typescript@5.9.3)
+        specifier: ^2.1.0
+        version: 2.1.0(@toon-protocol/connector@3.29.1)(typescript@5.9.3)
       ed25519-hd-key:
         specifier: ^1.3.0
         version: 1.3.0
@@ -249,23 +249,6 @@ packages:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
     dev: true
-
-  /@anyone-protocol/anyone-client@1.1.3:
-    resolution: {integrity: sha512-QIkIhOnQo6R8xn4VsqCbmG8JtKaAsSWnHb230NU0x7Oo5EEPW0kVeEIztIvHARWEAmQ0ntK+yVgFNK4MY8fSeA==}
-    hasBin: true
-    dependencies:
-      '@types/node': 20.19.32
-      '@types/unzipper': 0.10.11
-      axios: 1.13.4
-      chalk: 4.1.2
-      net: 1.0.2
-      socks-proxy-agent: 8.0.5
-      typescript: 5.9.3
-      unzipper: 0.12.3
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: false
 
   /@ardrive/turbo-sdk@1.41.0(typescript@5.9.3):
     resolution: {integrity: sha512-GVaOPAKKUZQo7cB7Teinp8VpwdzlvoyUtvjkS0A6Ru/Iu5tCGcuGiY7weI9vbT1tUKJqPnJVqiH1fU+v0Ha2Ww==}
@@ -2459,13 +2442,6 @@ packages:
       '@types/node': 20.19.32
       chardet: 2.1.1
       iconv-lite: 0.7.2
-
-  /@inquirer/figures@1.0.15:
-    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
-    engines: {node: '>=18'}
-    requiresBuild: true
-    dev: false
-    optional: true
 
   /@istanbuljs/schema@0.1.3:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
@@ -5489,8 +5465,8 @@ packages:
   /@toon-format/toon@1.4.0:
     resolution: {integrity: sha512-bjdhhIPjnX2oVk+pKy/nD3bwuESDLX/5fwW0TxwpV7Q4PVNkiRSv1S0sPeuy9TI4PfAlulow1HShdmMTnYvoLg==}
 
-  /@toon-protocol/connector@3.20.1(@types/node@20.19.32)(typescript@5.9.3):
-    resolution: {integrity: sha512-cf8aRAg7GB9bFH8PHWgA1wVjgG6cwf+PcM1ziviepPp2wlGP0I08PmTe3SXGRWv2usPfk00OwXNYiCD+ryCPKA==}
+  /@toon-protocol/connector@3.29.1(@types/node@20.19.32)(typescript@5.9.3):
+    resolution: {integrity: sha512-lja8WrHVaEF2Yh4TT5PeI8NuzCdYgVOmxfLSuCTp3IexYdP0tGTYLZzSABagReazTcSDKqd8Ao/lHM95a0MsAw==}
     engines: {node: '>=22.11.0'}
     hasBin: true
     peerDependencies:
@@ -5505,10 +5481,11 @@ packages:
       tigerbeetle-node:
         optional: true
     dependencies:
-      '@anyone-protocol/anyone-client': 1.1.3
       '@noble/ciphers': 1.3.0
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
       '@solana-program/token': 0.6.0(@solana/kit@3.0.3)
       '@solana/kit': 3.0.3(typescript@5.9.3)(ws@8.20.0)
       '@toon-protocol/mina-zkapp': 0.1.1
@@ -5518,9 +5495,9 @@ packages:
       express: 5.2.1
       js-yaml: 4.1.1
       netmask: 2.0.2
+      nostr-tools: 2.23.1(typescript@5.9.3)
       pino: 8.21.0
       prom-client: 15.1.3
-      socks-proxy-agent: 8.0.5
       tslib: 2.8.1
       ws: 8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod: 3.25.76
@@ -5535,15 +5512,13 @@ packages:
       ai: 4.3.19(zod@3.25.76)
       bip39: 3.1.0
       commander: 12.1.0
-      inquirer: 9.3.8(@types/node@20.19.32)
+      inquirer: 8.2.7(@types/node@20.19.32)
       libsql: 0.4.7
-      nostr-tools: 2.23.1(typescript@5.9.3)
       qrcode: 1.5.4
       sharp: 0.33.5
     transitivePeerDependencies:
       - '@types/node'
       - bufferutil
-      - debug
       - encoding
       - fastestsmallesttextencoderdecoder
       - react
@@ -5552,8 +5527,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@toon-protocol/core@2.0.1(@toon-protocol/connector@3.20.1)(typescript@5.9.3):
-    resolution: {integrity: sha512-SyHKdJd3G2vgkuBT0HWMaAuJ+TmJZpTgyxM1OSljATKSdYzK0ztokcHYV1hI7mVsXyXqqIv3lRDMoskDNuh3Ew==}
+  /@toon-protocol/core@2.1.0(@toon-protocol/connector@3.29.1)(typescript@5.9.3):
+    resolution: {integrity: sha512-UxIdR/2yjJF79jvsQ7l/CwKZlEzfxtQtqksE+5OzSagv+lV0p7gL+mBMlDn8JacvBNRanM1qa8f8BNyQfBtvhg==}
     peerDependencies:
       '@toon-protocol/connector': '>=3.3.3'
     peerDependenciesMeta:
@@ -5565,7 +5540,7 @@ packages:
       '@scure/bip32': 2.0.1
       '@scure/bip39': 2.0.1
       '@toon-format/toon': 1.4.0
-      '@toon-protocol/connector': 3.20.1(@types/node@20.19.32)(typescript@5.9.3)
+      '@toon-protocol/connector': 3.29.1(@types/node@20.19.32)(typescript@5.9.3)
       arweave: 1.15.7
       nostr-tools: 2.23.1(typescript@5.9.3)
       simple-git: 3.33.0
@@ -5616,8 +5591,8 @@ packages:
       o1js: 2.14.0
     dev: false
 
-  /@toon-protocol/sdk@2.0.1(@toon-protocol/connector@3.20.1)(typescript@5.9.3):
-    resolution: {integrity: sha512-dzZ2Ikd5LZhrd9PxBs/B3wDwTVAr9VFT2nHk0MwG7H+ghyG/HPiMMj1Qpm5s5fe4kfmeYUiwnkBEZsTawJUS9w==}
+  /@toon-protocol/sdk@2.1.0(@toon-protocol/connector@3.29.1)(typescript@5.9.3):
+    resolution: {integrity: sha512-1rJWUZNbMuT2Ch7AU7EJC1gtg8x6npbV91NzomwpDrJwiE5RKFF2Z9XmuVXz6BHRV1omFv4N83zCzKweMuInRw==}
     engines: {node: '>=22'}
     peerDependencies:
       '@toon-protocol/connector': '>=3.3.3'
@@ -5633,8 +5608,8 @@ packages:
       '@noble/hashes': 2.0.1
       '@scure/bip32': 2.0.1
       '@scure/bip39': 2.0.1
-      '@toon-protocol/connector': 3.20.1(@types/node@20.19.32)(typescript@5.9.3)
-      '@toon-protocol/core': 2.0.1(@toon-protocol/connector@3.20.1)(typescript@5.9.3)
+      '@toon-protocol/connector': 3.29.1(@types/node@20.19.32)(typescript@5.9.3)
+      '@toon-protocol/core': 2.1.0(@toon-protocol/connector@3.29.1)(typescript@5.9.3)
       nostr-tools: 2.23.1(typescript@5.9.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -5783,13 +5758,6 @@ packages:
 
   /@types/trusted-types@2.0.7:
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
-    dev: false
-
-  /@types/unzipper@0.10.11:
-    resolution: {integrity: sha512-D25im2zjyMCcgL9ag6N46+wbtJBnXIr7SI4zHf9eJD2Dw2tEB5e+p5MYkrxKIVRscs5QV0EhtU9rgXSPx90oJg==}
-    requiresBuild: true
-    dependencies:
-      '@types/node': 20.19.32
     dev: false
 
   /@types/uuid@8.3.4:
@@ -7229,6 +7197,7 @@ packages:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
     requiresBuild: true
     dev: false
+    optional: true
 
   /bn.js@4.12.2:
     resolution: {integrity: sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==}
@@ -7569,9 +7538,9 @@ packages:
       '@colors/colors': 1.5.0
     dev: true
 
-  /cli-width@4.1.0:
-    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
-    engines: {node: '>= 12'}
+  /cli-width@3.0.0:
+    resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
+    engines: {node: '>= 10'}
     requiresBuild: true
     dev: false
     optional: true
@@ -8127,6 +8096,7 @@ packages:
     requiresBuild: true
     dependencies:
       readable-stream: 2.3.8
+    dev: true
 
   /duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
@@ -8398,7 +8368,6 @@ packages:
   /escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
-    dev: true
 
   /escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
@@ -8868,6 +8837,15 @@ packages:
       escape-string-regexp: 1.0.5
     dev: true
 
+  /figures@3.2.0:
+    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
+    engines: {node: '>=8'}
+    requiresBuild: true
+    dependencies:
+      escape-string-regexp: 1.0.5
+    dev: false
+    optional: true
+
   /figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -9040,6 +9018,7 @@ packages:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
+    dev: true
 
   /fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -9627,32 +9606,30 @@ packages:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
     dev: true
 
-  /inquirer@9.3.8(@types/node@20.19.32):
-    resolution: {integrity: sha512-pFGGdaHrmRKMh4WoDDSowddgjT1Vkl90atobmTeSmcPGdYiwikch/m/Ef5wRaiamHejtw0cUUMMerzDUXCci2w==}
-    engines: {node: '>=18'}
+  /inquirer@8.2.7(@types/node@20.19.32):
+    resolution: {integrity: sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==}
+    engines: {node: '>=12.0.0'}
     requiresBuild: true
     dependencies:
       '@inquirer/external-editor': 1.0.3(@types/node@20.19.32)
-      '@inquirer/figures': 1.0.15
       ansi-escapes: 4.3.2
-      cli-width: 4.1.0
-      mute-stream: 1.0.0
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-width: 3.0.0
+      figures: 3.2.0
+      lodash: 4.17.23
+      mute-stream: 0.0.8
       ora: 5.4.1
-      run-async: 3.0.0
+      run-async: 2.4.1
       rxjs: 7.8.2
       string-width: 4.2.3
       strip-ansi: 6.0.1
+      through: 2.3.8
       wrap-ansi: 6.2.0
-      yoctocolors-cjs: 2.1.3
     transitivePeerDependencies:
       - '@types/node'
     dev: false
     optional: true
-
-  /ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
-    engines: {node: '>= 12'}
-    dev: false
 
   /ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -10118,6 +10095,7 @@ packages:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+    dev: true
 
   /jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
@@ -10754,9 +10732,8 @@ packages:
     dev: false
     optional: true
 
-  /mute-stream@1.0.0:
-    resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+  /mute-stream@0.0.8:
+    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
     requiresBuild: true
     dev: false
     optional: true
@@ -10790,11 +10767,6 @@ packages:
   /nerf-dart@1.0.0:
     resolution: {integrity: sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==}
     dev: true
-
-  /net@1.0.2:
-    resolution: {integrity: sha512-kbhcj2SVVR4caaVnGLJKmlk2+f+oLkjqdKeQlmUtz6nGzOpbcobwVIeSURNgraV/v3tlmGIX82OcPCl0K6RbHQ==}
-    requiresBuild: true
-    dev: false
 
   /netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
@@ -10864,10 +10836,6 @@ packages:
   /node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
-    dev: false
-
-  /node-int64@0.4.0:
-    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
     dev: false
 
   /node-mock-http@1.0.4:
@@ -12234,8 +12202,8 @@ packages:
     dev: false
     optional: true
 
-  /run-async@3.0.0:
-    resolution: {integrity: sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==}
+  /run-async@2.4.1:
+    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
     requiresBuild: true
     dev: false
@@ -12568,12 +12536,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /smart-buffer@4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-    requiresBuild: true
-    dev: false
-
   /socket.io-client@4.8.3:
     resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
     engines: {node: '>=10.0.0'}
@@ -12596,26 +12558,6 @@ packages:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /socks-proxy-agent@8.0.5:
-    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
-    engines: {node: '>= 14'}
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-      socks: 2.8.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /socks@2.8.7:
-    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
-    requiresBuild: true
-    dependencies:
-      ip-address: 10.2.0
-      smart-buffer: 4.2.0
     dev: false
 
   /sonic-boom@2.8.0:
@@ -13024,6 +12966,12 @@ packages:
       readable-stream: 2.3.8
       xtend: 4.0.2
 
+  /through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /time-span@5.1.0:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
@@ -13360,6 +13308,7 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
     requiresBuild: true
+    dev: true
 
   /unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -13437,17 +13386,6 @@ packages:
       node-fetch-native: 1.6.7
       ofetch: 1.5.1
       ufo: 1.6.3
-    dev: false
-
-  /unzipper@0.12.3:
-    resolution: {integrity: sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==}
-    requiresBuild: true
-    dependencies:
-      bluebird: 3.7.2
-      duplexer2: 0.1.4
-      fs-extra: 11.3.4
-      graceful-fs: 4.2.11
-      node-int64: 0.4.0
     dev: false
 
   /uri-js@4.4.1:
@@ -14215,13 +14153,6 @@ packages:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
     dev: true
-
-  /yoctocolors-cjs@2.1.3:
-    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
-    engines: {node: '>=18'}
-    requiresBuild: true
-    dev: false
-    optional: true
 
   /yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}


### PR DESCRIPTION
Part of toon-protocol/toon-meta#145. Closes #47.

Implements the rolling-swap maker engine per `toon-meta/docs/rolling-swap.md` §3 and the connector's `docs/local-delivery-fulfillment-contract.md` (shipped in connector 3.29.x). Prereq pins: `@toon-protocol/sdk` ^2.1.0, `@toon-protocol/core` ^2.1.0, `@toon-protocol/connector` ^3.29.1.

## What the FULFILL now carries vs before

| | before (legacy path) | after (rolling path) |
|---|---|---|
| leg-A FULFILL `data` | the signed chain-B balance proof itself (`claim`, NIP-44 ciphertext + settlement metadata) — delivery-atomic only | a compact `rolling/1` **accept record**: `{streamNonce, seq, rate, rateTimestamp, targetAmount, channelId, nonce, cumulativeAmount}` — quote tape + watermark echo, **no claim** |
| leg-A FULFILL `fulfillment` | none (connector injected its NIP-59/HKDF preimage) | the **sender-minted 32-byte preimage `P_i`**, learned from the leg-B FULFILL; the connector enforces `sha256(fulfillment) === executionCondition` before FULFILLing upstream (F99 + nothing recorded otherwise) |
| the chain-B claim | inside the leg-A FULFILL | on **leg B**: a maker→sender PREPARE carrying the `rolling/1` **advance payload** `{claim, claimId, channelId, nonce, cumulativeAmount, recipient, swapSignerAddress, rate, rateTimestamp, sourceAmount, targetAmount}` under the **same condition `C_i`** |

The legacy zero-condition gift-wrap path is preserved byte-for-byte (claim-in-FULFILL stays as the fallback until spec §10.3 step 5); both wire shapes coexist with no ambiguity — legacy fills are TOON kind:1059 gift wraps, rolling fills are unwrapped `rolling/1` JSON with a `streamNonce`.

## Coupling mechanics (spec §3 R1–R8, as implemented)

```
sender ── PREPARE(δ, condition C_i, {proto:"rolling/1", type:"fill", streamNonce, seq}) ──▶ maker connector
maker connector ── LocalDeliveryRequest{executionCondition: b64(C_i)} ──▶ RollingSwapEngine
engine: session lookup → staleness gate (T99/stale_rate, NO state) → replay reservation
        (`rolling:${streamNonce}:${seq}`, persisted synchronously) → leg-A expiry budget (R7)
        → fresh rate R_i (rateProvider, RateQuote tape) → issueClaim
        (debit + watermark advance + WRITE-AHEAD persist — crash rule 1)
engine ── leg-B PREPARE(⌊δ·R_i⌋, SAME C_i, expiresAt < leg-A expiry, advance payload) ──▶ sender
sender: verifies the chain-B claim BEFORE revealing (R5) — FULFILLs leg B with P_i iff it checks out
engine: verifies sha256(P_i) == C_i → { accept, fulfillment: b64(P_i), data: accept record } (R6)
maker connector: sha256(fulfillment) == C_i ? FULFILL(P_i) upstream : F99, nothing recorded
```

- **R4**: `C_i` is copied verbatim onto the leg-B PREPARE — never re-minted. The maker structurally cannot collect leg A without the sender's reveal; a stalling maker fails the packet and collects nothing (proven at the contract level with the connector's rule-3 enforcement mocked byte-for-byte, plus a Byzantine-accept simulation).
- **Failure unwind (AC-2/AC-4)**: leg-B reject/timeout/wrong-preimage → `MultiChainClaimIssuer.rollbackClaim()` (credit + release + best-effort re-persist, same pattern as the signer-failure rollback) + benign leg-A reject (`data.reason: "leg_b_failed"`/`"leg_b_fulfillment_invalid"`; T-class mirrored from the leg-B class). Nonce reuse after unwind is protocol-correct per R8 (claims on REJECTed packets are void receiver-side); the residual Byzantine exposure is the spec's designed δ·W bound (§3.1), not a new gap.
- **Crash safety**: write-ahead persist runs before the claim leaves the process; a crash between debit and fulfill leaves watermark-advanced/debited/seq-reserved state on disk — restart continues monotonically above the aborted reservation and replays reject F04 (crash rules 1/2/4).
- **Sessions (spec §2.2)**: fills carry only `{streamNonce, seq}`; pair/chainRecipient/sender leg-B ILP address/sender pubkey are session state registered via `SwapNodeInstance.registerRollingSession()` (bounded, TTL'd `RollingSessionStore`) — the seam the RFQ (kind:20033/20034) transport story plugs into. Unknown session → benign F06.
- **Dispatch matrix** (condition class × payload class): zero+gift-wrap → legacy unchanged; zero+rolling → F99 `condition_required` (no uncoupled fills); non-zero+rolling → engine; non-zero+legacy → F99 `condition_unsupported_legacy` **before** any legacy dispatch (dispatching would debit inventory only for the connector to F99 the FULFILL with nothing recorded upstream).
- **Fresh rate per packet (AC-3)**: `SWAP_RATE_URL` (+ `SWAP_RATE_TIMEOUT_MS`) wires `createHttpRateProvider` into the CLI — one GET per fill, timestamped responses arm the swap#48 `maxRateAge` guard. The staleness gate runs pre-reservation with the byte-identical T99/`stale_rate` contract; `STALE_RATE_SEMANTIC_REASON` flips to `'stale_rate'` for native wire T99 now that connector ≥3.29.0 maps it.

## Leg-B egress note (deviation from the issue's letter, not its intent)

The issue routes leg-B egress via `ConnectorNode.sendPacket` — but `sendPacket` (connector 3.29.1) builds the PREPARE without an `executionCondition`, which would sever the coupling (R4). `createConnectorLegBSender` therefore calls the same underlying entrypoint `sendPacket` wraps (`handlePreparePacket`) with the condition attached, runtime-guarded and **fail-closed** (no seam → the fill is rejected; leg B is never sent unconditioned). Follow-up: add `executionCondition?` to the connector's public `SendPacketParams` and drop the reach-in.

## Legacy compat

- Zero/absent condition + gift-wrap: pre-existing path byte-for-byte (claim-in-FULFILL, NIP-59 preimage injection connector-side, sdk 2.1.0 quote-tape fields on accept metadata) — pinned by an integration test running the legacy flow on the same node as rolling sessions.
- `MultiChainClaimIssuer` remains the leg-B claim signer (spec §10.3 step 5 keeps it), now also exposing `rollbackClaim()`.

## AC coverage

- [x] Per packet both legs commit or neither; forced stall → no committed-A-without-B (unit + integration, connector semantics mocked per the contract doc)
- [x] Wrong/withheld preimage → benign leg-A failure, nothing debited
- [x] Fresh per-packet rate via `rateProvider`, wired from the CLI (`SWAP_RATE_URL`)
- [x] Failed packet fully unwinds inventory/channel reservations
- [ ] Docker e2e on EVM for a multi-packet rolling swap — **deferred to swap#50** (its charter), hard-blocked on the sender-side leg-B termination (toon-client#352, spec P3): no real client can terminate leg B yet. Covered here at the contract level instead (mocked connector enforcement + R5-compliant sender daemon).

Tests: 232 unit (was 197) + 25 integration (was 22), lint/format clean. Do not merge without a maintainer look at the leg-B egress reach-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
