### PR TITLE
Rolling swap: inventory → in-flight window reservation model

### DIFF
--- a/.changeset/inflight-window-reservations.md
+++ b/.changeset/inflight-window-reservations.md
@@ -1,0 +1,15 @@
+---
+'@toon-protocol/swap': major
+---
+
+Rolling path: inventory → in-flight window reservation model (swap#49, rolling-swap spec §8, toon-meta#145).
+
+The rolling coupled-leg flow no longer permanently debits a notional pre-fund. Each fill takes a TTL'd **window reservation** for its leg-B amount (durable, write-ahead, before the leg-B advance is externalized), which is **committed** to unsettled channel liability on fulfill (shrunk later by on-chain settlement confirmations) or **released** on reject/rollback/TTL expiry. Capacity is gated by `min(windowBudget, available) − inFlight − unsettled` — the maker's honeypot is sized to δ×W of open packets plus the unsettled balance, not to notional volume; a capacity shortage rejects with the same benign T04 `insufficient_liquidity` vocabulary as before. Reservation TTLs align with the engine's leg-B expiry budget (+`rolling.reservationGraceMs`, default 5s), so a crashed/stalled packet frees its slot; crash recovery is expire-and-release (state-store crash rule 6) — no leaked capacity, no double-spend. The legacy zero-condition gift-wrap path keeps permanent debit/credit unchanged.
+
+Part of the same major train as the rolling engine (swap#47). Major because:
+
+- `SwapNodeInstance` gains a required `recordSettlement(event)` member and `SwapNodeHealthResponse` a required `inventoryWindow` three-bucket record (`budget`/`inFlight`/`unsettled`/`free`) — breaking for structural implementations/doubles.
+- `SwapInventoryBalance` gains a required `unsettled` field; `SwapInventory` snapshots and the persisted state schema change shape (`PersistedSwapState.version` 1 → 2, new `reservations`/`settledWatermarks` sections; v1 snapshots still load with defaults).
+- `MultiChainClaimIssuer.rollbackClaim()` (introduced unreleased in swap#47) is replaced by the reservation-keyed `issueRollingClaim()`/`commitRollingClaim()`/`rollbackRollingClaim()` triple; the rolling engine no longer calls `issueClaim()`.
+
+Also new: `SwapNodeConfig.windowBudget` (per-chain in-flight ceiling, CLI `windowBudget` config key), `SwapInventory.reserve/commitReservation/releaseReservation/recordSettlement/windowSnapshot`, and the `resolveChannel` doc comment corrected to the actual first-unbound-channel policy (binding is not capacity-aware; the window budget bounds exposure one level up).

--- a/packages/swap/src/channel-state.ts
+++ b/packages/swap/src/channel-state.ts
@@ -9,11 +9,16 @@
  * "sticky binding" that's established on the first `reserve()` for each
  * sender and held for the lifetime of this `SwapChannelState` instance.
  *
- * The sticky-binding policy ("first channel with sufficient capacity")
- * is deliberately minimal — a single sender never migrates to a second
- * channel — so sender⇄channel balance-proof state stays coherent. Two
- * senders with distinct pubkeys bind to distinct channels as long as
- * ≥2 channels were provisioned for that `(asset, chain)` (AC-7).
+ * The sticky-binding policy is "first UNBOUND channel" — deliberately
+ * minimal: a single sender never migrates to a second channel, so
+ * sender⇄channel balance-proof state stays coherent. Two senders with
+ * distinct pubkeys bind to distinct channels as long as ≥2 channels were
+ * provisioned for that `(asset, chain)` (AC-7). NOTE (issue #49): binding
+ * is NOT capacity-aware — `ChannelEntry` carries no deposit/capacity field
+ * to check against, so per-channel headroom cannot be enforced here.
+ * Capacity is bounded one level up by the in-flight window
+ * (`SwapInventory` budget/reservations); making the binding deposit-aware
+ * is future work once channel deposits are tracked in this state.
  *
  * State is held in memory for microtask-atomic `reserve`/`release`;
  * durability is provided by `SwapStatePersister` (`state-store.ts`, issue
@@ -137,7 +142,8 @@ export class SwapChannelState {
   /**
    * Resolve the channel for a given sender, establishing a sticky binding
    * on first use. Returns `null` if no unbound channel is available for
-   * this `(asset, chain)`.
+   * this `(asset, chain)`. First-use selection is "first unbound channel"
+   * — NOT capacity-aware (see the class docblock, issue #49).
    *
    * @internal — exposed for AC-12 test introspection via the swap node.
    */

--- a/packages/swap/src/claim-issuer.test.ts
+++ b/packages/swap/src/claim-issuer.test.ts
@@ -896,3 +896,251 @@ describe('Story 12.9 — chain-recipient threading to signBalanceProof', () => {
     ).rejects.toBeInstanceOf(SwapWalletError);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #49 — rolling path: in-flight window reservation lifecycle
+// ---------------------------------------------------------------------------
+
+describe('MultiChainClaimIssuer — issueRollingClaim / commit / rollback (issue #49)', () => {
+  const CHAIN49 = 'evm:base:8453';
+  const KEY49 = `ETH:${CHAIN49}`;
+
+  function buildRollingIssuer(opts?: {
+    signBalanceProof?: (arg: unknown) => Promise<Uint8Array>;
+    persistState?: () => void;
+    windowBudget?: bigint;
+    now?: () => number;
+  }) {
+    const inventory = new SwapInventory({
+      balances: {
+        [KEY49]: {
+          available: 1_000n,
+          total: 1_000n,
+          ...(opts?.windowBudget !== undefined && {
+            windowBudget: opts.windowBudget,
+          }),
+        },
+      },
+      ...(opts?.now && { clock: opts.now }),
+    });
+    const channelState = new SwapChannelState({
+      channels: {
+        [`ETH:${CHAIN49}:0xchan49`]: {
+          channelId: '0xchan49',
+          cumulativeAmount: 0n,
+          nonce: 0n,
+          updatedAt: 0,
+        },
+      },
+    });
+    const signBalanceProof = vi.fn(
+      opts?.signBalanceProof ?? (async () => new Uint8Array([0x49]))
+    );
+    const issuer = new MultiChainClaimIssuer({
+      inventory,
+      signers: {
+        [CHAIN49]: {
+          chain: CHAIN49,
+          chainKind: 'evm' as const,
+          signBalanceProof,
+        },
+      },
+      channelState,
+      ...(opts?.persistState && { persistState: opts.persistState }),
+    });
+    return { issuer, inventory, channelState, signBalanceProof };
+  }
+
+  function rollingParams(targetAmount = 50n) {
+    return {
+      sourceAmount: 100_000n,
+      targetAmount,
+      pair: PAIR_USDC_TO_ETH,
+      senderPubkey: SENDER_PUBKEY,
+      chainRecipient: FIXTURE_EVM_RECIPIENT,
+      rumor: makeRumor(),
+    };
+  }
+
+  function window49(inventory: SwapInventory) {
+    return inventory
+      .windowSnapshot()
+      .find((w) => w.assetCode === 'ETH' && w.chain === CHAIN49)!;
+  }
+
+  it('[P0] reserves the window (no permanent debit), returns a reservationId, honors reservationTtlMs', async () => {
+    let now = 10_000;
+    const { issuer, inventory } = buildRollingIssuer({ now: () => now });
+    const result = await issuer.issueRollingClaim({
+      ...rollingParams(),
+      reservationTtlMs: 1_234,
+    });
+    expect(result.claim).toBeInstanceOf(Uint8Array);
+    expect(result.reservationId.length).toBeGreaterThan(0);
+    // available untouched; the amount is IN FLIGHT.
+    expect(inventory.get('ETH', CHAIN49)!.available).toBe(1_000n);
+    const w = window49(inventory);
+    expect(w.inFlight).toBe(50n);
+    expect(w.free).toBe(950n);
+    const reservations = inventory.reservationsSnapshot();
+    expect(reservations[result.reservationId]).toEqual({
+      key: KEY49,
+      amount: 50n,
+      expiresAt: 10_000 + 1_234,
+    });
+    // TTL expiry frees the slot (crashed/stalled packet).
+    now = 10_000 + 1_235;
+    expect(window49(inventory).inFlight).toBe(0n);
+    expect(window49(inventory).free).toBe(1_000n);
+  });
+
+  it('[P0] write-ahead: the reservation is durable BEFORE the claim is signed', async () => {
+    const order: string[] = [];
+    let reservationsAtPersist = -1;
+    const stack = buildRollingIssuer({
+      persistState: () => {
+        order.push('persist');
+        reservationsAtPersist = Object.keys(
+          stack.inventory.reservationsSnapshot()
+        ).length;
+      },
+      signBalanceProof: async () => {
+        order.push('sign');
+        return new Uint8Array([0x49]);
+      },
+    });
+    await stack.issuer.issueRollingClaim(rollingParams());
+    expect(order).toEqual(['persist', 'sign']);
+    expect(reservationsAtPersist).toBe(1);
+  });
+
+  it('[P0] write-ahead persist failure → reservation + watermark rolled back, claim refused', async () => {
+    let fail = true;
+    const { issuer, inventory, channelState, signBalanceProof } =
+      buildRollingIssuer({
+        persistState: () => {
+          if (fail) throw new Error('disk full');
+        },
+      });
+    await expect(issuer.issueRollingClaim(rollingParams())).rejects.toThrow(
+      /persist/i
+    );
+    expect(signBalanceProof).not.toHaveBeenCalled();
+    expect(window49(inventory).inFlight).toBe(0n);
+    const entry = channelState.get({
+      assetCode: 'ETH',
+      chain: CHAIN49,
+      senderPubkey: SENDER_PUBKEY,
+    })!;
+    expect(entry.nonce).toBe(0n);
+    fail = false;
+    await expect(
+      issuer.issueRollingClaim(rollingParams())
+    ).resolves.toBeDefined();
+  });
+
+  it('[P0] signer failure → reservation released + watermark reversed (nothing leaks)', async () => {
+    const { issuer, inventory, channelState } = buildRollingIssuer({
+      signBalanceProof: async () => {
+        throw new Error('signer exploded');
+      },
+    });
+    await expect(issuer.issueRollingClaim(rollingParams())).rejects.toThrow(
+      /signing failed/i
+    );
+    expect(window49(inventory).inFlight).toBe(0n);
+    expect(window49(inventory).free).toBe(1_000n);
+    expect(
+      channelState.get({
+        assetCode: 'ETH',
+        chain: CHAIN49,
+        senderPubkey: SENDER_PUBKEY,
+      })!.nonce
+    ).toBe(0n);
+  });
+
+  it('[P0] capacity refusal: windowBudget − inFlight − unsettled gates the reserve with INSUFFICIENT_INVENTORY (T04 vocabulary)', async () => {
+    const { issuer, inventory } = buildRollingIssuer({ windowBudget: 70n });
+    const first = await issuer.issueRollingClaim(rollingParams(50n));
+    // 70 budget − 50 in flight = 20 free < 50.
+    await expect(issuer.issueRollingClaim(rollingParams(50n))).rejects.toThrow(
+      SwapInventoryError
+    );
+    await expect(
+      issuer.issueRollingClaim(rollingParams(50n))
+    ).rejects.toMatchObject({ code: 'INSUFFICIENT_INVENTORY' });
+    // Commit converts to unsettled — STILL occupies the window.
+    issuer.commitRollingClaim({
+      reservationId: first.reservationId,
+      pair: PAIR_USDC_TO_ETH,
+      targetAmount: 50n,
+    });
+    expect(window49(inventory).unsettled).toBe(50n);
+    await expect(issuer.issueRollingClaim(rollingParams(50n))).rejects.toThrow(
+      /window capacity/
+    );
+    // Settlement confirmation frees it.
+    inventory.recordSettlement({
+      assetCode: 'ETH',
+      chain: CHAIN49,
+      channelId: '0xchan49',
+      cumulativeAmount: 50n,
+    });
+    await expect(
+      issuer.issueRollingClaim(rollingParams(50n))
+    ).resolves.toBeDefined();
+  });
+
+  it('[P0] rollbackRollingClaim releases exactly once (double unwind cannot double-decrement the watermark)', async () => {
+    const persist = vi.fn();
+    const { issuer, inventory, channelState } = buildRollingIssuer({
+      persistState: persist,
+    });
+    const issued = await issuer.issueRollingClaim(rollingParams(50n));
+    const persistsAfterIssue = persist.mock.calls.length;
+    const rollback = () =>
+      issuer.rollbackRollingClaim({
+        reservationId: issued.reservationId,
+        pair: PAIR_USDC_TO_ETH,
+        senderPubkey: SENDER_PUBKEY,
+        targetAmount: 50n,
+      });
+    rollback();
+    const entry = () =>
+      channelState.get({
+        assetCode: 'ETH',
+        chain: CHAIN49,
+        senderPubkey: SENDER_PUBKEY,
+      })!;
+    expect(entry().nonce).toBe(0n);
+    expect(entry().cumulativeAmount).toBe(0n);
+    expect(window49(inventory).free).toBe(1_000n);
+    expect(persist.mock.calls.length).toBe(persistsAfterIssue + 1);
+    // Second unwind: logged no-op — watermark NOT decremented again, no persist.
+    rollback();
+    expect(entry().nonce).toBe(0n);
+    expect(entry().cumulativeAmount).toBe(0n);
+    expect(window49(inventory).free).toBe(1_000n);
+    expect(persist.mock.calls.length).toBe(persistsAfterIssue + 1);
+  });
+
+  it('[P1] late commit (reservation TTL-expired mid-flight) still records the liability', async () => {
+    let now = 0;
+    const { issuer, inventory } = buildRollingIssuer({ now: () => now });
+    const issued = await issuer.issueRollingClaim({
+      ...rollingParams(50n),
+      reservationTtlMs: 100,
+    });
+    now = 200; // reservation expired while leg B was in flight
+    issuer.commitRollingClaim({
+      reservationId: issued.reservationId,
+      pair: PAIR_USDC_TO_ETH,
+      targetAmount: 50n,
+    });
+    const w = window49(inventory);
+    expect(w.inFlight).toBe(0n);
+    // The revealed claim is redeemable regardless of the clock: liability
+    // is recorded anyway.
+    expect(w.unsettled).toBe(50n);
+  });
+});

--- a/packages/swap/src/claim-issuer.ts
+++ b/packages/swap/src/claim-issuer.ts
@@ -1,18 +1,32 @@
 /**
- * `MultiChainClaimIssuer` (Story 12.4 AC-6, AC-8, AC-10).
+ * `MultiChainClaimIssuer` (Story 12.4 AC-6, AC-8, AC-10; issue #49 window).
  *
  * Implements the `ClaimIssuer` interface from `@toon-protocol/sdk` (type-only
- * import — no runtime cycle). Flow: debit inventory → reserve channel state
- * → write-ahead persist (issue #46) → await signer.signBalanceProof →
- * return { claim, claimId }. On signer failure, both inventory and channel
- * state are reversed (and the reversal re-persisted, best-effort).
+ * import — no runtime cycle), plus the rolling-path reservation entrypoints.
+ *
+ * Two claim flows share one core (acquire inventory hold → reserve channel
+ * state → write-ahead persist (issue #46) → await signer.signBalanceProof →
+ * return { claim, claimId }; on signer failure everything is reversed and
+ * the reversal re-persisted, best-effort):
+ *
+ * - {@link issueClaim} — LEGACY gift-wrap path: the inventory hold is a
+ *   permanent `debit` (undone by `credit` only on rollback). Byte-for-byte
+ *   the pre-#49 behavior.
+ * - {@link issueRollingClaim} — rolling coupled-leg path (issue #49): the
+ *   inventory hold is a TTL'd in-flight window **reservation**
+ *   (`SwapInventory.reserve`). The caller then either
+ *   {@link commitRollingClaim}s it (leg-B fulfilled → unsettled liability)
+ *   or {@link rollbackRollingClaim}s it (leg-B failed → capacity released,
+ *   exactly once). No permanent debit exists on this flow.
  *
  * Issue #46 crash-consistency: when `persistState` is configured, the
  * post-reserve watermark hits durable storage BEFORE the balance proof is
  * signed — so no claim a counterparty can ever hold is AHEAD of the stored
- * watermark. If the write-ahead persist throws, the debit + reservation are
+ * watermark. If the write-ahead persist throws, the hold + reservation are
  * rolled back and the claim is refused (`PERSISTENCE_FAILED` → ILP T00).
- * See `state-store.ts` for the full recovery rules.
+ * The same write-ahead ordering makes the WINDOW reservation durable before
+ * its leg-B advance can be externalized (issue #49). See `state-store.ts`
+ * for the full recovery rules.
  */
 
 import type {
@@ -69,6 +83,32 @@ function validateClaimIssuerChainRecipient(
   // Unknown chain: permit non-empty; the signer lookup below will surface
   // UNSUPPORTED_CHAIN before any signing actually happens.
   return value.length > 0;
+}
+
+/**
+ * Inventory hold abstraction — how {@link MultiChainClaimIssuer.issueWithHold}
+ * stays byte-equal across the legacy (debit/credit) and rolling
+ * (reserve/release) flows. `undo()` reverses the hold and must be
+ * exception-free.
+ */
+interface InventoryHold {
+  undo(): void;
+}
+
+/** {@link MultiChainClaimIssuer.issueRollingClaim} params (issue #49). */
+export interface IssueRollingClaimParams extends IssueClaimParams {
+  /**
+   * Window-reservation lifetime. The rolling engine sizes this to its
+   * leg-B expiry budget + grace (spec R7 alignment); defaults to the
+   * inventory's `defaultReservationTtlMs`.
+   */
+  reservationTtlMs?: number;
+}
+
+/** {@link MultiChainClaimIssuer.issueRollingClaim} result (issue #49). */
+export interface RollingIssueClaimResult extends IssueClaimResult {
+  /** Handle for {@link MultiChainClaimIssuer.commitRollingClaim} / {@link MultiChainClaimIssuer.rollbackRollingClaim}. */
+  reservationId: string;
 }
 
 export interface SwapClaimIssuerLogger {
@@ -160,7 +200,71 @@ export class MultiChainClaimIssuer implements ClaimIssuer {
       });
   }
 
+  /**
+   * LEGACY gift-wrap path: permanent-debit inventory hold. Behavior is
+   * byte-for-byte the pre-#49 `issueClaim` (issue #49 keeps the legacy
+   * path on debit/credit; only the rolling flow moved to reservations).
+   */
   async issueClaim(params: IssueClaimParams): Promise<IssueClaimResult> {
+    const { pair, targetAmount } = params;
+    const targetAsset = pair.to.assetCode;
+    const targetChain = pair.to.chain;
+    const { result } = await this.issueWithHold(params, () => {
+      // 2. Debit inventory SYNCHRONOUSLY (before any await). Throws
+      //    SwapInventoryError('INSUFFICIENT_INVENTORY') when reserves are
+      //    exhausted — Story 12.3's handler maps this to ILP T04.
+      this.inventory.debit(targetAsset, targetChain, targetAmount);
+      return {
+        undo: () =>
+          this.inventory.credit(targetAsset, targetChain, targetAmount),
+      };
+    });
+    return result;
+  }
+
+  /**
+   * Rolling coupled-leg path (issue #49): the inventory hold is a TTL'd
+   * in-flight window reservation sized to the leg-B amount. The reservation
+   * is durable (write-ahead persist) BEFORE the signed claim — and therefore
+   * before the leg-B advance — can leave the process. The caller MUST
+   * resolve the returned `reservationId` via {@link commitRollingClaim}
+   * (leg-B fulfilled) or {@link rollbackRollingClaim} (anything else); an
+   * unresolved reservation (process crash) expires at `reservationTtlMs`
+   * and frees its window slot (state-store crash rule 6).
+   *
+   * A window-capacity shortage throws
+   * `SwapInventoryError('INSUFFICIENT_INVENTORY')` — same benign T04
+   * vocabulary as a legacy reserves shortage.
+   */
+  async issueRollingClaim(
+    params: IssueRollingClaimParams
+  ): Promise<RollingIssueClaimResult> {
+    const { pair, targetAmount, reservationTtlMs } = params;
+    const targetAsset = pair.to.assetCode;
+    const targetChain = pair.to.chain;
+    let reservationId = '';
+    const { result } = await this.issueWithHold(params, () => {
+      const reserved = this.inventory.reserve({
+        assetCode: targetAsset,
+        chain: targetChain,
+        amount: targetAmount,
+        ...(reservationTtlMs !== undefined && { ttlMs: reservationTtlMs }),
+      });
+      reservationId = reserved.reservationId;
+      return {
+        undo: () => {
+          this.inventory.releaseReservation(reserved.reservationId);
+        },
+      };
+    });
+    return { ...result, reservationId };
+  }
+
+  /** Shared issueClaim core — see the class docblock for the two flows. */
+  private async issueWithHold(
+    params: IssueClaimParams,
+    acquireHold: () => InventoryHold
+  ): Promise<{ result: IssueClaimResult }> {
     const { pair, senderPubkey, chainRecipient, targetAmount } = params;
     const targetChain = pair.to.chain;
     const targetAsset = pair.to.assetCode;
@@ -178,7 +282,7 @@ export class MultiChainClaimIssuer implements ClaimIssuer {
     // format against `pair.to.chain` BEFORE any inventory debit or channel
     // reservation so a malformed value cannot leak state changes. Third
     // defensive tier; sender + handler already validate. No inventory
-    // rollback is needed because this runs before the debit.
+    // rollback is needed because this runs before the hold.
     if (
       typeof chainRecipient !== 'string' ||
       !validateClaimIssuerChainRecipient(chainRecipient, targetChain)
@@ -189,12 +293,11 @@ export class MultiChainClaimIssuer implements ClaimIssuer {
       );
     }
 
-    // 2. Debit inventory SYNCHRONOUSLY (before any await). Throws
-    //    SwapInventoryError('INSUFFICIENT_INVENTORY') when reserves are
-    //    exhausted — Story 12.3's handler maps this to ILP T04.
-    this.inventory.debit(targetAsset, targetChain, targetAmount);
+    // 2. Acquire the inventory hold SYNCHRONOUSLY (before any await):
+    //    legacy = permanent debit; rolling = in-flight window reservation.
+    const hold = acquireHold();
 
-    // 3. Reserve channel state SYNCHRONOUSLY. On failure, reverse the debit.
+    // 3. Reserve channel state SYNCHRONOUSLY. On failure, reverse the hold.
     let reservation: Reservation;
     try {
       reservation = this.channelState.reserve({
@@ -204,22 +307,22 @@ export class MultiChainClaimIssuer implements ClaimIssuer {
         cumulativeDelta: targetAmount,
       });
     } catch (err) {
-      this.inventory.credit(targetAsset, targetChain, targetAmount);
+      hold.undo();
       throw err;
     }
 
     // 3b. Issue #46 — WRITE-AHEAD persist. The reservation (nonce +
-    //     cumulative watermark + inventory debit) MUST be durable before the
+    //     cumulative watermark + inventory hold) MUST be durable before the
     //     signed claim can leave the process. Synchronous, so no other
     //     issueClaim can interleave between reserve and persist. On failure:
-    //     roll back debit + reservation and refuse the claim — handing out a
+    //     roll back hold + reservation and refuse the claim — handing out a
     //     claim ahead of the stored watermark is the exact desync this
     //     hook exists to prevent.
     if (this.persistState) {
       try {
         this.persistState();
       } catch (err) {
-        this.inventory.credit(targetAsset, targetChain, targetAmount);
+        hold.undo();
         this.channelState.release({
           assetCode: targetAsset,
           chain: targetChain,
@@ -255,7 +358,7 @@ export class MultiChainClaimIssuer implements ClaimIssuer {
         recipient: chainRecipient,
       });
     } catch (err) {
-      this.inventory.credit(targetAsset, targetChain, targetAmount);
+      hold.undo();
       this.channelState.release({
         assetCode: targetAsset,
         chain: targetChain,
@@ -313,15 +416,73 @@ export class MultiChainClaimIssuer implements ClaimIssuer {
       result.recipient = chainRecipient;
       result.swapSignerAddress = swapSignerAddress;
     }
-    return result;
+    return { result };
   }
 
   /**
-   * Rolling-engine unwind (swap#47 AC-4): fully reverse a previously issued
-   * claim's inventory debit and channel reservation after the coupled leg-B
-   * PREPARE failed (reject / timeout / withheld preimage). Mirrors the
-   * signer-failure rollback in {@link issueClaim} step 4 byte-for-byte:
-   * credit + release + best-effort re-persist.
+   * Rolling-engine accept (issue #49): the leg-B FULFILL revealed the
+   * preimage, so the counterparty holds a redeemable claim — convert the
+   * in-flight reservation into unsettled channel liability. Persisted
+   * best-effort (the claim is already externalized at this point; a failed
+   * persist under-reports liability by at most this packet until the next
+   * snapshot — state-store crash rule 6's bounded window).
+   *
+   * A `'late'` commit (reservation TTL-expired mid-flight) is logged and
+   * still recorded: liability follows the revealed claim, not the clock.
+   */
+  commitRollingClaim(params: {
+    reservationId: string;
+    pair: SwapPair;
+    targetAmount: bigint;
+  }): void {
+    const targetChain = params.pair.to.chain;
+    const targetAsset = params.pair.to.assetCode;
+    const status = this.inventory.commitReservation({
+      reservationId: params.reservationId,
+      assetCode: targetAsset,
+      chain: targetChain,
+      amount: params.targetAmount,
+    });
+    if (status === 'late') {
+      this.logger?.warn?.('swap.commitRollingClaim.late', {
+        reservationId: params.reservationId,
+        chain: targetChain,
+        asset: targetAsset,
+        targetAmount: params.targetAmount.toString(),
+        reason:
+          'reservation TTL-expired before the leg-B FULFILL; liability recorded anyway (a revealed claim is redeemable regardless of the local clock)',
+      });
+    }
+    if (this.persistState) {
+      try {
+        this.persistState();
+      } catch (persistErr) {
+        this.logger?.error?.('swap.commitRollingClaim.persist_failed', {
+          err: persistErr,
+          chain: targetChain,
+          asset: targetAsset,
+        });
+      }
+    }
+    this.logger?.debug?.('swap.commitRollingClaim.ok', {
+      chain: targetChain,
+      asset: targetAsset,
+      status,
+      targetAmount: params.targetAmount.toString(),
+    });
+  }
+
+  /**
+   * Rolling-engine unwind (swap#47 AC-4, reshaped by issue #49): fully
+   * reverse a previously issued rolling claim after the coupled leg-B
+   * PREPARE failed (reject / timeout / withheld preimage) — release the
+   * window reservation + reverse the channel watermark + best-effort
+   * re-persist.
+   *
+   * Exactly-once: the reservation release is the idempotency gate. If the
+   * reservation is already gone (double unwind, or a TTL prune raced the
+   * unwind), NOTHING is reversed — in particular the channel watermark is
+   * not double-decremented — and the call is a logged no-op.
    *
    * Safety: per rolling-swap §3 R8, a channel claim attached to a PREPARE
    * that terminates in a REJECT MUST NOT advance the redeemable watermark on
@@ -332,14 +493,23 @@ export class MultiChainClaimIssuer implements ClaimIssuer {
    * it), disk keeps the pre-rollback snapshot — a safe over-reservation
    * (state-store crash rule 3).
    */
-  rollbackClaim(params: {
+  rollbackRollingClaim(params: {
+    reservationId: string;
     pair: SwapPair;
     senderPubkey: string;
     targetAmount: bigint;
   }): void {
     const targetChain = params.pair.to.chain;
     const targetAsset = params.pair.to.assetCode;
-    this.inventory.credit(targetAsset, targetChain, params.targetAmount);
+    const released = this.inventory.releaseReservation(params.reservationId);
+    if (!released) {
+      this.logger?.warn?.('swap.rollbackRollingClaim.already_released', {
+        reservationId: params.reservationId,
+        chain: targetChain,
+        asset: targetAsset,
+      });
+      return;
+    }
     this.channelState.release({
       assetCode: targetAsset,
       chain: targetChain,
@@ -350,14 +520,14 @@ export class MultiChainClaimIssuer implements ClaimIssuer {
       try {
         this.persistState();
       } catch (persistErr) {
-        this.logger?.error?.('swap.rollbackClaim.persist_failed', {
+        this.logger?.error?.('swap.rollbackRollingClaim.persist_failed', {
           err: persistErr,
           chain: targetChain,
           asset: targetAsset,
         });
       }
     }
-    this.logger?.info?.('swap.rollbackClaim.ok', {
+    this.logger?.info?.('swap.rollbackRollingClaim.ok', {
       chain: targetChain,
       asset: targetAsset,
       targetAmount: params.targetAmount.toString(),

--- a/packages/swap/src/cli.test.ts
+++ b/packages/swap/src/cli.test.ts
@@ -456,3 +456,38 @@ describe('issue #47 — SWAP_RATE_URL rateProvider wiring', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #49 — windowBudget config plumbing
+// ---------------------------------------------------------------------------
+
+describe('issue #49 — CLI windowBudget config key', () => {
+  it('[P1] rejects a windowBudget map with a prototype-polluting key', async () => {
+    const mod = (await import('./cli.js')) as {
+      main: (argv: string[]) => Promise<unknown>;
+    };
+    const rawJson =
+      '{"mnemonic":"x","channels":{},"inventory":{},' +
+      '"relayUrls":["wss://relay.example"],' +
+      '"windowBudget":{"__proto__":"1"}}';
+    const cfgPath = writeTempRawJson(rawJson);
+    await expect(mod.main(['--config', cfgPath])).rejects.toThrow(
+      /Unsafe key "__proto__"/
+    );
+  });
+
+  it('[P1] rejects a non-numeric windowBudget value', async () => {
+    const mod = (await import('./cli.js')) as {
+      main: (argv: string[]) => Promise<unknown>;
+    };
+    const cfg = {
+      mnemonic: 'x',
+      channels: {},
+      inventory: {},
+      windowBudget: { 'evm:8453': 'lots' },
+      relayUrls: ['wss://relay.example'],
+    };
+    const cfgPath = writeTempConfig(cfg);
+    await expect(mod.main(['--config', cfgPath])).rejects.toThrow();
+  });
+});

--- a/packages/swap/src/cli.ts
+++ b/packages/swap/src/cli.ts
@@ -70,6 +70,11 @@ interface CliRawConfig {
     }[]
   >;
   inventory?: Record<string, string | number>;
+  /**
+   * Issue #49 — per-chain in-flight window ceiling for the rolling path
+   * (rolling-swap §8). Same keying as `inventory`.
+   */
+  windowBudget?: Record<string, string | number>;
   relayUrls?: string[];
   blsPort?: number;
   btpServerPort?: number;
@@ -159,6 +164,16 @@ function parseRawConfig(raw: CliRawConfig): SwapNodeConfig {
     }
   }
 
+  // Normalize windowBudget (issue #49) — same shape/guards as inventory.
+  let windowBudget: Record<string, bigint> | undefined;
+  if (raw.windowBudget) {
+    windowBudget = Object.create(null) as Record<string, bigint>;
+    for (const [chain, amt] of Object.entries(raw.windowBudget)) {
+      assertSafeKey(chain, 'windowBudget');
+      windowBudget[chain] = toBigInt(amt);
+    }
+  }
+
   const cfg: SwapNodeConfig = {
     swapPairs: (raw.swapPairs as SwapNodeConfig['swapPairs']) ?? [],
     chains: (raw.chains as SwapNodeConfig['chains']) ?? [],
@@ -166,6 +181,7 @@ function parseRawConfig(raw: CliRawConfig): SwapNodeConfig {
     inventory,
     relayUrls: raw.relayUrls ?? [],
   };
+  if (windowBudget) cfg.windowBudget = windowBudget;
   if (raw.mnemonic) cfg.mnemonic = raw.mnemonic;
   if (raw.secretKey) {
     // Strict 64-char hex validation — `Buffer.from(str, 'hex')` silently

--- a/packages/swap/src/health.test.ts
+++ b/packages/swap/src/health.test.ts
@@ -228,3 +228,63 @@ describe('AC-1 inventoryAvailable field in /health', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #49 — /health three-bucket in-flight window view
+// ---------------------------------------------------------------------------
+
+describe('issue #49 inventoryWindow field in /health', () => {
+  it('[P1] reports budget / inFlight / unsettled / free per assetCode:chain pool, honoring windowBudget', async () => {
+    const { startSwapNode } = (await import('./swap-node.js')) as {
+      startSwapNode: (c: unknown) => Promise<{
+        blsPort: number;
+        stop: () => Promise<void>;
+      }>;
+    };
+    const instance = await startSwapNode({
+      ...validConfig(),
+      windowBudget: { 'evm:8453': 12_345n },
+    });
+    try {
+      const res = await fetch(`http://127.0.0.1:${instance.blsPort}/health`);
+      const body = (await res.json()) as {
+        inventoryWindow: Record<
+          string,
+          { budget: string; inFlight: string; unsettled: string; free: string }
+        >;
+      };
+      expect(body.inventoryWindow['USDC:evm:8453']).toEqual({
+        budget: '12345',
+        inFlight: '0',
+        unsettled: '0',
+        free: '12345',
+      });
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('[P1] without windowBudget the ceiling degrades to available', async () => {
+    const { startSwapNode } = (await import('./swap-node.js')) as {
+      startSwapNode: (c: unknown) => Promise<{
+        blsPort: number;
+        stop: () => Promise<void>;
+      }>;
+    };
+    const instance = await startSwapNode(validConfig());
+    try {
+      const res = await fetch(`http://127.0.0.1:${instance.blsPort}/health`);
+      const body = (await res.json()) as {
+        inventoryWindow: Record<string, { budget: string; free: string }>;
+      };
+      expect(body.inventoryWindow['USDC:evm:8453']!.budget).toBe(
+        '9007199254740993'
+      );
+      expect(body.inventoryWindow['USDC:evm:8453']!.free).toBe(
+        '9007199254740993'
+      );
+    } finally {
+      await instance.stop();
+    }
+  });
+});

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -10,9 +10,14 @@ export type {
   DeriveSwapNodeKeysInput,
 } from './wallet.js';
 
-// Inventory (Story 12.4)
-export { SwapInventory } from './inventory.js';
-export type { SwapInventoryBalance, SwapInventoryInit } from './inventory.js';
+// Inventory (Story 12.4; issue #49 in-flight window reservation lifecycle)
+export { SwapInventory, DEFAULT_RESERVATION_TTL_MS } from './inventory.js';
+export type {
+  SwapInventoryBalance,
+  SwapInventoryInit,
+  SwapInventoryReservation,
+  SwapWindowSnapshotEntry,
+} from './inventory.js';
 
 // Payment-channel signing (Story 12.4)
 export type {
@@ -43,6 +48,8 @@ export { MultiChainClaimIssuer } from './claim-issuer.js';
 export type {
   MultiChainClaimIssuerConfig,
   SwapClaimIssuerLogger,
+  IssueRollingClaimParams,
+  RollingIssueClaimResult,
 } from './claim-issuer.js';
 
 // State persistence (issue #46 — rolling-swap prerequisite P2)
@@ -60,6 +67,7 @@ export type {
   PersistedSwapState,
   PersistedInventoryEntry,
   PersistedChannelEntry,
+  PersistedReservationEntry,
 } from './state-store.js';
 
 // Errors (Story 12.4)
@@ -75,6 +83,7 @@ export type {
   SwapNodeConfig,
   SwapNodeInstance,
   SwapNodeHealthResponse,
+  SwapNodeHealthWindowEntry,
   SwapNodeLogger,
   Publisher,
 } from './swap-node.js';
@@ -123,6 +132,7 @@ export {
   DEFAULT_LEG_B_BUDGET_MS,
   DEFAULT_LEG_B_EXPIRY_MARGIN_MS,
   DEFAULT_MIN_LEG_B_TIME_MS,
+  DEFAULT_RESERVATION_GRACE_MS,
 } from './rolling-engine.js';
 export type {
   RollingSwapEngineConfig,

--- a/packages/swap/src/inventory.test.ts
+++ b/packages/swap/src/inventory.test.ts
@@ -242,3 +242,265 @@ describe('SwapInventory — in-memory per-pair reserves (Story 12.4 AC-4)', () =
     expect(sol?.chain).toBe('solana:mainnet');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #49 — in-flight window reservation lifecycle
+// ---------------------------------------------------------------------------
+
+describe('SwapInventory — in-flight window (issue #49)', () => {
+  const ASSET = 'ETH';
+  const CHAIN = 'evm:base:8453';
+  const KEY = `${ASSET}:${CHAIN}`;
+
+  function build(opts?: {
+    windowBudget?: bigint;
+    available?: bigint;
+    now?: () => number;
+    defaultReservationTtlMs?: number;
+  }) {
+    return new SwapInventory({
+      balances: {
+        [KEY]: {
+          available: opts?.available ?? 1_000n,
+          total: opts?.available ?? 1_000n,
+          ...(opts?.windowBudget !== undefined && {
+            windowBudget: opts.windowBudget,
+          }),
+        },
+      },
+      ...(opts?.now && { clock: opts.now }),
+      ...(opts?.defaultReservationTtlMs !== undefined && {
+        defaultReservationTtlMs: opts.defaultReservationTtlMs,
+      }),
+    });
+  }
+
+  function windowOf(inv: SwapInventory) {
+    return inv
+      .windowSnapshot()
+      .find((w) => w.assetCode === ASSET && w.chain === CHAIN)!;
+  }
+
+  it('[P0] reserve → commit lifecycle: capacity formula budget − inFlight − unsettled', () => {
+    const inv = build({ windowBudget: 100n });
+    const w0 = windowOf(inv);
+    expect(w0).toMatchObject({
+      budget: 100n,
+      inFlight: 0n,
+      unsettled: 0n,
+      free: 100n,
+    });
+
+    const { reservationId } = inv.reserve({
+      assetCode: ASSET,
+      chain: CHAIN,
+      amount: 60n,
+    });
+    expect(windowOf(inv)).toMatchObject({ inFlight: 60n, free: 40n });
+    // available untouched — reservations are not debits.
+    expect(inv.get(ASSET, CHAIN)!.available).toBe(1_000n);
+
+    expect(
+      inv.commitReservation({
+        reservationId,
+        assetCode: ASSET,
+        chain: CHAIN,
+        amount: 60n,
+      })
+    ).toBe('committed');
+    expect(windowOf(inv)).toMatchObject({
+      inFlight: 0n,
+      unsettled: 60n,
+      free: 40n,
+    });
+  });
+
+  it('[P0] capacity refusal: INSUFFICIENT_INVENTORY when the window cannot fit the amount', () => {
+    const inv = build({ windowBudget: 100n });
+    inv.reserve({ assetCode: ASSET, chain: CHAIN, amount: 80n });
+    expect(() =>
+      inv.reserve({ assetCode: ASSET, chain: CHAIN, amount: 30n })
+    ).toThrowError(SwapInventoryError);
+    try {
+      inv.reserve({ assetCode: ASSET, chain: CHAIN, amount: 30n });
+    } catch (err) {
+      expect((err as SwapInventoryError).code).toBe('INSUFFICIENT_INVENTORY');
+      expect((err as Error).message).toMatch(/window capacity/);
+    }
+    // Non-positive amounts and unknown pools are rejected.
+    expect(() =>
+      inv.reserve({ assetCode: ASSET, chain: CHAIN, amount: 0n })
+    ).toThrowError(/positive/);
+    expect(() =>
+      inv.reserve({ assetCode: 'BTC', chain: CHAIN, amount: 1n })
+    ).toThrowError(/not initialized/);
+  });
+
+  it('[P0] the effective budget is clamped to available (a budget cannot advertise capital the maker lacks; legacy debits shrink it)', () => {
+    const inv = build({ windowBudget: 5_000n, available: 1_000n });
+    expect(windowOf(inv).budget).toBe(1_000n);
+    // A legacy permanent debit shrinks the rolling ceiling too.
+    inv.debit(ASSET, CHAIN, 400n);
+    expect(windowOf(inv).budget).toBe(600n);
+    expect(() =>
+      inv.reserve({ assetCode: ASSET, chain: CHAIN, amount: 601n })
+    ).toThrowError(/window capacity/);
+    // Absent windowBudget → ceiling degrades to available.
+    const noBudget = build();
+    expect(windowOf(noBudget).budget).toBe(1_000n);
+  });
+
+  it('[P0] TTL expiry frees a stalled reservation slot', () => {
+    let now = 0;
+    const inv = build({ windowBudget: 100n, now: () => now });
+    inv.reserve({
+      assetCode: ASSET,
+      chain: CHAIN,
+      amount: 100n,
+      ttlMs: 500,
+      id: 'stalled',
+    });
+    expect(() =>
+      inv.reserve({ assetCode: ASSET, chain: CHAIN, amount: 1n })
+    ).toThrowError(/window capacity/);
+    now = 501;
+    expect(windowOf(inv).inFlight).toBe(0n);
+    expect(
+      inv.reserve({ assetCode: ASSET, chain: CHAIN, amount: 100n })
+        .reservationId
+    ).toBeTruthy();
+    // The expired reservation is gone: releasing it reports false.
+    expect(inv.releaseReservation('stalled')).toBe(false);
+  });
+
+  it('[P0] releaseReservation is exactly-once', () => {
+    const inv = build();
+    const { reservationId } = inv.reserve({
+      assetCode: ASSET,
+      chain: CHAIN,
+      amount: 10n,
+    });
+    expect(inv.releaseReservation(reservationId)).toBe(true);
+    expect(inv.releaseReservation(reservationId)).toBe(false);
+    expect(windowOf(inv).inFlight).toBe(0n);
+  });
+
+  it('[P1] recordSettlement: monotone per channel, clamps to unsettled, recycles capacity', () => {
+    const inv = build({ windowBudget: 100n });
+    const { reservationId } = inv.reserve({
+      assetCode: ASSET,
+      chain: CHAIN,
+      amount: 100n,
+    });
+    inv.commitReservation({
+      reservationId,
+      assetCode: ASSET,
+      chain: CHAIN,
+      amount: 100n,
+    });
+    expect(windowOf(inv).free).toBe(0n);
+
+    // Partial settlement (cumulative watermark 40).
+    expect(
+      inv.recordSettlement({
+        assetCode: ASSET,
+        chain: CHAIN,
+        channelId: 'chan-1',
+        cumulativeAmount: 40n,
+      })
+    ).toBe(40n);
+    expect(windowOf(inv)).toMatchObject({ unsettled: 60n, free: 40n });
+
+    // Replay / stale confirmation → 0n no-op.
+    expect(
+      inv.recordSettlement({
+        assetCode: ASSET,
+        chain: CHAIN,
+        channelId: 'chan-1',
+        cumulativeAmount: 40n,
+      })
+    ).toBe(0n);
+    expect(
+      inv.recordSettlement({
+        assetCode: ASSET,
+        chain: CHAIN,
+        channelId: 'chan-1',
+        cumulativeAmount: 30n,
+      })
+    ).toBe(0n);
+    expect(windowOf(inv).unsettled).toBe(60n);
+
+    // Over-settlement (delta beyond liability) clamps at zero.
+    expect(
+      inv.recordSettlement({
+        assetCode: ASSET,
+        chain: CHAIN,
+        channelId: 'chan-1',
+        cumulativeAmount: 500n,
+      })
+    ).toBe(60n);
+    expect(windowOf(inv)).toMatchObject({ unsettled: 0n, free: 100n });
+  });
+
+  it('[P1] reservations + watermarks + unsettled round-trip through snapshots (rehydration)', () => {
+    let now = 1_000;
+    const inv = build({ windowBudget: 100n, now: () => now });
+    inv.reserve({
+      assetCode: ASSET,
+      chain: CHAIN,
+      amount: 25n,
+      ttlMs: 60_000,
+      id: 'live-1',
+    });
+    const c = inv.reserve({
+      assetCode: ASSET,
+      chain: CHAIN,
+      amount: 30n,
+    });
+    inv.commitReservation({
+      reservationId: c.reservationId,
+      assetCode: ASSET,
+      chain: CHAIN,
+      amount: 30n,
+    });
+    inv.recordSettlement({
+      assetCode: ASSET,
+      chain: CHAIN,
+      channelId: 'chan-9',
+      cumulativeAmount: 10n,
+    });
+
+    const rehydrated = new SwapInventory({
+      balances: Object.fromEntries(
+        inv.snapshot().map((b) => [
+          `${b.assetCode}:${b.chain}`,
+          {
+            available: b.available,
+            total: b.total,
+            unsettled: b.unsettled,
+            ...(b.windowBudget !== undefined && {
+              windowBudget: b.windowBudget,
+            }),
+            updatedAt: b.updatedAt,
+          },
+        ])
+      ),
+      reservations: inv.reservationsSnapshot(),
+      settledWatermarks: inv.settledWatermarksSnapshot(),
+      clock: () => now,
+    });
+    expect(windowOf(rehydrated)).toEqual(windowOf(inv));
+    // Watermark monotonicity survives: the replayed confirmation stays a no-op.
+    expect(
+      rehydrated.recordSettlement({
+        assetCode: ASSET,
+        chain: CHAIN,
+        channelId: 'chan-9',
+        cumulativeAmount: 10n,
+      })
+    ).toBe(0n);
+    // Expire-and-release applies to rehydrated reservations too.
+    now = 1_000 + 60_001;
+    expect(windowOf(rehydrated).inFlight).toBe(0n);
+  });
+});

--- a/packages/swap/src/inventory.ts
+++ b/packages/swap/src/inventory.ts
@@ -1,9 +1,50 @@
 /**
- * `SwapInventory` — in-memory per-pair reserves (Story 12.4 AC-4).
+ * `SwapInventory` — per-pair reserves + in-flight window reservations.
  *
- * Single-threaded microtask atomicity: `debit` / `credit` are synchronous and
+ * Single-threaded microtask atomicity: every mutator is synchronous and
  * therefore atomic w.r.t. concurrent `issueClaim` callers under `Promise.all`.
  * See Dev Notes "Microtask atomicity argument" in the story doc.
+ *
+ * ## Two capital models on one surface (issue #49)
+ *
+ * - **Legacy (gift-wrap path): permanent debit/credit.** `debit` consumes
+ *   `available` for good; `credit` is the operator refill / rollback.
+ *   Unchanged since Story 12.4.
+ * - **Rolling path (toon-meta#145 / rolling-swap.md §8): the in-flight
+ *   window reservation lifecycle.** A fill packet `reserve`s its leg-B
+ *   amount while the packet is in flight, then either
+ *   - **commits** (leg B fulfilled → the amount becomes *unsettled channel
+ *     liability*, shrunk later by on-chain settlement confirmations via
+ *     {@link recordSettlement}), or
+ *   - **releases** (reject / rollback / TTL expiry → capacity returns).
+ *
+ *   Nothing on the rolling path ever debits `available` permanently: what
+ *   was a notional-sized pre-fund becomes working capital cycling through
+ *   settlement (spec §8 "settle-and-recycle replaces manual refill").
+ *
+ * ## Capacity formula (spec §8)
+ *
+ * ```
+ * effectiveBudget = min(windowBudget ?? available, available)
+ * free            = effectiveBudget − inFlight − unsettled
+ * ```
+ *
+ * `windowBudget` is the operator-advertised in-flight ceiling (δ_max·W_max·R
+ * plus a settlement-latency buffer). It is clamped to `available` so a
+ * misconfigured budget can never advertise capital the maker does not hold,
+ * and legacy debits (which shrink `available`) shrink rolling capacity too —
+ * both paths compete for the same real pool. Without an explicit budget the
+ * ceiling degrades to `available` (no worse than the pre-#49 notional check).
+ *
+ * ## Reservation TTLs
+ *
+ * Every reservation carries an expiry. The rolling engine sizes it to its
+ * leg-B round-trip budget plus a grace margin (spec R7 alignment), so a
+ * crashed or stalled packet frees its window slot once the packet could not
+ * possibly fulfill anymore. Expired reservations are pruned lazily on every
+ * window operation; a commit that arrives after its reservation expired is
+ * still recorded as liability (`'late'`) — an already-revealed claim must
+ * never be under-counted just because the clock ran out.
  */
 
 import { SwapInventoryError } from './errors.js';
@@ -13,21 +54,83 @@ export interface SwapInventoryBalance {
   chain: string;
   available: bigint;
   total: bigint;
+  /** Committed-but-unsettled channel liability (rolling path). */
+  unsettled: bigint;
+  /** Operator-configured in-flight window ceiling (absent → `available`). */
+  windowBudget?: bigint;
   updatedAt: number;
+}
+
+/** One (assetCode, chain) row of the three-bucket window view (spec §8). */
+export interface SwapWindowSnapshotEntry {
+  assetCode: string;
+  chain: string;
+  /** Effective ceiling: `min(windowBudget ?? available, available)`. */
+  budget: bigint;
+  /** Σ live (unexpired) reservations. */
+  inFlight: bigint;
+  /** Committed liability awaiting on-chain settlement confirmation. */
+  unsettled: bigint;
+  /** `budget − inFlight − unsettled` (clamped at 0). */
+  free: bigint;
+  updatedAt: number;
+}
+
+export interface SwapInventoryReservation {
+  /** `${assetCode}:${chain}` of the reserved pool. */
+  key: string;
+  amount: bigint;
+  /** ms-epoch after which the reservation no longer occupies the window. */
+  expiresAt: number;
 }
 
 export interface SwapInventoryInit {
   balances: Record<
     string,
     /** `updatedAt` — issue #46: preserved on rehydration from a persisted snapshot; defaults to `clock()` when omitted. */
-    { available: bigint; total: bigint; updatedAt?: number }
+    {
+      available: bigint;
+      total: bigint;
+      updatedAt?: number;
+      /** Issue #49 — in-flight window ceiling (operator config; config wins over snapshots). */
+      windowBudget?: bigint;
+      /** Issue #49 — rehydrated unsettled liability. Defaults to 0n. */
+      unsettled?: bigint;
+    }
   >;
+  /**
+   * Issue #49 — rehydrated in-flight reservations (keyed by reservation id).
+   * Crash-recovery rule: rehydrated reservations are honored until their
+   * persisted `expiresAt` and then expire-and-release — no engine survives a
+   * restart to commit them, so the TTL frees the leaked capacity while the
+   * write-ahead channel watermark (which never regresses) prevents any
+   * double-spend. See `state-store.ts` crash rule 6.
+   */
+  reservations?: Record<string, SwapInventoryReservation>;
+  /**
+   * Issue #49 — highest settled cumulative watermark per
+   * `${assetCode}:${chain}:${channelId}`, so replayed / out-of-order
+   * settlement confirmations cannot double-shrink the liability.
+   */
+  settledWatermarks?: Record<string, bigint>;
+  /** Fallback reservation TTL when `reserve()` gets no explicit `ttlMs`. */
+  defaultReservationTtlMs?: number;
   clock?: () => number;
 }
+
+/**
+ * Default reservation TTL: 2× the engine's default leg-B budget
+ * (`DEFAULT_LEG_B_BUDGET_MS` = 30s) — generous enough that no live packet's
+ * reservation can expire under it, small enough that a crashed packet frees
+ * its slot within a minute.
+ */
+export const DEFAULT_RESERVATION_TTL_MS = 60_000;
 
 interface InternalEntry {
   available: bigint;
   total: bigint;
+  unsettled: bigint;
+  windowBudget?: bigint;
   updatedAt: number;
 }
 
@@ -44,19 +147,55 @@ function parseKey(k: string): { assetCode: string; chain: string } {
   return { assetCode: k.slice(0, i), chain: k.slice(i + 1) };
 }
 
+function newReservationId(): string {
+  const c = globalThis.crypto as { randomUUID?: () => string } | undefined;
+  if (c && typeof c.randomUUID === 'function') return c.randomUUID();
+  return `rsv_${Date.now().toString(36)}_${Math.floor(
+    Math.random() * 1e9
+  ).toString(36)}`;
+}
+
 export class SwapInventory {
   private readonly entries = new Map<string, InternalEntry>();
+  /** reservation id → live reservation (pruned lazily on window ops). */
+  private readonly reservations = new Map<string, SwapInventoryReservation>();
+  /** `${assetCode}:${chain}:${channelId}` → highest settled cumulative. */
+  private readonly settledWatermarks = new Map<string, bigint>();
+  private readonly defaultReservationTtlMs: number;
   private readonly clock: () => number;
 
   constructor(init: SwapInventoryInit) {
     this.clock = init.clock ?? Date.now;
+    this.defaultReservationTtlMs =
+      init.defaultReservationTtlMs ?? DEFAULT_RESERVATION_TTL_MS;
+    if (
+      !Number.isFinite(this.defaultReservationTtlMs) ||
+      this.defaultReservationTtlMs <= 0
+    ) {
+      throw new SwapInventoryError(
+        'UNKNOWN_PAIR',
+        'defaultReservationTtlMs must be a positive number'
+      );
+    }
     const now = this.clock();
     for (const [k, v] of Object.entries(init.balances)) {
       this.entries.set(k, {
         available: v.available,
         total: v.total,
+        unsettled: v.unsettled ?? 0n,
+        ...(v.windowBudget !== undefined && { windowBudget: v.windowBudget }),
         updatedAt: v.updatedAt ?? now,
       });
+    }
+    if (init.reservations) {
+      for (const [id, r] of Object.entries(init.reservations)) {
+        this.reservations.set(id, { ...r });
+      }
+    }
+    if (init.settledWatermarks) {
+      for (const [k, v] of Object.entries(init.settledWatermarks)) {
+        this.settledWatermarks.set(k, v);
+      }
     }
   }
 
@@ -68,6 +207,8 @@ export class SwapInventory {
       chain,
       available: e.available,
       total: e.total,
+      unsettled: e.unsettled,
+      ...(e.windowBudget !== undefined && { windowBudget: e.windowBudget }),
       updatedAt: e.updatedAt,
     };
   }
@@ -75,6 +216,11 @@ export class SwapInventory {
   /**
    * Atomically debit `amount` from `(assetCode, chain).available`.
    * Synchronous — no `await` — so concurrent callers see a consistent view.
+   *
+   * LEGACY PATH ONLY (permanent spend). The rolling engine uses
+   * {@link reserve} / {@link commitReservation} / {@link releaseReservation}
+   * instead — issue #49 AC: no permanent-debit path remains on the
+   * rolling-engine flow.
    */
   debit(assetCode: string, chain: string, amount: bigint): void {
     if (amount <= 0n) {
@@ -124,6 +270,7 @@ export class SwapInventory {
       this.entries.set(k, {
         available: amount,
         total: amount,
+        unsettled: 0n,
         updatedAt: now,
       });
       return;
@@ -131,6 +278,204 @@ export class SwapInventory {
     entry.available += amount;
     entry.total += amount;
     entry.updatedAt = now;
+  }
+
+  // -------------------------------------------------------------------------
+  // Issue #49 — in-flight window reservation lifecycle
+  // -------------------------------------------------------------------------
+
+  /**
+   * Reserve `amount` of the (assetCode, chain) in-flight window for one
+   * packet. Throws `SwapInventoryError('INSUFFICIENT_INVENTORY')` when the
+   * window has no free capacity (`free = effectiveBudget − inFlight −
+   * unsettled`) — callers map this to the same benign T04 refusal as a
+   * notional shortage.
+   *
+   * Synchronous → microtask atomic; expired reservations are pruned first,
+   * so a stalled packet's slot is reusable the instant its TTL lapses.
+   */
+  reserve(p: {
+    assetCode: string;
+    chain: string;
+    amount: bigint;
+    /** Reservation lifetime; defaults to `defaultReservationTtlMs`. */
+    ttlMs?: number;
+    /** Caller-supplied id (tests); defaults to a random UUID. */
+    id?: string;
+  }): { reservationId: string; expiresAt: number } {
+    if (p.amount <= 0n) {
+      throw new SwapInventoryError(
+        'INSUFFICIENT_INVENTORY',
+        'Reservation amount must be positive'
+      );
+    }
+    const k = key(p.assetCode, p.chain);
+    const entry = this.entries.get(k);
+    if (!entry) {
+      throw new SwapInventoryError(
+        'INVENTORY_NOT_INITIALIZED',
+        `Inventory not initialized for ${k}`
+      );
+    }
+    const now = this.clock();
+    this.pruneExpired(now);
+    const free = this.freeCapacity(k, entry);
+    if (free < p.amount) {
+      throw new SwapInventoryError(
+        'INSUFFICIENT_INVENTORY',
+        `Insufficient in-flight window capacity for ${k}: free ${free}, need ${p.amount}`
+      );
+    }
+    const ttlMs = p.ttlMs ?? this.defaultReservationTtlMs;
+    if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+      throw new SwapInventoryError(
+        'UNKNOWN_PAIR',
+        'Reservation ttlMs must be a positive number'
+      );
+    }
+    const reservationId = p.id ?? newReservationId();
+    if (this.reservations.has(reservationId)) {
+      throw new SwapInventoryError(
+        'UNKNOWN_PAIR',
+        `Duplicate reservation id ${reservationId}`
+      );
+    }
+    this.reservations.set(reservationId, {
+      key: k,
+      amount: p.amount,
+      expiresAt: now + ttlMs,
+    });
+    entry.updatedAt = now;
+    return { reservationId, expiresAt: now + ttlMs };
+  }
+
+  /**
+   * Convert a reservation into unsettled channel liability (leg B fulfilled;
+   * the counterparty now holds a redeemable claim). Returns `'committed'`
+   * normally, or `'late'` when the reservation had already TTL-expired —
+   * the liability is recorded anyway (transiently exceeding the window
+   * budget) because a revealed claim exists regardless of the local clock.
+   */
+  commitReservation(p: {
+    reservationId: string;
+    assetCode: string;
+    chain: string;
+    amount: bigint;
+  }): 'committed' | 'late' {
+    const k = key(p.assetCode, p.chain);
+    const entry = this.entries.get(k);
+    if (!entry) {
+      throw new SwapInventoryError(
+        'INVENTORY_NOT_INITIALIZED',
+        `Inventory not initialized for ${k}`
+      );
+    }
+    const now = this.clock();
+    const r = this.reservations.get(p.reservationId);
+    if (r) {
+      this.reservations.delete(p.reservationId);
+      entry.unsettled += r.amount;
+      entry.updatedAt = now;
+      return 'committed';
+    }
+    entry.unsettled += p.amount;
+    entry.updatedAt = now;
+    return 'late';
+  }
+
+  /**
+   * Release a reservation (reject / rollback / recovery). Exactly-once:
+   * returns `true` only for the call that actually removed it; subsequent
+   * calls (or a release racing a TTL prune) return `false` and change
+   * nothing.
+   */
+  releaseReservation(reservationId: string): boolean {
+    const r = this.reservations.get(reservationId);
+    if (!r) return false;
+    this.reservations.delete(reservationId);
+    const entry = this.entries.get(r.key);
+    if (entry) entry.updatedAt = this.clock();
+    return true;
+  }
+
+  /**
+   * Apply an on-chain settlement confirmation: liability shrinks by the
+   * watermark delta (`cumulativeAmount − lastSettled(channel)`), clamped to
+   * the current unsettled bucket. Monotone per channel — a stale or replayed
+   * confirmation (cumulative ≤ last settled) is a no-op returning 0n.
+   *
+   * Freed liability recycles into window capacity automatically
+   * (`free = budget − inFlight − unsettled`): spec §8 settle-and-recycle.
+   */
+  recordSettlement(p: {
+    assetCode: string;
+    chain: string;
+    channelId: string;
+    cumulativeAmount: bigint;
+  }): bigint {
+    const k = key(p.assetCode, p.chain);
+    const entry = this.entries.get(k);
+    if (!entry) {
+      throw new SwapInventoryError(
+        'INVENTORY_NOT_INITIALIZED',
+        `Inventory not initialized for ${k}`
+      );
+    }
+    const wmKey = `${k}:${p.channelId}`;
+    const last = this.settledWatermarks.get(wmKey) ?? 0n;
+    if (p.cumulativeAmount <= last) return 0n;
+    this.settledWatermarks.set(wmKey, p.cumulativeAmount);
+    const delta = p.cumulativeAmount - last;
+    const reduced = delta < entry.unsettled ? delta : entry.unsettled;
+    entry.unsettled -= reduced;
+    entry.updatedAt = this.clock();
+    return reduced;
+  }
+
+  /** Three-bucket window view per (assetCode, chain) — spec §8 / health. */
+  windowSnapshot(): readonly SwapWindowSnapshotEntry[] {
+    this.pruneExpired(this.clock());
+    const out: SwapWindowSnapshotEntry[] = [];
+    for (const [k, e] of this.entries.entries()) {
+      const { assetCode, chain } = parseKey(k);
+      const budget = this.effectiveBudget(e);
+      const inFlight = this.inFlight(k);
+      const spoken = inFlight + e.unsettled;
+      out.push({
+        assetCode,
+        chain,
+        budget,
+        inFlight,
+        unsettled: e.unsettled,
+        free: spoken >= budget ? 0n : budget - spoken,
+        updatedAt: e.updatedAt,
+      });
+    }
+    return out;
+  }
+
+  /** Live (unexpired) reservations, for persistence. */
+  reservationsSnapshot(): Record<string, SwapInventoryReservation> {
+    this.pruneExpired(this.clock());
+    const out: Record<string, SwapInventoryReservation> = Object.create(
+      null
+    ) as Record<string, SwapInventoryReservation>;
+    for (const [id, r] of this.reservations) {
+      out[id] = { ...r };
+    }
+    return out;
+  }
+
+  /** Per-channel settled cumulative watermarks, for persistence. */
+  settledWatermarksSnapshot(): Record<string, bigint> {
+    const out: Record<string, bigint> = Object.create(null) as Record<
+      string,
+      bigint
+    >;
+    for (const [k, v] of this.settledWatermarks) {
+      out[k] = v;
+    }
+    return out;
   }
 
   snapshot(): readonly SwapInventoryBalance[] {
@@ -142,9 +487,36 @@ export class SwapInventory {
         chain,
         available: e.available,
         total: e.total,
+        unsettled: e.unsettled,
+        ...(e.windowBudget !== undefined && { windowBudget: e.windowBudget }),
         updatedAt: e.updatedAt,
       });
     }
     return out;
+  }
+
+  private effectiveBudget(e: InternalEntry): bigint {
+    if (e.windowBudget === undefined) return e.available;
+    return e.windowBudget < e.available ? e.windowBudget : e.available;
+  }
+
+  private freeCapacity(k: string, e: InternalEntry): bigint {
+    const budget = this.effectiveBudget(e);
+    const spoken = this.inFlight(k) + e.unsettled;
+    return spoken >= budget ? 0n : budget - spoken;
+  }
+
+  private inFlight(k: string): bigint {
+    let sum = 0n;
+    for (const r of this.reservations.values()) {
+      if (r.key === k) sum += r.amount;
+    }
+    return sum;
+  }
+
+  private pruneExpired(now: number): void {
+    for (const [id, r] of this.reservations) {
+      if (r.expiresAt <= now) this.reservations.delete(id);
+    }
   }
 }

--- a/packages/swap/src/rolling-engine.test.ts
+++ b/packages/swap/src/rolling-engine.test.ts
@@ -15,7 +15,7 @@
  *     safe state (state-store crash rules 2/4)
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { sha256 } from '@noble/hashes/sha2.js';
 import type { SwapPair } from '@toon-protocol/core';
 
@@ -151,6 +151,9 @@ function buildStack(options?: {
   minLegBTimeMs?: number;
   legBExpiryMarginMs?: number;
   legBBudgetMs?: number;
+  reservationGraceMs?: number;
+  /** Issue #49 — in-flight window ceiling for the fixture pool. */
+  windowBudget?: bigint;
 }): Stack {
   const persisted = options?.rehydrateFrom ?? null;
 
@@ -159,15 +162,42 @@ function buildStack(options?: {
       ? Object.fromEntries(
           Object.entries(persisted.inventory).map(([k, v]) => [
             k,
-            { available: BigInt(v.available), total: BigInt(v.total) },
+            {
+              available: BigInt(v.available),
+              total: BigInt(v.total),
+              unsettled: BigInt(v.unsettled ?? '0'),
+              ...(options?.windowBudget !== undefined && {
+                windowBudget: options.windowBudget,
+              }),
+            },
           ])
         )
       : {
           [INVENTORY_KEY]: {
             available: INITIAL_INVENTORY,
             total: INITIAL_INVENTORY,
+            ...(options?.windowBudget !== undefined && {
+              windowBudget: options.windowBudget,
+            }),
           },
         },
+    // Issue #49 — rehydrate in-flight reservations + settled watermarks
+    // exactly as startSwapNode does (expire-and-release recovery).
+    ...(persisted && {
+      reservations: Object.fromEntries(
+        Object.entries(persisted.reservations).map(([id, r]) => [
+          id,
+          { key: r.key, amount: BigInt(r.amount), expiresAt: r.expiresAt },
+        ])
+      ),
+      settledWatermarks: Object.fromEntries(
+        Object.entries(persisted.settledWatermarks).map(([k, v]) => [
+          k,
+          BigInt(v),
+        ])
+      ),
+    }),
+    ...(options?.now && { clock: options.now }),
   });
   const channelState = new SwapChannelState({
     channels: persisted
@@ -263,6 +293,9 @@ function buildStack(options?: {
     ...(options?.legBBudgetMs !== undefined && {
       legBBudgetMs: options.legBBudgetMs,
     }),
+    ...(options?.reservationGraceMs !== undefined && {
+      reservationGraceMs: options.reservationGraceMs,
+    }),
   });
 
   return {
@@ -274,6 +307,14 @@ function buildStack(options?: {
     saved: () => savedState,
     legB,
   };
+}
+
+function windowOf(stack: Stack) {
+  const w = stack.inventory
+    .windowSnapshot()
+    .find((e) => e.assetCode === ASSET && e.chain === CHAIN);
+  expect(w).toBeDefined();
+  return w!;
 }
 
 function stackPreimages(stack: Stack): Map<string, Uint8Array> {
@@ -401,10 +442,15 @@ describe('rolling engine — coupled happy path', () => {
       expect(JSON.stringify(record)).not.toContain(advance.claim);
     }
 
-    // State: debit + watermark advance stand.
+    // State (issue #49): NO permanent debit — the fulfilled fill's amount
+    // moved reservation → unsettled liability; available is untouched.
     expect(stack.inventory.get(ASSET, CHAIN)!.available).toBe(
-      INITIAL_INVENTORY - TARGET_PER_DELTA
+      INITIAL_INVENTORY
     );
+    const w = windowOf(stack);
+    expect(w.inFlight).toBe(0n);
+    expect(w.unsettled).toBe(TARGET_PER_DELTA);
+    expect(w.free).toBe(INITIAL_INVENTORY - TARGET_PER_DELTA);
     const entry = stack.channelState.get({
       assetCode: ASSET,
       chain: CHAIN,
@@ -465,10 +511,15 @@ describe('rolling engine — maker cannot collect leg A while withholding leg B'
     // Contract: the connector records nothing for a reject.
     expect(connectorEnforce(response, condition).delivered).toBe(false);
 
-    // AC-4: the failed packet fully unwound inventory + channel reservation.
+    // AC-4: the failed packet fully unwound the window reservation +
+    // channel reservation — released, not converted (issue #49).
     expect(stack.inventory.get(ASSET, CHAIN)!.available).toBe(
       INITIAL_INVENTORY
     );
+    const wUnwound = windowOf(stack);
+    expect(wUnwound.inFlight).toBe(0n);
+    expect(wUnwound.unsettled).toBe(0n);
+    expect(wUnwound.free).toBe(INITIAL_INVENTORY);
     const entry = stack.channelState.get({
       assetCode: ASSET,
       chain: CHAIN,
@@ -495,6 +546,7 @@ describe('rolling engine — maker cannot collect leg A while withholding leg B'
     expect(stack.inventory.get(ASSET, CHAIN)!.available).toBe(
       INITIAL_INVENTORY
     );
+    expect(windowOf(stack).free).toBe(INITIAL_INVENTORY);
 
     // Byzantine-maker simulation: even if a maker implementation tried to
     // accept anyway (with the wrong preimage, or none), the connector's
@@ -681,9 +733,10 @@ describe('rolling engine — guards', () => {
     );
   });
 
-  it('insufficient inventory → T04 insufficient_funds, replay seq burned', async () => {
+  it('insufficient window capacity → T04 insufficient_funds, replay seq burned', async () => {
     const stack = buildStack();
-    // 1 ETH inventory; ask for a fill needing 4000 ETH (10^7 USDC * 0.0004).
+    // 1 ETH window (no explicit budget → ceiling degrades to available);
+    // ask for a fill needing 4000 ETH (10^7 USDC * 0.0004).
     const { response } = await sendFill(stack, 1, {
       amount: (10n ** 13n).toString(),
     });
@@ -704,14 +757,16 @@ describe('rolling engine — guards', () => {
 // Crash consistency (state-store rules 1/2/4)
 // ---------------------------------------------------------------------------
 
-describe('rolling engine — crash between debit and fulfill', () => {
-  it('persisted snapshot at leg-B time is the safe state; restart continues monotonically and rejects the replay', async () => {
-    const stack = buildStack();
+describe('rolling engine — crash between reservation and fulfill', () => {
+  it('persisted snapshot at leg-B time is the safe state; recovery expires-and-releases the reservation with no leaked capacity and no double-spend', async () => {
+    let now = 1_700_000_000_000;
+    const stack = buildStack({ now: () => now });
     let crashSnapshot: PersistedSwapState | null = null;
     stack.legB.respond = () => {
       // The instant leg B is in flight IS the crash window: the write-ahead
-      // persist has already happened (crash rule 1). Capture disk state,
-      // then die before any response/unwind.
+      // persist has already happened (crash rule 1 — the reservation is
+      // durable BEFORE the leg-B advance is externalized). Capture disk
+      // state, then die before any response/unwind.
       crashSnapshot = structuredClone(stack.saved());
       throw new Error('simulated crash');
     };
@@ -719,24 +774,44 @@ describe('rolling engine — crash between debit and fulfill', () => {
 
     expect(crashSnapshot).not.toBeNull();
     const snap = crashSnapshot! as PersistedSwapState;
-    // Watermark advanced + inventory debited + replay seq reserved — all
-    // BEFORE the claim could have left the process.
+    // Watermark advanced + window RESERVED (not debited — issue #49) +
+    // replay seq reserved — all BEFORE the claim could have left the process.
     expect(snap.channels[CHANNEL_KEY]!.nonce).toBe('1');
     expect(snap.channels[CHANNEL_KEY]!.cumulativeAmount).toBe(
       TARGET_PER_DELTA.toString()
     );
     expect(BigInt(snap.inventory[INVENTORY_KEY]!.available)).toBe(
-      INITIAL_INVENTORY - TARGET_PER_DELTA
+      INITIAL_INVENTORY
     );
+    expect(snap.inventory[INVENTORY_KEY]!.unsettled).toBe('0');
+    const persistedReservations = Object.values(snap.reservations);
+    expect(persistedReservations).toHaveLength(1);
+    expect(persistedReservations[0]!.key).toBe(INVENTORY_KEY);
+    expect(persistedReservations[0]!.amount).toBe(TARGET_PER_DELTA.toString());
     expect(snap.seenPacketIds).toContain(`rolling:${STREAM_NONCE}:1`);
 
     // "Reboot" from the crash snapshot.
-    const rebooted = buildStack({ rehydrateFrom: snap });
+    const rebooted = buildStack({ rehydrateFrom: snap, now: () => now });
 
-    // Replay of the aborted fill → F04 (crash rule 4, fail-closed).
+    // Until its TTL, the rehydrated reservation still occupies the window
+    // (conservative: the crashed packet is treated as possibly live).
+    const before = windowOf(rebooted);
+    expect(before.inFlight).toBe(TARGET_PER_DELTA);
+    expect(before.free).toBe(INITIAL_INVENTORY - TARGET_PER_DELTA);
+
+    // Replay of the aborted fill → F04 (crash rule 4, fail-closed) — the
+    // no-double-spend half of recovery.
     const replay = await sendFill(rebooted, 1);
     expect(replay.response.accept).toBe(false);
     if (!replay.response.accept) expect(replay.response.code).toBe('F04');
+
+    // Past the persisted expiry, the reservation expires-and-releases
+    // (crash rule 6) — the no-leaked-capacity half of recovery.
+    now = persistedReservations[0]!.expiresAt + 1;
+    const after = windowOf(rebooted);
+    expect(after.inFlight).toBe(0n);
+    expect(after.unsettled).toBe(0n);
+    expect(after.free).toBe(INITIAL_INVENTORY);
 
     // The next fill continues ABOVE the aborted reservation (crash rule 2):
     // nonce 2, cumulative stacked on the aborted watermark — never behind
@@ -746,6 +821,168 @@ describe('rolling engine — crash between debit and fulfill', () => {
     const advance = decodeAdvance(rebooted.legB.received[0]!);
     expect(advance.nonce).toBe('2');
     expect(advance.cumulativeAmount).toBe((TARGET_PER_DELTA * 2n).toString());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #49 — in-flight window: capacity, TTL alignment, settle-and-recycle
+// ---------------------------------------------------------------------------
+
+describe('rolling engine — in-flight window (issue #49)', () => {
+  it('window budget exhausted by in-flight packets → benign T04 insufficient_liquidity; releases restore capacity', async () => {
+    // Budget = exactly 2 packets. Hold two fills in flight (leg B pending).
+    const stack = buildStack({
+      windowBudget: TARGET_PER_DELTA * 2n,
+      rateProvider: () => ({ rate: '0.0004', at: Date.now() }),
+    });
+    const preimages = stackPreimages(stack);
+    const resolvers: (() => void)[] = [];
+    stack.legB.respond = (prepare) =>
+      new Promise<LegBResult>((resolve) => {
+        resolvers.push(() => {
+          const key = Buffer.from(prepare.executionCondition).toString(
+            'base64'
+          );
+          resolve({ type: 'fulfill', fulfillment: preimages.get(key)! });
+        });
+      });
+
+    const fill1 = sendFill(stack, 1);
+    const fill2 = sendFill(stack, 2);
+    // Let both fills reach the leg-B await (claim signing is async).
+    await vi.waitFor(() =>
+      expect(windowOf(stack).inFlight).toBe(TARGET_PER_DELTA * 2n)
+    );
+    expect(windowOf(stack).free).toBe(0n);
+
+    // Third fill exceeds the window → benign capacity refusal (same T04
+    // vocabulary as a reserves shortage), nothing new in flight.
+    stack.legB.respond = () => {
+      throw new Error('leg B must not be attempted for a refused fill');
+    };
+    const refused = await sendFill(stack, 3);
+    expect(refused.response.accept).toBe(false);
+    if (!refused.response.accept) {
+      expect(refused.response.code).toBe('T04');
+      expect(refused.response.rejectReason.code).toBe('insufficient_funds');
+      expect(decodeRejectData(refused.response.data)['reason']).toBe(
+        ROLLING_REJECT_REASONS.INSUFFICIENT_LIQUIDITY
+      );
+    }
+    expect(windowOf(stack).inFlight).toBe(TARGET_PER_DELTA * 2n);
+
+    // Resolve the held packets → reservations convert to unsettled.
+    for (const r of resolvers) r();
+    const [r1, r2] = await Promise.all([fill1, fill2]);
+    expect(r1.response.accept).toBe(true);
+    expect(r2.response.accept).toBe(true);
+    const w = windowOf(stack);
+    expect(w.inFlight).toBe(0n);
+    expect(w.unsettled).toBe(TARGET_PER_DELTA * 2n);
+    expect(w.free).toBe(0n);
+
+    // Settlement confirmation recycles the capacity (settle-and-recycle).
+    const reduced = stack.inventory.recordSettlement({
+      assetCode: ASSET,
+      chain: CHAIN,
+      channelId: CHANNEL_ID,
+      cumulativeAmount: TARGET_PER_DELTA * 2n,
+    });
+    expect(reduced).toBe(TARGET_PER_DELTA * 2n);
+    const settled = windowOf(stack);
+    expect(settled.unsettled).toBe(0n);
+    expect(settled.free).toBe(TARGET_PER_DELTA * 2n);
+    stack.legB.respond = (prepare) => {
+      const key = Buffer.from(prepare.executionCondition).toString('base64');
+      return { type: 'fulfill', fulfillment: preimages.get(key)! };
+    };
+    const retry = await sendFill(stack, 4);
+    expect(retry.response.accept).toBe(true);
+  });
+
+  it('reservation TTL is aligned with the leg-B expiry budget + grace (spec R7)', async () => {
+    const now = 1_700_000_000_000;
+    const stack = buildStack({
+      now: () => now,
+      legBBudgetMs: 10_000,
+      reservationGraceMs: 2_000,
+    });
+    let observedExpiry: number | undefined;
+    stack.legB.respond = (prepare) => {
+      const reservations = Object.values(
+        stack.inventory.reservationsSnapshot()
+      );
+      expect(reservations).toHaveLength(1);
+      observedExpiry = reservations[0]!.expiresAt;
+      const key = Buffer.from(prepare.executionCondition).toString('base64');
+      return {
+        type: 'fulfill',
+        fulfillment: stackPreimages(stack).get(key)!,
+      };
+    };
+    const { response } = await sendFill(stack, 1);
+    expect(response.accept).toBe(true);
+    // legBExpiry = now + budget (no leg-A expiry cap here); TTL adds grace.
+    expect(observedExpiry).toBe(now + 10_000 + 2_000);
+  });
+
+  it('AC-1: a long stream settles through a window budget ≪ notional volume; no permanent debit anywhere', async () => {
+    const FILLS = 60;
+    const BUDGET = TARGET_PER_DELTA * 5n; // 5-packet window
+    const SETTLE_EVERY = 4;
+    const stack = buildStack({
+      windowBudget: BUDGET,
+      rateProvider: () => ({ rate: '0.0004', at: Date.now() }),
+    });
+
+    let maxExposure = 0n;
+    let settledCumulative = 0n;
+    for (let seq = 1; seq <= FILLS; seq++) {
+      const { response } = await sendFill(stack, seq);
+      expect(response.accept).toBe(true);
+      const w = windowOf(stack);
+      const exposure = w.inFlight + w.unsettled;
+      if (exposure > maxExposure) maxExposure = exposure;
+      // Steady-state float: exposure never exceeds the window budget.
+      expect(exposure <= BUDGET).toBe(true);
+      if (seq % SETTLE_EVERY === 0) {
+        // Batched on-chain settlement confirms the latest cumulative
+        // watermark → liability shrinks, capacity recycles.
+        settledCumulative = TARGET_PER_DELTA * BigInt(seq);
+        stack.inventory.recordSettlement({
+          assetCode: ASSET,
+          chain: CHAIN,
+          channelId: CHANNEL_ID,
+          cumulativeAmount: settledCumulative,
+        });
+      }
+    }
+
+    const notionalDelivered = TARGET_PER_DELTA * BigInt(FILLS);
+    // The whole stream flowed through a float 12× smaller than notional.
+    expect(notionalDelivered).toBe(BUDGET * 12n);
+    expect(maxExposure <= BUDGET).toBe(true);
+    // AC-4: no permanent-debit path — available never moved.
+    expect(stack.inventory.get(ASSET, CHAIN)!.available).toBe(
+      INITIAL_INVENTORY
+    );
+    // Watermark integrity across the stream.
+    const entry = stack.channelState.get({
+      assetCode: ASSET,
+      chain: CHAIN,
+      senderPubkey: SENDER_PUBKEY,
+    })!;
+    expect(entry.nonce).toBe(BigInt(FILLS));
+    expect(entry.cumulativeAmount).toBe(notionalDelivered);
+    // Stale/replayed settlement confirmations are no-ops (monotone).
+    expect(
+      stack.inventory.recordSettlement({
+        assetCode: ASSET,
+        chain: CHAIN,
+        channelId: CHANNEL_ID,
+        cumulativeAmount: settledCumulative,
+      })
+    ).toBe(0n);
   });
 });
 

--- a/packages/swap/src/rolling-engine.ts
+++ b/packages/swap/src/rolling-engine.ts
@@ -14,7 +14,8 @@
  *   sender ─ PREPARE(δ, condition C_i, fill {streamNonce, seq}) ─▶ maker connector
  *   maker connector ─ LocalDeliveryRequest{executionCondition: b64(C_i)} ─▶ THIS ENGINE
  *   engine: staleness gate → replay reservation → fresh rate R_i →
- *           issueClaim (debit + watermark advance + WRITE-AHEAD PERSIST) →
+ *           issueRollingClaim (TTL'd WINDOW RESERVATION + watermark advance +
+ *           WRITE-AHEAD PERSIST — issue #49: no permanent debit) →
  *           leg-B PREPARE(⌊δ·R_i⌋, SAME C_i, advance payload w/ chain-B claim) → sender
  *   sender (toon-client#352): verifies the leg-B claim BEFORE revealing —
  *           FULFILLs leg B with P_i iff the claim checks out (spec R5)
@@ -29,20 +30,34 @@
  * chain-B claim. That inversion (verify-before-reveal) is the value-atomicity
  * core; a stalling/withholding maker fails the packet and collects nothing.
  *
- * ## Failure unwinding (issue #47 AC-4)
+ * ## Failure unwinding (issue #47 AC-4) and the window lifecycle (issue #49)
  *
- * `issueClaim` debits inventory, advances the channel watermark, and persists
- * write-ahead BEFORE the leg-B PREPARE is sent (state-store crash rule 1: no
- * claim a counterparty can hold is ever ahead of the stored watermark). If
- * leg B then rejects, times out, or fulfills without the correct preimage,
- * the engine fully unwinds via `MultiChainClaimIssuer.rollbackClaim` (the
- * same credit+release+re-persist pattern as the signer-failure rollback) and
- * rejects leg A benignly. Per spec R8 the sender MUST NOT treat a claim from
- * a REJECTed packet as redeemable; the residual Byzantine exposure is the
- * designed `δ·W` in-flight bound (spec §3.1/§8), not a new gap.
+ * `issueRollingClaim` takes a TTL'd in-flight window reservation (sized to
+ * the leg-B amount, TTL = leg-B expiry + grace), advances the channel
+ * watermark, and persists write-ahead BEFORE the leg-B PREPARE is sent
+ * (state-store crash rule 1: no claim a counterparty can hold is ever ahead
+ * of the stored watermark; the reservation is durable before the advance is
+ * externalized). Then exactly one of:
+ *
+ *  - leg B fulfills with the correct preimage → `commitRollingClaim`
+ *    (reservation → unsettled channel liability, later shrunk by settlement
+ *    confirmations via `SwapInventory.recordSettlement`);
+ *  - leg B rejects / times out / fulfills without the correct preimage →
+ *    full unwind via `MultiChainClaimIssuer.rollbackRollingClaim` (release
+ *    reservation exactly once + reverse watermark + re-persist) and a benign
+ *    leg-A reject. Per spec R8 the sender MUST NOT treat a claim from a
+ *    REJECTed packet as redeemable; the residual Byzantine exposure is the
+ *    designed `δ·W` in-flight bound (spec §3.1/§8), not a new gap;
+ *  - the process crashes → the persisted reservation expires at its TTL and
+ *    frees the window slot on/after restart (expire-and-release, state-store
+ *    crash rule 6); the watermark stays advanced (never regresses).
+ *
+ * Capacity refusal is benign: a fill that does not fit
+ * `windowBudget − inFlight − unsettled` rejects T04 `insufficient_liquidity`
+ * exactly like a legacy reserves shortage.
  *
  * A crash between the write-ahead persist and the leg-A response leaves the
- * safe state on disk: watermark advanced, inventory debited, replay seq
+ * safe state on disk: watermark advanced, window reserved, replay seq
  * reserved — the restart continues monotonically above the aborted
  * reservation and replays of the fill are rejected F04 (crash rules 2 and 4).
  *
@@ -60,10 +75,12 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import type { UnsignedEvent } from 'nostr-tools/pure';
 
 import { applyRate } from '@toon-protocol/sdk';
-import type { IssueClaimResult } from '@toon-protocol/sdk';
 import type { SwapPair } from '@toon-protocol/core';
 
-import type { MultiChainClaimIssuer } from './claim-issuer.js';
+import type {
+  MultiChainClaimIssuer,
+  RollingIssueClaimResult,
+} from './claim-issuer.js';
 import {
   buildStaleRateReject,
   StaleRateError,
@@ -580,11 +597,20 @@ export interface RollingSwapEngineConfig {
   legBExpiryMarginMs?: number;
   /** Reject (before any debit) when the remaining leg-A budget is below this. */
   minLegBTimeMs?: number;
+  /**
+   * Issue #49 — grace added on top of the leg-B expiry when sizing the
+   * window-reservation TTL (`ttl = legBExpiry − now + grace`), so a live
+   * packet's reservation can never expire under it while a crashed/stalled
+   * packet frees its slot right after the packet could no longer fulfill.
+   * Default 5s.
+   */
+  reservationGraceMs?: number;
 }
 
 export const DEFAULT_LEG_B_BUDGET_MS = 30_000;
 export const DEFAULT_LEG_B_EXPIRY_MARGIN_MS = 1_000;
 export const DEFAULT_MIN_LEG_B_TIME_MS = 2_000;
+export const DEFAULT_RESERVATION_GRACE_MS = 5_000;
 
 /**
  * Synthetic inner-rumor kind attached to `issueClaim` calls on the rolling
@@ -606,6 +632,7 @@ export class RollingSwapEngine {
   readonly #legBBudgetMs: number;
   readonly #legBExpiryMarginMs: number;
   readonly #minLegBTimeMs: number;
+  readonly #reservationGraceMs: number;
 
   constructor(config: RollingSwapEngineConfig) {
     this.#sessions = config.sessions;
@@ -620,6 +647,8 @@ export class RollingSwapEngine {
     this.#legBExpiryMarginMs =
       config.legBExpiryMarginMs ?? DEFAULT_LEG_B_EXPIRY_MARGIN_MS;
     this.#minLegBTimeMs = config.minLegBTimeMs ?? DEFAULT_MIN_LEG_B_TIME_MS;
+    this.#reservationGraceMs =
+      config.reservationGraceMs ?? DEFAULT_RESERVATION_GRACE_MS;
   }
 
   /** Register a session (RFQ intake seam). See {@link RollingSessionStore}. */
@@ -814,17 +843,22 @@ export class RollingSwapEngine {
       });
     }
 
-    // 6. Issue the chain-B claim: debit + watermark advance + WRITE-AHEAD
-    //    persist (crash rule 1) — all BEFORE the claim leaves the process.
-    let issued: IssueClaimResult;
+    // 6. Issue the chain-B claim: in-flight window reservation (issue #49 —
+    //    NOT a permanent debit) + watermark advance + WRITE-AHEAD persist
+    //    (crash rule 1) — all BEFORE the claim leaves the process. The
+    //    reservation TTL is the leg-B expiry + grace (spec R7 alignment):
+    //    a crash from here on frees the window slot once this packet can
+    //    no longer fulfill.
+    let issued: RollingIssueClaimResult;
     try {
-      issued = await this.#claimIssuer.issueClaim({
+      issued = await this.#claimIssuer.issueRollingClaim({
         sourceAmount,
         targetAmount,
         pair,
         senderPubkey: session.senderPubkey,
         chainRecipient: session.chainRecipient,
         rumor: this.#syntheticRumor(session, payload),
+        reservationTtlMs: legBExpiryMs - now + this.#reservationGraceMs,
       });
     } catch (err) {
       const code =
@@ -912,6 +946,14 @@ export class RollingSwapEngine {
             cumulativeAmount: issued.cumulativeAmount.toString(),
           }),
         };
+        // Issue #49: the sender revealed the preimage, so it now holds a
+        // redeemable claim — convert the window reservation into unsettled
+        // channel liability (shrunk later by settlement confirmations).
+        this.#claimIssuer.commitRollingClaim({
+          reservationId: issued.reservationId,
+          pair,
+          targetAmount,
+        });
         this.#logger.info?.('swap.rolling.fill_fulfilled', {
           streamNonce: payload.streamNonce,
           seq: payload.seq,
@@ -927,7 +969,13 @@ export class RollingSwapEngine {
       }
       // A leg-B FULFILL without the correct preimage cannot satisfy leg A
       // (the connector would F99 it anyway — contract rule 3). Unwind.
-      this.#unwind(session, targetAmount, payload, 'leg_b_fulfillment_invalid');
+      this.#unwind(
+        session,
+        issued,
+        targetAmount,
+        payload,
+        'leg_b_fulfillment_invalid'
+      );
       return buildRollingReject({
         code: 'F99',
         semantic: 'application_error',
@@ -938,8 +986,8 @@ export class RollingSwapEngine {
     }
 
     // 8b. Leg B rejected/timed out → full unwind + benign leg-A reject
-    //     (AC-2/AC-4: nothing stays debited on a failed packet).
-    this.#unwind(session, targetAmount, payload, legB.code);
+    //     (AC-2/AC-4: nothing stays reserved on a failed packet).
+    this.#unwind(session, issued, targetAmount, payload, legB.code);
     const legBFClass = legB.code.startsWith('F');
     return buildRollingReject({
       code: legBFClass ? 'F99' : 'T00',
@@ -952,6 +1000,7 @@ export class RollingSwapEngine {
 
   #unwind(
     session: RollingSession,
+    issued: RollingIssueClaimResult,
     targetAmount: bigint,
     payload: RollingFillPayload,
     cause: string
@@ -962,7 +1011,10 @@ export class RollingSwapEngine {
       targetAmount: targetAmount.toString(),
       cause,
     });
-    this.#claimIssuer.rollbackClaim({
+    // Issue #49: releases the window reservation (exactly once — the
+    // reservation is the idempotency gate) + reverses the channel watermark.
+    this.#claimIssuer.rollbackRollingClaim({
+      reservationId: issued.reservationId,
       pair: session.pair,
       senderPubkey: session.senderPubkey,
       targetAmount,

--- a/packages/swap/src/state-store.test.ts
+++ b/packages/swap/src/state-store.test.ts
@@ -63,11 +63,13 @@ afterEach(() => {
 
 function sampleState(): PersistedSwapState {
   return {
-    version: 1,
+    version: 2,
     inventory: {
       'ETH:evm:base:8453': {
         available: '9007199254740993', // > MAX_SAFE_INTEGER (precision guard)
         total: '9007199254740995',
+        unsettled: '18000000000000001',
+        windowBudget: '20000000000000000',
         updatedAt: 123,
       },
     },
@@ -83,7 +85,33 @@ function sampleState(): PersistedSwapState {
       [`ETH:evm:base:8453:${SENDER_PUBKEY}`]: 'ETH:evm:base:8453:0xchan',
     },
     seenPacketIds: ['pkt-1', 'pkt-2'],
+    // Issue #49 — in-flight window reservations + settled watermarks.
+    reservations: {
+      'rsv-1': {
+        key: 'ETH:evm:base:8453',
+        amount: '400000000000001',
+        expiresAt: 1_800_000_000_000,
+      },
+    },
+    settledWatermarks: {
+      'ETH:evm:base:8453:0xchan': '9000000000000000',
+    },
   };
+}
+
+/** A pre-#49 (v1) snapshot — must remain loadable with defaults. */
+function sampleV1State(): Record<string, unknown> {
+  const { reservations, settledWatermarks, ...rest } = sampleState();
+  void reservations;
+  void settledWatermarks;
+  const inventory = {
+    'ETH:evm:base:8453': {
+      available: '9007199254740993',
+      total: '9007199254740995',
+      updatedAt: 123,
+    },
+  };
+  return { ...rest, inventory, version: 1 };
 }
 
 /** Fresh live state + persister wired to a store, for crash-recovery tests. */
@@ -209,11 +237,51 @@ describe('JsonFileSwapStateStore', () => {
     const path = join(makeTmpDir(), 'state.json');
     writeFileSync(
       path,
-      JSON.stringify({ ...sampleState(), version: 2 }),
+      JSON.stringify({ ...sampleState(), version: 99 }),
       'utf-8'
     );
     const store = new JsonFileSwapStateStore(path);
     expect(() => store.load()).toThrowError(/version/);
+  });
+
+  it('[P0] (#49) v1 snapshots load with window fields defaulted (reservations/watermarks empty, unsettled absent)', () => {
+    const path = join(makeTmpDir(), 'state.json');
+    writeFileSync(path, JSON.stringify(sampleV1State()), 'utf-8');
+    const store = new JsonFileSwapStateStore(path);
+    const loaded = store.load()!;
+    expect(loaded.version).toBe(2);
+    expect(loaded.reservations).toEqual({});
+    expect(loaded.settledWatermarks).toEqual({});
+    expect(loaded.inventory['ETH:evm:base:8453']!.available).toBe(
+      '9007199254740993'
+    );
+    expect(loaded.inventory['ETH:evm:base:8453']!.unsettled).toBeUndefined();
+  });
+
+  it('[P1] (#49) malformed reservations / settledWatermarks fail load()', () => {
+    const path = join(makeTmpDir(), 'state.json');
+    const badAmount = sampleState();
+    badAmount.reservations['rsv-1']!.amount = 'not-a-bigint';
+    writeFileSync(path, JSON.stringify(badAmount), 'utf-8');
+    expect(() => new JsonFileSwapStateStore(path).load()).toThrowError(
+      SwapStateStoreError
+    );
+
+    const badWm = sampleState();
+    (badWm.settledWatermarks as Record<string, unknown>)['k'] = 12;
+    writeFileSync(path, JSON.stringify(badWm), 'utf-8');
+    expect(() => new JsonFileSwapStateStore(path).load()).toThrowError(
+      SwapStateStoreError
+    );
+
+    const badExpiry = sampleState();
+    (badExpiry.reservations['rsv-1'] as unknown as Record<string, unknown>)[
+      'expiresAt'
+    ] = 'soon';
+    writeFileSync(path, JSON.stringify(badExpiry), 'utf-8');
+    expect(() => new JsonFileSwapStateStore(path).load()).toThrowError(
+      /expiresAt/
+    );
   });
 
   it('[P1] malformed bigint strings fail load()', () => {
@@ -329,6 +397,52 @@ describe('SwapStatePersister', () => {
     );
     expect(loaded.seenPacketIds).toEqual(['pkt-9']);
     expect(persister).toBeDefined();
+  });
+
+  it('[P0] (#49) persists in-flight reservations, unsettled liability, and settled watermarks', () => {
+    const path = join(makeTmpDir(), 'state.json');
+    const store = new JsonFileSwapStateStore(path);
+    const { inventory, channelState, persister } = makeLiveSwapNode(store);
+    void channelState;
+
+    const a = inventory.reserve({
+      assetCode: 'ETH',
+      chain: 'evm:base:8453',
+      amount: 5n,
+      id: 'rsv-a',
+    });
+    inventory.reserve({
+      assetCode: 'ETH',
+      chain: 'evm:base:8453',
+      amount: 3n,
+      id: 'rsv-b',
+    });
+    inventory.commitReservation({
+      reservationId: 'rsv-b',
+      assetCode: 'ETH',
+      chain: 'evm:base:8453',
+      amount: 3n,
+    });
+    inventory.recordSettlement({
+      assetCode: 'ETH',
+      chain: 'evm:base:8453',
+      channelId: 'chan-a',
+      cumulativeAmount: 1n,
+    });
+    persister.persist();
+
+    const loaded = store.load()!;
+    expect(loaded.inventory['ETH:evm:base:8453']!.unsettled).toBe('2');
+    expect(loaded.reservations).toEqual({
+      'rsv-a': {
+        key: 'ETH:evm:base:8453',
+        amount: '5',
+        expiresAt: a.expiresAt,
+      },
+    });
+    expect(loaded.settledWatermarks).toEqual({
+      'ETH:evm:base:8453:chan-a': '1',
+    });
   });
 });
 

--- a/packages/swap/src/state-store.ts
+++ b/packages/swap/src/state-store.ts
@@ -59,6 +59,24 @@
  *    reservation bookkeeping (`releaseAll`) for GC; the on-disk snapshot
  *    keeps the last handed-out watermarks and is authoritative on the next
  *    boot.
+ * 6. **In-flight window reservations recover by expire-and-release**
+ *    (issue #49). A rolling fill's window reservation is persisted
+ *    write-ahead (inside the same rule-1 snapshot) BEFORE its leg-B advance
+ *    can be externalized, and its commit (→ `unsettled`) or release is
+ *    re-persisted when the packet resolves. After a crash, rehydrated
+ *    reservations are honored until their persisted `expiresAt` and then
+ *    expire — no engine survives a restart to commit them, the leg-A packet
+ *    has long expired upstream, and per rolling-swap §3 R8 a claim on a
+ *    REJECTed packet is void — so releasing leaks no capacity to an honest
+ *    counterparty while the write-ahead watermark (which never regresses)
+ *    prevents any double-spend. Residual windows are bounded: a Byzantine
+ *    sender banking a voided in-flight claim is the spec's designed δ·W
+ *    exposure (§3.1), and a crash between the leg-B FULFILL and the commit
+ *    persist under-reports `unsettled` by at most the packets in flight at
+ *    the crash — the same δ·W bound. The alternative (re-checking by
+ *    recomputing `unsettled` from channel cumulative − settled watermarks)
+ *    is unsound while legacy and rolling traffic share channels: it would
+ *    double-count legacy claims that already debited `available`.
  *
  * ## Rehydration precedence
  *
@@ -93,6 +111,16 @@ export interface PersistedInventoryEntry {
   available: string;
   /** String-encoded bigint. */
   total: string;
+  /**
+   * Issue #49 — committed-but-unsettled channel liability (string-encoded
+   * bigint). Absent in v1 snapshots → 0.
+   */
+  unsettled?: string;
+  /**
+   * Issue #49 — operator window ceiling at snapshot time (string-encoded
+   * bigint). Informational: on rehydration the live config wins.
+   */
+  windowBudget?: string;
   updatedAt: number;
 }
 
@@ -105,9 +133,23 @@ export interface PersistedChannelEntry {
   updatedAt: number;
 }
 
+/** Issue #49 — one persisted in-flight window reservation. */
+export interface PersistedReservationEntry {
+  /** `${assetCode}:${chain}` of the reserved pool. */
+  key: string;
+  /** String-encoded bigint. */
+  amount: string;
+  /** ms-epoch expiry — crash recovery expires-and-releases at this instant. */
+  expiresAt: number;
+}
+
 export interface PersistedSwapState {
-  /** Schema version — bump on breaking shape changes. */
-  version: 1;
+  /**
+   * Schema version — bump on breaking shape changes. v2 (issue #49) adds
+   * `reservations` + `settledWatermarks` + per-entry `unsettled`; v1
+   * snapshots load with those defaulted empty.
+   */
+  version: 2;
   /** `${assetCode}:${chain}` → reserves. */
   inventory: Record<string, PersistedInventoryEntry>;
   /** `${assetCode}:${chain}:${channelId}` → watermark entry. */
@@ -116,6 +158,13 @@ export interface PersistedSwapState {
   bindings: Record<string, string>;
   /** Replay reservations (insertion-ordered, oldest first). */
   seenPacketIds: string[];
+  /** Issue #49 — reservation id → in-flight window reservation. */
+  reservations: Record<string, PersistedReservationEntry>;
+  /**
+   * Issue #49 — `${assetCode}:${chain}:${channelId}` → highest settled
+   * cumulative watermark (string-encoded bigint).
+   */
+  settledWatermarks: Record<string, string>;
 }
 
 /** Storage abstraction so tests / future sqlite backends can swap in. */
@@ -271,15 +320,19 @@ export function validatePersistedState(raw: unknown): PersistedSwapState {
     throw new Error('state must be a JSON object');
   }
   const rec = raw as Record<string, unknown>;
-  if (rec['version'] !== 1) {
+  const version = rec['version'];
+  if (version !== 1 && version !== 2) {
     throw new Error(
-      `unsupported state schema version ${JSON.stringify(rec['version'])} (expected 1)`
+      `unsupported state schema version ${JSON.stringify(version)} (expected 1 or 2)`
     );
   }
   const invRaw = rec['inventory'];
   const chanRaw = rec['channels'];
   const bindRaw = rec['bindings'];
   const seenRaw = rec['seenPacketIds'];
+  // Issue #49 (v2) — absent in v1 snapshots → defaulted empty.
+  const resvRaw = rec['reservations'] ?? {};
+  const wmRaw = rec['settledWatermarks'] ?? {};
   if (typeof invRaw !== 'object' || invRaw === null || Array.isArray(invRaw)) {
     throw new Error('state.inventory must be an object');
   }
@@ -300,6 +353,16 @@ export function validatePersistedState(raw: unknown): PersistedSwapState {
   if (!Array.isArray(seenRaw) || seenRaw.some((s) => typeof s !== 'string')) {
     throw new Error('state.seenPacketIds must be an array of strings');
   }
+  if (
+    typeof resvRaw !== 'object' ||
+    resvRaw === null ||
+    Array.isArray(resvRaw)
+  ) {
+    throw new Error('state.reservations must be an object');
+  }
+  if (typeof wmRaw !== 'object' || wmRaw === null || Array.isArray(wmRaw)) {
+    throw new Error('state.settledWatermarks must be an object');
+  }
 
   const inventory = copyRecord(
     invRaw as Record<string, PersistedInventoryEntry>,
@@ -307,6 +370,15 @@ export function validatePersistedState(raw: unknown): PersistedSwapState {
     (v, k) => {
       assertBigintString(v?.available, `state.inventory["${k}"].available`);
       assertBigintString(v?.total, `state.inventory["${k}"].total`);
+      if (v?.unsettled !== undefined) {
+        assertBigintString(v.unsettled, `state.inventory["${k}"].unsettled`);
+      }
+      if (v?.windowBudget !== undefined) {
+        assertBigintString(
+          v.windowBudget,
+          `state.inventory["${k}"].windowBudget`
+        );
+      }
     }
   );
   const channels = copyRecord(
@@ -332,12 +404,36 @@ export function validatePersistedState(raw: unknown): PersistedSwapState {
       }
     }
   );
+  const reservations = copyRecord(
+    resvRaw as Record<string, PersistedReservationEntry>,
+    'state.reservations',
+    (v, k) => {
+      if (typeof v?.key !== 'string' || v.key.length === 0) {
+        throw new Error(`state.reservations["${k}"].key must be a string`);
+      }
+      assertBigintString(v.amount, `state.reservations["${k}"].amount`);
+      if (typeof v.expiresAt !== 'number' || !Number.isFinite(v.expiresAt)) {
+        throw new Error(
+          `state.reservations["${k}"].expiresAt must be a finite number`
+        );
+      }
+    }
+  );
+  const settledWatermarks = copyRecord(
+    wmRaw as Record<string, string>,
+    'state.settledWatermarks',
+    (v, k) => {
+      assertBigintString(v, `state.settledWatermarks["${k}"]`);
+    }
+  );
   return {
-    version: 1,
+    version: 2,
     inventory,
     channels,
     bindings,
     seenPacketIds: [...(seenRaw as string[])],
+    reservations,
+    settledWatermarks,
   };
 }
 
@@ -467,8 +563,33 @@ export class SwapStatePersister {
       inventory[`${b.assetCode}:${b.chain}`] = {
         available: b.available.toString(),
         total: b.total.toString(),
+        unsettled: b.unsettled.toString(),
+        ...(b.windowBudget !== undefined && {
+          windowBudget: b.windowBudget.toString(),
+        }),
         updatedAt: b.updatedAt,
       };
+    }
+
+    // Issue #49 — in-flight window reservations + settled watermarks.
+    const reservations: Record<string, PersistedReservationEntry> =
+      Object.create(null) as Record<string, PersistedReservationEntry>;
+    for (const [id, r] of Object.entries(
+      this.inventory.reservationsSnapshot()
+    )) {
+      reservations[id] = {
+        key: r.key,
+        amount: r.amount.toString(),
+        expiresAt: r.expiresAt,
+      };
+    }
+    const settledWatermarks: Record<string, string> = Object.create(
+      null
+    ) as Record<string, string>;
+    for (const [k, v] of Object.entries(
+      this.inventory.settledWatermarksSnapshot()
+    )) {
+      settledWatermarks[k] = v.toString();
     }
 
     const { channels: liveChannels, bindings } = this.channelState.snapshot();
@@ -485,11 +606,13 @@ export class SwapStatePersister {
     }
 
     this.store.save({
-      version: 1,
+      version: 2,
       inventory,
       channels,
       bindings,
       seenPacketIds: this.seenPacketIds?.values() ?? [],
+      reservations,
+      settledWatermarks,
     });
   }
 }

--- a/packages/swap/src/swap-node-persistence.test.ts
+++ b/packages/swap/src/swap-node-persistence.test.ts
@@ -18,6 +18,12 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { startSwapNode, validateConfig } from './swap-node.js';
 import type { SwapNodeConfig } from './swap-node.js';
 import { JsonFileSwapStateStore } from './state-store.js';
+import type { PersistedSwapState } from './state-store.js';
+
+/** Write a pre-#49 (v1) snapshot — boot-path compat for the schema upgrade. */
+function saveV1Snapshot(path: string, state: unknown): void {
+  new JsonFileSwapStateStore(path).save(state as PersistedSwapState);
+}
 import { SwapNodeStartError } from './errors.js';
 
 const VALID_MNEMONIC =
@@ -87,7 +93,7 @@ describe('issue #46 — startSwapNode state persistence', () => {
     // Simulate a previous run that spent inventory and advanced watermarks
     // (including a channel that was provisioned dynamically, absent from
     // config) before crashing.
-    new JsonFileSwapStateStore(statePath).save({
+    saveV1Snapshot(statePath, {
       version: 1,
       inventory: {
         'USDC:evm:8453': {
@@ -143,7 +149,7 @@ describe('issue #46 — startSwapNode state persistence', () => {
 
   it('[P0] stop() does not clobber persisted watermarks (no persist of releaseAll zeros)', async () => {
     const statePath = join(makeTmpDir(), 'swap-state.json');
-    new JsonFileSwapStateStore(statePath).save({
+    saveV1Snapshot(statePath, {
       version: 1,
       inventory: {},
       channels: {
@@ -198,6 +204,131 @@ describe('issue #46 — startSwapNode state persistence', () => {
     const instance = await startSwapNode(cfg);
     try {
       expect(existsSync(join(dir, 'unused.json'))).toBe(false);
+    } finally {
+      await instance.stop();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #49 — window rehydration + node-level settlement intake
+// ---------------------------------------------------------------------------
+
+describe('issue #49 — startSwapNode window state', () => {
+  it('[P0] rehydrates unsettled + reservations from a v2 snapshot; windowBudget comes from config (config wins)', async () => {
+    const statePath = join(makeTmpDir(), 'swap-state.json');
+    const farFuture = Date.now() + 3_600_000;
+    new JsonFileSwapStateStore(statePath).save({
+      version: 2,
+      inventory: {
+        'USDC:evm:8453': {
+          available: '1000000',
+          total: '1000000',
+          unsettled: '300',
+          windowBudget: '999999', // stale operator config — must be ignored
+          updatedAt: 1,
+        },
+      },
+      channels: {
+        'USDC:evm:8453:c-1': {
+          channelId: 'c-1',
+          cumulativeAmount: '500',
+          nonce: '5',
+          updatedAt: 1,
+        },
+      },
+      bindings: {},
+      seenPacketIds: [],
+      reservations: {
+        'rsv-live': {
+          key: 'USDC:evm:8453',
+          amount: '100',
+          expiresAt: farFuture,
+        },
+        'rsv-stale': { key: 'USDC:evm:8453', amount: '50', expiresAt: 1 },
+      },
+      settledWatermarks: { 'USDC:evm:8453:c-1': '200' },
+    });
+
+    const cfg = validConfig(statePath);
+    cfg.windowBudget = { 'evm:8453': 1_000n };
+    const instance = await startSwapNode(cfg);
+    try {
+      const res = await fetch(`http://127.0.0.1:${instance.blsPort}/health`);
+      const body = (await res.json()) as {
+        inventoryWindow: Record<
+          string,
+          { budget: string; inFlight: string; unsettled: string; free: string }
+        >;
+      };
+      // Config budget (1000) wins over the persisted 999999; the expired
+      // reservation is released (expire-and-release recovery, crash rule 6)
+      // while the live one still occupies the window until its TTL.
+      expect(body.inventoryWindow['USDC:evm:8453']).toEqual({
+        budget: '1000',
+        inFlight: '100',
+        unsettled: '300',
+        free: '600',
+      });
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('[P0] recordSettlement resolves the pool by channelId, shrinks liability monotonically, and persists', async () => {
+    const statePath = join(makeTmpDir(), 'swap-state.json');
+    new JsonFileSwapStateStore(statePath).save({
+      version: 2,
+      inventory: {
+        'USDC:evm:8453': {
+          available: '1000000',
+          total: '1000000',
+          unsettled: '400',
+          updatedAt: 1,
+        },
+      },
+      channels: {
+        'USDC:evm:8453:c-1': {
+          channelId: 'c-1',
+          cumulativeAmount: '400',
+          nonce: '4',
+          updatedAt: 1,
+        },
+      },
+      bindings: {},
+      seenPacketIds: [],
+      reservations: {},
+      settledWatermarks: {},
+    });
+    const instance = await startSwapNode(validConfig(statePath));
+    try {
+      const event = {
+        txHash: `0x${'ab'.repeat(32)}`,
+        chain: 'evm' as const,
+        channelId: 'c-1',
+        cumulativeAmount: '250',
+        nonce: '3',
+        recipient: `0x${'11'.repeat(20)}`,
+        settledAt: Date.now(),
+      };
+      expect(instance.recordSettlement(event)).toBe(250n);
+      // Replayed confirmation → monotone no-op.
+      expect(instance.recordSettlement(event)).toBe(0n);
+      // Unknown channel → 0n, no throw.
+      expect(instance.recordSettlement({ ...event, channelId: 'nope' })).toBe(
+        0n
+      );
+
+      const res = await fetch(`http://127.0.0.1:${instance.blsPort}/health`);
+      const body = (await res.json()) as {
+        inventoryWindow: Record<string, { unsettled: string }>;
+      };
+      expect(body.inventoryWindow['USDC:evm:8453']!.unsettled).toBe('150');
+
+      // Persisted: the settled watermark + reduced liability survive.
+      const snap = new JsonFileSwapStateStore(statePath).load()!;
+      expect(snap.settledWatermarks['USDC:evm:8453:c-1']).toBe('250');
+      expect(snap.inventory['USDC:evm:8453']!.unsettled).toBe('150');
     } finally {
       await instance.stop();
     }

--- a/packages/swap/src/swap-node.rolling-dispatch.test.ts
+++ b/packages/swap/src/swap-node.rolling-dispatch.test.ts
@@ -294,10 +294,18 @@ describe('issue #47 — rolling dispatch matrix', () => {
       expect(legBCalls[0]!.destination).toBe('g.toon.client.sender01');
       expect(legBCalls[0]!.amount).toBe(250_000n); // 1:1 pair, same scale
 
-      // Inventory debited by the fill.
-      expect(instance.health().inventoryAvailable[`USDC:${CHAIN}`]).toBe(
-        (1_000_000_000n - 250_000n).toString()
+      // Issue #49: NO permanent debit on the rolling flow — the fill's
+      // amount is unsettled channel liability in the window view.
+      const health = instance.health();
+      expect(health.inventoryAvailable[`USDC:${CHAIN}`]).toBe(
+        1_000_000_000n.toString()
       );
+      expect(health.inventoryWindow[`USDC:${CHAIN}`]).toEqual({
+        budget: 1_000_000_000n.toString(),
+        inFlight: '0',
+        unsettled: '250000',
+        free: (1_000_000_000n - 250_000n).toString(),
+      });
     } finally {
       await instance.stop();
     }

--- a/packages/swap/src/swap-node.ts
+++ b/packages/swap/src/swap-node.ts
@@ -59,6 +59,7 @@ import { createHandlerContext } from '@toon-protocol/sdk';
 
 import { deriveSwapNodeKeys } from './wallet.js';
 import type { SwapNodeKeys, SwapNodeChainKind } from './wallet.js';
+import type { SettlementEvent } from './settlement-event.js';
 import { SwapInventory } from './inventory.js';
 import { SwapChannelState } from './channel-state.js';
 import type { ChannelEntry } from './channel-state.js';
@@ -248,6 +249,16 @@ export interface SwapNodeConfig {
   chains: readonly SwapNodeChainKind[];
   channels: Record<string, readonly ChannelEntry[]>;
   inventory: Record<string, bigint>;
+  /**
+   * Issue #49 — per-chain in-flight window ceiling for the ROLLING path
+   * (rolling-swap §8: size it to `δ_max·W_max·R` plus a settlement-latency
+   * buffer, NOT to notional volume). Keyed like {@link inventory}; applies
+   * to every `(pair.to.assetCode, chain)` pool on that chain. Clamped to
+   * live `available` at check time, so it can never advertise capital the
+   * maker does not hold. Absent → the ceiling degrades to `available`.
+   * Operator config ALWAYS wins over persisted snapshots for this field.
+   */
+  windowBudget?: Record<string, bigint>;
 
   /**
    * Optional live-rate hook, widened from the SDK's string-only shape:
@@ -322,6 +333,12 @@ export interface SwapNodeConfig {
     legBExpiryMarginMs?: number;
     /** Reject fills whose remaining leg-A budget (ms) is below this. */
     minLegBTimeMs?: number;
+    /**
+     * Issue #49 — grace (ms) added on top of the leg-B expiry when sizing a
+     * fill's window-reservation TTL (crashed/stalled packets free their
+     * slot right after they could no longer fulfill). Default 5s.
+     */
+    reservationGraceMs?: number;
   };
   /**
    * Leg-B egress override (tests / custom connectors). When omitted, the
@@ -487,10 +504,35 @@ export interface SwapNodeInstance {
    * call it directly.
    */
   registerRollingSession(session: RollingSession): void;
+  /**
+   * Issue #49 — apply an on-chain settlement confirmation: shrinks the
+   * matching pool's unsettled liability by the watermark delta (monotone
+   * per channel; stale/replayed confirmations are a 0n no-op) and recycles
+   * the freed capacity into the in-flight window. The pool is resolved by
+   * `event.channelId` against the provisioned channel state. Returns the
+   * liability actually reduced. Persisted (best-effort) when persistence
+   * is enabled.
+   */
+  recordSettlement(event: SettlementEvent): bigint;
   /** @internal — AC-10 test hook. */
   readonly _handlerRegistry?: HandlerRegistry;
   /** @internal — issue #47 test hook (rolling-engine introspection). */
   readonly _rollingEngine?: RollingSwapEngine;
+}
+
+/**
+ * Issue #49 — the three-bucket in-flight window view for one
+ * `assetCode:chain` pool (rolling-swap §8). All bigints as decimal strings.
+ */
+export interface SwapNodeHealthWindowEntry {
+  /** Effective ceiling: `min(configured windowBudget, available)`. */
+  budget: string;
+  /** Σ live packet reservations (reserve → commit/release/TTL). */
+  inFlight: string;
+  /** Committed liability awaiting on-chain settlement confirmation. */
+  unsettled: string;
+  /** `budget − inFlight − unsettled` — capacity for new fills. */
+  free: string;
 }
 
 export interface SwapNodeHealthResponse {
@@ -505,6 +547,12 @@ export interface SwapNodeHealthResponse {
   swapPairs: SwapPair[];
   /** Per-asset available reserves, parallel to `inventory` (which is total). */
   inventoryAvailable: Record<string, string>;
+  /**
+   * Issue #49 — in-flight vs unsettled vs free per `assetCode:chain` pool:
+   * the capital-exposure view that replaces total/available as the rolling
+   * path's operational signal (total/available remain for the legacy pool).
+   */
+  inventoryWindow: Record<string, SwapNodeHealthWindowEntry>;
 }
 
 // ---------------------------------------------------------------------------
@@ -698,6 +746,23 @@ export function validateConfig(config: SwapNodeConfig): void {
     }
   }
 
+  if (config.windowBudget !== undefined) {
+    for (const [chain, budget] of Object.entries(config.windowBudget)) {
+      if (typeof budget !== 'bigint' || budget < 0n) {
+        throw new SwapNodeStartError(
+          'INVALID_CONFIG',
+          `SwapNodeConfig.windowBudget["${chain}"] MUST be a non-negative bigint`
+        );
+      }
+      if (!distinctTargetChains.has(chain)) {
+        throw new SwapNodeStartError(
+          'INVALID_CONFIG',
+          `SwapNodeConfig.windowBudget["${chain}"] references a chain no swap pair targets`
+        );
+      }
+    }
+  }
+
   if (config.maxRateAge !== undefined) {
     try {
       validateMaxRateAgeConfig(config.maxRateAge);
@@ -722,6 +787,7 @@ export function validateConfig(config: SwapNodeConfig): void {
       'legBBudgetMs',
       'legBExpiryMarginMs',
       'minLegBTimeMs',
+      'reservationGraceMs',
     ];
     for (const k of knobs) {
       const v = config.rolling[k];
@@ -957,26 +1023,78 @@ export async function startSwapNode(
   //    (persisted wins): a restart must not reset spent inventory back to
   //    the notional boot value. Config seeds only keys the snapshot has
   //    never recorded.
+  //    Issue #49 — `windowBudget` is operator config and ALWAYS comes from
+  //    config (never the snapshot); `unsettled` + in-flight reservations +
+  //    settled watermarks rehydrate from the snapshot. Rehydrated
+  //    reservations recover by expire-and-release: they occupy the window
+  //    until their persisted `expiresAt`, then free it (state-store crash
+  //    rule 6 — no leaked capacity, and the write-ahead watermark already
+  //    prevents any double-spend).
   const inventoryInit: Record<
     string,
-    { available: bigint; total: bigint; updatedAt?: number }
+    {
+      available: bigint;
+      total: bigint;
+      updatedAt?: number;
+      windowBudget?: bigint;
+      unsettled?: bigint;
+    }
   > = {};
   for (const pair of config.swapPairs) {
     const chain = pair.to.chain;
     const asset = pair.to.assetCode;
     const bal = config.inventory[chain] ?? 0n;
-    inventoryInit[`${asset}:${chain}`] = { available: bal, total: bal };
+    const budget = config.windowBudget?.[chain];
+    inventoryInit[`${asset}:${chain}`] = {
+      available: bal,
+      total: bal,
+      ...(budget !== undefined && { windowBudget: budget }),
+    };
   }
   if (persistedState) {
     for (const [k, v] of Object.entries(persistedState.inventory)) {
+      const configBudget = inventoryInit[k]?.windowBudget;
       inventoryInit[k] = {
         available: BigInt(v.available),
         total: BigInt(v.total),
+        unsettled: BigInt(v.unsettled ?? '0'),
         updatedAt: v.updatedAt,
+        // Config wins; a snapshot-only budget (key no longer configured) is
+        // dropped rather than resurrected.
+        ...(configBudget !== undefined && { windowBudget: configBudget }),
       };
     }
   }
-  const inventory = new SwapInventory({ balances: inventoryInit });
+  const rehydratedReservations = persistedState
+    ? Object.fromEntries(
+        Object.entries(persistedState.reservations).map(([id, r]) => [
+          id,
+          { key: r.key, amount: BigInt(r.amount), expiresAt: r.expiresAt },
+        ])
+      )
+    : undefined;
+  const inventory = new SwapInventory({
+    balances: inventoryInit,
+    ...(rehydratedReservations && { reservations: rehydratedReservations }),
+    ...(persistedState && {
+      settledWatermarks: Object.fromEntries(
+        Object.entries(persistedState.settledWatermarks).map(([k, v]) => [
+          k,
+          BigInt(v),
+        ])
+      ),
+    }),
+  });
+  if (
+    rehydratedReservations &&
+    Object.keys(rehydratedReservations).length > 0
+  ) {
+    logger.info?.('swap.state.reservations_rehydrated', {
+      count: Object.keys(rehydratedReservations).length,
+      policy:
+        'expire-and-release: crashed in-flight reservations free their window slot at their persisted expiresAt (state-store crash rule 6)',
+    });
+  }
 
   // 6. Channel state — flatten `Record<chain, ChannelEntry[]>` into the
   //    `SwapChannelState` key scheme (`assetCode:chain:senderPubkey`). For
@@ -1398,6 +1516,9 @@ export async function startSwapNode(
     ...(config.rolling?.minLegBTimeMs !== undefined && {
       minLegBTimeMs: config.rolling.minLegBTimeMs,
     }),
+    ...(config.rolling?.reservationGraceMs !== undefined && {
+      reservationGraceMs: config.rolling.reservationGraceMs,
+    }),
   });
 
   // 11a. Wire the HandlerRegistry to the connector's local-delivery path.
@@ -1650,6 +1771,17 @@ export async function startSwapNode(
         invAvailable[b.chain] = b.available.toString();
       }
     }
+    // Issue #49 — the three-bucket window view (in-flight / unsettled /
+    // free) per pool: the honeypot-sized exposure signal (spec §8).
+    const inventoryWindow: Record<string, SwapNodeHealthWindowEntry> = {};
+    for (const w of inventory.windowSnapshot()) {
+      inventoryWindow[`${w.assetCode}:${w.chain}`] = {
+        budget: w.budget.toString(),
+        inFlight: w.inFlight.toString(),
+        unsettled: w.unsettled.toString(),
+        free: w.free.toString(),
+      };
+    }
     return {
       status,
       version: VERSION,
@@ -1660,6 +1792,7 @@ export async function startSwapNode(
       inventory: inv,
       swapPairs: [...config.swapPairs],
       inventoryAvailable: invAvailable,
+      inventoryWindow,
     };
   };
 
@@ -1877,6 +2010,64 @@ export async function startSwapNode(
     _rollingEngine: rollingEngine,
     registerRollingSession: (session: RollingSession) => {
       rollingEngine.registerSession(session);
+    },
+    recordSettlement: (event: SettlementEvent): bigint => {
+      // Resolve the (assetCode, chain) pool via the provisioned channel
+      // state: stored keys are `${assetCode}:${chain}:${channelId}`.
+      const { channels: liveChannels } = channelState.snapshot();
+      const matches: { assetCode: string; chain: string }[] = [];
+      for (const [storedKey, entry] of Object.entries(liveChannels)) {
+        if (entry.channelId !== event.channelId) continue;
+        const suffix = `:${event.channelId}`;
+        if (!storedKey.endsWith(suffix)) continue;
+        const prefix = storedKey.slice(0, -suffix.length);
+        const sep = prefix.indexOf(':');
+        if (sep <= 0) continue;
+        matches.push({
+          assetCode: prefix.slice(0, sep),
+          chain: prefix.slice(sep + 1),
+        });
+      }
+      if (matches.length === 0) {
+        logger.warn?.('swap.recordSettlement.unknown_channel', {
+          channelId: event.channelId,
+          txHash: event.txHash,
+        });
+        return 0n;
+      }
+      if (matches.length > 1) {
+        logger.warn?.('swap.recordSettlement.ambiguous_channel', {
+          channelId: event.channelId,
+          matches,
+          note: 'applying to the first match only; provision distinct channelIds per (asset, chain) pool',
+        });
+      }
+      const [target] = matches;
+      if (!target) return 0n; // unreachable (length checked above)
+      const reduced = inventory.recordSettlement({
+        assetCode: target.assetCode,
+        chain: target.chain,
+        channelId: event.channelId,
+        cumulativeAmount: BigInt(event.cumulativeAmount),
+      });
+      if (persister) {
+        try {
+          persister.persist();
+        } catch (err) {
+          logger.error?.('swap.recordSettlement.persist_failed', {
+            err: errSummary(err),
+          });
+        }
+      }
+      logger.info?.('swap.recordSettlement.ok', {
+        channelId: event.channelId,
+        chain: target.chain,
+        asset: target.assetCode,
+        txHash: event.txHash,
+        cumulativeAmount: event.cumulativeAmount,
+        liabilityReduced: reduced.toString(),
+      });
+      return reduced;
     },
     health: getHealth,
     async stop() {

--- a/packages/swap/tests/integration/rolling-swap.integration.test.ts
+++ b/packages/swap/tests/integration/rolling-swap.integration.test.ts
@@ -309,8 +309,17 @@ describe('swap#47 — rolling coupled-leg engine (integration)', () => {
         expect(advance.channelId).toBe(CHANNEL_ID);
       }
 
-      // Maker inventory reflects exactly the delivered total.
-      expect(instance.health().inventoryAvailable[INVENTORY_KEY]).toBe(
+      // Issue #49: the delivered total is UNSETTLED LIABILITY in the
+      // window view — no permanent debit on the rolling flow.
+      const health = instance.health();
+      expect(health.inventoryAvailable[INVENTORY_KEY]).toBe(
+        INITIAL_INVENTORY.toString()
+      );
+      expect(health.inventoryWindow[INVENTORY_KEY]!.unsettled).toBe(
+        (DELTA_WEI * BigInt(packets)).toString()
+      );
+      expect(health.inventoryWindow[INVENTORY_KEY]!.inFlight).toBe('0');
+      expect(health.inventoryWindow[INVENTORY_KEY]!.free).toBe(
         (INITIAL_INVENTORY - DELTA_WEI * BigInt(packets)).toString()
       );
     } finally {
@@ -335,10 +344,15 @@ describe('swap#47 — rolling coupled-leg engine (integration)', () => {
       const stalled = await driveFill(handler, daemon, 3, DELTA);
       expect(stalled.wire).toBe('REJECT');
 
-      // Nothing stayed debited for the failed packet (full unwind).
+      // Nothing stayed reserved for the failed packet (full unwind —
+      // issue #49: the window releases; unsettled stays at the 2 fills).
       expect(instance.health().inventoryAvailable[INVENTORY_KEY]).toBe(
         availableAfter2
       );
+      expect(instance.health().inventoryWindow[INVENTORY_KEY]!).toMatchObject({
+        inFlight: '0',
+        unsettled: (DELTA_WEI * 2n).toString(),
+      });
 
       // Recovery: sender resumes with a NEW seq (spec: seq never reused).
       // The maker re-issues from the unwound watermark — nonce 3 again —
@@ -349,8 +363,12 @@ describe('swap#47 — rolling coupled-leg engine (integration)', () => {
       const last = daemon.advances[daemon.advances.length - 1]!;
       expect(BigInt(last.nonce!)).toBe(3n);
       expect(BigInt(last.cumulativeAmount!)).toBe(DELTA_WEI * 3n);
+      expect(instance.health().inventoryWindow[INVENTORY_KEY]!).toMatchObject({
+        inFlight: '0',
+        unsettled: (DELTA_WEI * 3n).toString(),
+      });
       expect(instance.health().inventoryAvailable[INVENTORY_KEY]).toBe(
-        (INITIAL_INVENTORY - DELTA_WEI * 3n).toString()
+        INITIAL_INVENTORY.toString()
       );
     } finally {
       await instance.stop();


### PR DESCRIPTION
Part of toon-protocol/toon-meta#145. Closes #49. **Stacked on #56** (`feat/47-rolling-engine` is the base branch — merge #56 first, then retarget/merge this).

Implements the honeypot shrink from `toon-meta/docs/rolling-swap.md` §8: the swap node's capital exposure on the rolling path is now sized to the **in-flight window** (δ×W of open packets + unsettled channel balance), not to notional volume. This replaces the one seam #56 left on debit/credit.

## The reservation model

```
reserve  (packet open, leg-B amount)  ──fulfill──▶  commit  (→ unsettled channel liability)
        │                                                  │
        ├──reject / rollback / TTL expiry──▶ release        └──settlement confirmation──▶ liability shrinks,
        │   (exactly once)                                      capacity recycles (settle-and-recycle)
```

**Capacity formula** (per `assetCode:chain` pool):

```
effectiveBudget = min(windowBudget ?? available, available)
free            = effectiveBudget − inFlight − unsettled
```

`SwapNodeConfig.windowBudget` (per chain, CLI `windowBudget` config key) is the operator-advertised ceiling — size it to `δ_max·W_max·R` plus a settlement-latency buffer. It is clamped to live `available` (a budget can never advertise capital the maker lacks; legacy debits shrink rolling capacity too — one real pool). A fill that does not fit rejects with the engine's existing benign vocabulary: T04 / `insufficient_liquidity`, replay seq burned fail-closed, nothing reserved.

**Lifecycle wiring** (`RollingSwapEngine` × `MultiChainClaimIssuer`):

- `issueRollingClaim` — window **reservation** (never a debit) + channel watermark advance + **write-ahead persist**: the reservation is durable BEFORE the leg-B advance can be externalized (persistence rule 1 extended).
- verified leg-B FULFILL → `commitRollingClaim`: reservation → `unsettled`. A `'late'` commit (TTL lapsed mid-flight) is logged and still recorded — liability follows the revealed claim, not the clock.
- reject / timeout / wrong preimage → `rollbackRollingClaim`: releases the reservation **exactly once** (the reservation is the idempotency gate — a double unwind cannot double-decrement the channel watermark) + reverses the watermark + re-persists. Replaces #56's `rollbackClaim` (unreleased API).
- `SwapNodeInstance.recordSettlement(SettlementEvent)` — resolves the pool by `channelId`, shrinks `unsettled` by the per-channel **monotone** cumulative-watermark delta (stale/replayed confirmations are a 0n no-op), persists. Freed liability recycles into window capacity — spec §8 settle-and-recycle replaces manual refill. (Nothing emits `SettlementEvent` live yet; this is the intake seam the settlement auto-drive plugs into.)

**TTLs (R7 alignment):** reservation TTL = leg-B expiry (already capped strictly under leg-A expiry per R7) + `rolling.reservationGraceMs` (default 5s), so no live packet's reservation can expire under it, while a crashed/stalled packet frees its slot right after it could no longer fulfill. Bare `SwapInventory.reserve` defaults to 60s (2× the default leg-B budget).

**Crash recovery — expire-and-release** (state-store crash rule 6): rehydrated reservations occupy the window until their persisted `expiresAt`, then release. No engine survives a restart to commit them, the leg-A packet has expired upstream, and per spec R8 a claim on a REJECTed packet is void — so nothing leaks against an honest counterparty, while the write-ahead watermark (which never regresses) prevents any double-spend (replays stay F04). Rejected alternative, documented in `state-store.ts`: re-deriving `unsettled` from `cumulativeSigned − lastSettled` is unsound while legacy and rolling traffic share channels (it double-counts legacy claims that already debited `available`). Residual windows are the spec's designed δ·W bound (§3.1): a Byzantine sender banking a voided in-flight claim, or a crash between the leg-B FULFILL and the commit persist (under-reports `unsettled` by ≤ the packets in flight, once).

**Health (issue AC-3):** `GET /health` now reports the three buckets per pool — `inventoryWindow: { budget, inFlight, unsettled, free }` — the capital-exposure signal for the rolling path. `inventory`/`inventoryAvailable` are retained (not dropped) because they remain the meaningful view of the legacy pool.

## AC coverage

- [x] Steady-state required float ≈ δ×W + unsettled, not notional: long-stream test drives 60 fills (12× the window budget in notional) through a 5-packet budget with periodic settlement confirmations; max(inFlight+unsettled) never exceeds the budget and `available` never moves.
- [x] Reject/timeout releases; fulfill converts; settlement confirmation shrinks liability (unit + engine + node-level tests).
- [x] Health endpoint reports the three buckets.
- [x] No permanent-debit path remains on the rolling-engine flow (`issueClaim`/debit is now legacy-only; integration test pins the legacy gift-wrap fill still debiting byte-for-byte on the same node).
- [x] `channel-state.ts` `resolveChannel` capacity discrepancy: resolved by **correcting the comment** to the actual first-unbound policy — `ChannelEntry` carries no deposit/capacity field to check against, so a capacity-aware binding is not implementable here; per-pool exposure is bounded one level up by the window budget, and the doc says so.

## Persistence (rules 1–5 + new rule 6)

Schema v2: per-entry `unsettled` (+ informational `windowBudget`), top-level `reservations` + `settledWatermarks`. v1 snapshots load with those defaulted (boot-path compat test); config always wins over snapshots for `windowBudget`. Every reservation/commit/release/settlement re-persists through the same synchronous `SwapStatePersister` path.

## Breaking (same major train as #56 — one changeset each)

`SwapNodeInstance.recordSettlement` + `SwapNodeHealthResponse.inventoryWindow` + `SwapInventoryBalance.unsettled` are new required members (breaking for structural doubles); persisted schema writes v2; `rollbackClaim` → `rollbackRollingClaim` (was unreleased #56 API). Legacy runtime behavior (gift-wrap path, SDK `ClaimIssuer` interface) is unchanged.

Tests: **258 unit** (base 232) + **25 integration** (base 25, 2 updated to window semantics), build/lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
