### PR TITLE
docs(swap-node): correct false claim that chain-id is bound in the balance-proof signature

### DIFF
--- a/packages/swap/src/swap-node.ts
+++ b/packages/swap/src/swap-node.ts
@@ -928,8 +928,16 @@ export async function startSwapNode(
 
   // 4. Construct payment-channel signers per configured family.
   //    Re-use one signer instance per family across every `evm:*`/`solana:*`/
-  //    `mina:*` chain — the chain-id is baked into `BalanceProofParams` at
-  //    signing time, not into the signer itself (per AC-4 phase 4).
+  //    `mina:*` chain. NOTE: the shared EVM signer key is reused for every
+  //    `evm:*` chain, but the signed balance-proof digest does NOT currently
+  //    bind the chainId or the contract/deployment address —
+  //    `EvmPaymentChannelSigner.signBalanceProof` hashes only
+  //    { channelId, cumulativeAmount, nonce, recipient }. Cross-chain /
+  //    cross-deployment replay is therefore prevented ONLY by channelId
+  //    uniqueness, not by the signature itself. A proper fix that
+  //    domain-separates the digest (binding chainId + contract address) is
+  //    tracked in connector#324 (finding #1 from connector PR #320); until
+  //    then, do NOT rely on the signature to scope a balance proof to a chain.
   const signers: Record<string, PaymentChannelSigner> = {};
   const distinctTargetChains = Array.from(
     new Set(config.swapPairs.map((p) => p.to.chain))
@@ -945,7 +953,10 @@ export async function startSwapNode(
           `Pair targets ${chain} but no EVM key was derived`
         );
       }
-      // Re-use a single signer across all `evm:*` chains (AC-4 phase 4).
+      // Re-use a single signer/key across all `evm:*` chains. See the note
+      // above: the balance-proof digest does not bind chainId or contract
+      // address, so this key sharing is NOT what provides cross-chain replay
+      // protection (connector#324).
       sharedEvmSigner ??= new EvmPaymentChannelSigner({
         chain,
         privateKey: swapNodeKeys.evm.privateKey,


### PR DESCRIPTION
## Summary

Documentation-only correction in `packages/swap/src/swap-node.ts` (~L929-956).

The prior comment near the `sharedEvmSigner` construction justified re-using one signer key across every `evm:*` chain by asserting that "the chain-id is baked into `BalanceProofParams` at signing time." **This is false.**

`EvmPaymentChannelSigner.signBalanceProof` (`packages/swap/src/payment-channel-signer.ts`) calls `balanceProofHashEvm(channelBytes, cumulativeAmount, nonce, recipientBytes)` — the digest is computed over only `{ channelId, cumulativeAmount, nonce, recipient }`. Neither the chainId nor the contract/deployment address is passed to the hash, so they are **not** bound in the signature.

The old wording is dangerous because it implies cross-chain / cross-deployment replay protection that does not exist. In reality such replay is prevented **only** by channelId uniqueness.

## What changed

- Rewrote the block comment above the per-family signer construction and the inline comment above `sharedEvmSigner ??= ...` to state accurately that:
  - the EVM signer key is shared across all EVM chains;
  - the signed balance-proof digest does NOT currently bind chainId or contract address;
  - cross-chain/cross-deployment replay is prevented only by channelId uniqueness;
  - a proper fix (domain-separating the digest to bind chainId + contract address) is tracked separately.

No signer logic or runtime behavior is changed — the diff is comment-only.

## References

- This is finding #1 from the review of connector PR #320.
- Proper fix tracked at connector#324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)