### PR TITLE
chore(factory): scaffold the sandcastle software factory (pnpm variant)

### DIFF
--- a/.github/workflows/agent-image.yml
+++ b/.github/workflows/agent-image.yml
@@ -1,0 +1,43 @@
+name: Agent image
+
+# Minimal build-only check for the sandcastle agent container image.
+# Proves the `.sandcastle/Dockerfile` (node:22-bookworm + gh + Claude Code CLI
+# + corepack/pnpm) builds. This is NOT the label->runner: the
+# agent:implement / agent:review triggered runner is a later slice (#184).
+
+on:
+  pull_request:
+    paths:
+      - '.sandcastle/**'
+      - '.github/workflows/agent-image.yml'
+  workflow_dispatch:
+
+jobs:
+  build-image:
+    name: Build sandcastle agent image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # Docker is preinstalled on ubuntu-latest GitHub-hosted runners.
+      # `sandcastle docker build-image` builds .sandcastle/Dockerfile,
+      # defaulting the AGENT_UID/AGENT_GID build args to the runner's uid/gid.
+      - name: Build agent image
+        run: npx --yes @ai-hero/sandcastle@0.12.0 docker build-image
+
+      - name: Verify toolchain inside image
+        run: |
+          docker run --rm --entrypoint bash sandcastle:swap -lc '
+            set -e
+            node --version
+            gh --version | head -1
+            # pnpm resolves via corepack; the mounted repo pins pnpm@8.15.9
+            # through its packageManager field at runtime.
+            corepack --version
+            test "$(whoami)" = "agent"
+            test -x /home/agent/.local/bin/claude
+          '

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -1,0 +1,169 @@
+# agent:implement runner — the sandcastle label→runner for building one issue.
+#
+# WHAT THIS DOES (and does NOT do):
+#   Fires when a human applies the `agent:implement` label to an issue. It runs
+#   the single-issue PR-mode sandcastle runner (`pnpm sandcastle:implement`),
+#   which implements → reviews → OPENS A PR and STOPS. A human reviews and
+#   merges. It does NOT auto-merge and does NOT close the issue.
+#
+#   Merely committing this file triggers nothing: issue-`labeled` workflows only
+#   fire from the default branch, and only when someone actually applies the
+#   label. The first live run is a deliberate human action — see
+#   docs/factory-runbook.md.
+#
+# ┌───────────────────────────────────────────────────────────────────────────┐
+# │ AUTO-MERGE TOGGLE (first-run safety)                                       │
+# │                                                                            │
+# │ DEFAULT = PR mode: the agent opens a PR; a human merges. This is enforced │
+# │ by the runner having no merge phase unless told otherwise.                 │
+# │                                                                            │
+# │ TO RE-ENABLE AUTO-MERGE once the pilot is trusted: add                     │
+# │       SANDCASTLE_AUTO_MERGE: "true"                                        │
+# │ to the `env:` of the "Run sandcastle implement runner" step below. The     │
+# │ runner will then merge the branch into main and close the issue instead of │
+# │ opening a PR. (Confirm the merge path's push-to-main behavior on a         │
+# │ throwaway issue first — it is inherited from the stock engine and is       │
+# │ itself verify-on-first-run.) Leave it unset/false for the pilot.           │
+# └───────────────────────────────────────────────────────────────────────────┘
+#
+# Coexists with the OLD loops (backlog-manager / issue-executor / pr-reviewer /
+# issue-decomposer): those fire on `agent:ready` / `review-round:*` — DISJOINT
+# labels — so no issue triggers two engines. Retiring the old loops is slice
+# #185, gated on a merged agent PR.
+
+name: agent:implement
+
+on:
+  issues:
+    types: [labeled]
+
+# Least-privilege for this job's GITHUB_TOKEN. The engine itself opens the PR
+# using the GitHub App token generated below (a PR opened by the default
+# GITHUB_TOKEN would NOT trigger ci.yml, so the green gate would never run on
+# the agent's PR). These scopes cover the guard job's read-only gh api calls.
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Guard: refuse the wrong targets before spending an agent run.
+  # ---------------------------------------------------------------------------
+  guard:
+    # Only react to THIS label. Every other labeled event is ignored.
+    if: github.event.label.name == 'agent:implement'
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    steps:
+      - name: Evaluate guards
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          proceed=true
+
+          # --- Guard 1: the labeler must have write access -------------------
+          # Refuses drive-by labeling by outside collaborators / bots without
+          # push rights.
+          perm=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" \
+            --jq '.permission' 2>/dev/null || echo "none")
+          echo "Actor ${ACTOR} permission: ${perm}"
+          case "$perm" in
+            admin|maintain|write) ;;
+            *)
+              echo "::warning::Actor ${ACTOR} lacks write permission (${perm}) — skipping."
+              proceed=false ;;
+          esac
+
+          # --- Guard 2: skip triage/parent labels ----------------------------
+          # epic / tracking = PRD-shaped parents; needs:human = held for a human.
+          labels=$(gh issue view "${ISSUE}" --repo "${REPO}" \
+            --json labels --jq '.labels[].name')
+          echo "Issue labels: $(echo "$labels" | paste -sd, -)"
+          for bad in epic tracking needs:human; do
+            if echo "$labels" | grep -qx "$bad"; then
+              echo "::warning::Issue #${ISSUE} carries '${bad}' — not an agent:implement target. Skipping."
+              proceed=false
+            fi
+          done
+
+          # --- Guard 3: refuse parents that have sub-issues ------------------
+          # A PRD-shaped parent (has child issues) must be decomposed, not built
+          # directly. Sub-issues are queried via GraphQL; if the field is
+          # unavailable on this GitHub plan the query errors — we then log and
+          # DO NOT block (documented residual gap: falls back to the epic/
+          # tracking label check above). See docs/factory-runbook.md.
+          sub=$(gh api graphql -f query='
+            query($owner:String!,$repo:String!,$num:Int!){
+              repository(owner:$owner,name:$repo){
+                issue(number:$num){ subIssues(first:1){ totalCount } }
+              }
+            }' \
+            -F owner="${REPO%/*}" -F repo="${REPO#*/}" -F num="${ISSUE}" \
+            --jq '.data.repository.issue.subIssues.totalCount' 2>/dev/null || echo "unknown")
+          echo "Sub-issue count: ${sub}"
+          if [ "$sub" != "unknown" ] && [ "${sub:-0}" -gt 0 ]; then
+            echo "::warning::Issue #${ISSUE} has ${sub} sub-issue(s) — it is a parent. Skipping."
+            proceed=false
+          elif [ "$sub" = "unknown" ]; then
+            echo "::warning::Could not query sub-issues (field unavailable). Relying on epic/tracking labels only."
+          fi
+
+          echo "proceed=${proceed}" >> "$GITHUB_OUTPUT"
+
+  # ---------------------------------------------------------------------------
+  # Implement: run the single-issue PR-mode sandcastle runner.
+  # ---------------------------------------------------------------------------
+  implement:
+    needs: guard
+    if: needs.guard.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60 # real backstop; the implementer allows up to 100 iters
+    concurrency:
+      group: agent-implement-issue-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so the sandbox can diff/branch cleanly
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Enable pnpm via corepack
+        run: corepack enable && corepack prepare pnpm@8.15.9 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Docker is preinstalled on ubuntu-latest. Build the agent sandbox image
+      # (.sandcastle/Dockerfile) the engine runs each agent inside.
+      - name: Build sandcastle agent image
+        run: npx --yes @ai-hero/sandcastle@0.12.0 docker build-image
+
+      # The engine opens the PR via this App token. A PR opened by it (unlike one
+      # opened by the default GITHUB_TOKEN) triggers ci.yml, so the green gate
+      # runs on the agent's PR. Requires the org/repo secrets APP_ID +
+      # APP_PRIVATE_KEY (already used by the existing issue-executor loop).
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Run sandcastle implement runner
+        env:
+          SANDCASTLE_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          # PR mode (default). To re-enable auto-merge later, uncomment:
+          # SANDCASTLE_AUTO_MERGE: "true"
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: pnpm sandcastle:implement

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -1,0 +1,110 @@
+# agent:review runner — the sandcastle label→runner for reviewing one PR.
+#
+# WHAT THIS DOES (and does NOT do):
+#   Fires when a human applies the `agent:review` label to a PULL REQUEST. It
+#   runs the single-pass reviewer (`pnpm sandcastle:review`) against the PR's
+#   head branch, pushing any clarity/standards refinements back onto the PR. It
+#   NEVER merges the PR and NEVER closes anything — a human still merges. This is
+#   the single-pass replacement for the old 4-round `review-round:*` loop.
+#
+#   Committing this file triggers nothing: pull_request-`labeled` workflows fire
+#   only from the default branch and only when someone applies the label.
+#
+# VERIFY ON FIRST RUN — the standalone-review path:
+#   Sandcastle 0.12.0 only exercises the reviewer inside its parallel loop, on a
+#   fresh branch it just created. Running it standalone against an existing PR
+#   head branch is our interpretation (see .sandcastle/agent-review-pr.ts). On
+#   the first live run confirm: (1) the sandbox checks out the existing PR head
+#   rather than erroring on the ref, and (2) review-prompt.md's built-in
+#   {{TARGET_BRANCH}} resolves to `main` so the diff is non-empty.
+#
+# Note: label events on PRs opened from FORKS run without secrets (GitHub
+# security), so this runner only works on same-repo PRs. That is expected for
+# the internal factory flow.
+#
+# Coexists with the old pr-reviewer loop, which fires on `review-round:*`
+# (disjoint labels). Retiring the old loops is slice #185.
+
+name: agent:review
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  guard:
+    if: github.event.label.name == 'agent:review'
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    steps:
+      - name: Evaluate guards
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          proceed=true
+
+          # The labeler must have write access — refuses drive-by review
+          # requests from outsiders.
+          perm=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" \
+            --jq '.permission' 2>/dev/null || echo "none")
+          echo "Actor ${ACTOR} permission: ${perm}"
+          case "$perm" in
+            admin|maintain|write) ;;
+            *)
+              echo "::warning::Actor ${ACTOR} lacks write permission (${perm}) — skipping."
+              proceed=false ;;
+          esac
+
+          echo "proceed=${proceed}" >> "$GITHUB_OUTPUT"
+
+  review:
+    needs: guard
+    if: needs.guard.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: agent-review-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Check out the PR head so the reviewer operates on the right branch.
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Enable pnpm via corepack
+        run: corepack enable && corepack prepare pnpm@8.15.9 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build sandcastle agent image
+        run: npx --yes @ai-hero/sandcastle@0.12.0 docker build-image
+
+      # App token so review commits pushed back to the PR re-trigger ci.yml.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Run sandcastle review runner
+        env:
+          SANDCASTLE_PR_NUMBER: ${{ github.event.pull_request.number }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: pnpm sandcastle:review

--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -1,0 +1,9 @@
+# Claude Code OAuth token — get one by running `claude setup-token` on your host.
+# Lets the agent use your Claude subscription instead of an API key.
+CLAUDE_CODE_OAUTH_TOKEN=
+# Or use an Anthropic API key instead — uncomment and fill in:
+# ANTHROPIC_API_KEY=
+# GitHub personal access token — the agent uses it to read and manage GitHub Issues
+# Create a fine-grained token: https://github.com/settings/personal-access-tokens/new
+# Required repository permissions: Issues (Read and write) and Metadata (Read)
+GH_TOKEN=

--- a/.sandcastle/.gitignore
+++ b/.sandcastle/.gitignore
@@ -1,0 +1,3 @@
+.env
+logs/
+worktrees/

--- a/.sandcastle/CODING_STANDARDS.md
+++ b/.sandcastle/CODING_STANDARDS.md
@@ -1,0 +1,27 @@
+# Coding Standards
+
+<!-- Customize this file with your project's coding standards.
+     The reviewer agent loads it during code review via @.sandcastle/CODING_STANDARDS.md
+     so these standards are enforced during review without costing tokens during implementation. -->
+
+## Style
+
+<!-- Example:
+- Use camelCase for variables and functions
+- Use PascalCase for classes and types
+- Prefer named exports over default exports
+-->
+
+## Testing
+
+<!-- Example:
+- Every public function must have at least one test
+- Use descriptive test names that explain the expected behavior
+-->
+
+## Architecture
+
+<!-- Example:
+- Keep modules focused on a single responsibility
+- Prefer composition over inheritance
+-->

--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -1,0 +1,44 @@
+FROM node:22-bookworm
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+  git \
+  curl \
+  jq \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+  | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && apt-get update && apt-get install -y gh \
+  && rm -rf /var/lib/apt/lists/*
+
+# Enable pnpm via corepack (run as root, before the USER switch — corepack
+# writes shims into a root-owned prefix). Pin matches swap's package.json
+# `packageManager` field (pnpm@8.15.9).
+RUN corepack enable && corepack prepare pnpm@8.15.9 --activate
+
+# Build-args for UID/GID alignment: sandcastle docker build-image
+# defaults these to the host user's UID/GID so image-built files
+# and bind-mounted files share an owner without runtime chown.
+ARG AGENT_UID=1000
+ARG AGENT_GID=1000
+
+# Rename the base image's "node" user to "agent" and align UID/GID.
+RUN groupmod -o -g $AGENT_GID node && usermod -o -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+USER ${AGENT_UID}:${AGENT_GID}
+
+# Install Claude Code CLI
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+# Add Claude to PATH
+ENV PATH="/home/agent/.local/bin:$PATH"
+
+WORKDIR /home/agent
+
+# In worktree sandbox mode, Sandcastle bind-mounts the git worktree at /home/agent/workspace
+# and overrides the working directory to /home/agent/workspace at container start.
+# Structure your Dockerfile so that /home/agent/workspace can serve as the project root.
+ENTRYPOINT ["sleep", "infinity"]

--- a/.sandcastle/agent-implement-issue.ts
+++ b/.sandcastle/agent-implement-issue.ts
@@ -1,0 +1,174 @@
+// Single-issue PR-mode implement runner — the entry point the
+// `agent:implement` label→runner workflow (.github/workflows/agent-implement.yml)
+// invokes for ONE explicitly-labeled issue.
+//
+// How this differs from the full autonomous loop in `main.ts`:
+//   - main.ts  = the multi-issue autonomous engine: Phase 1 planner scans ALL
+//                open `agent:implement` issues, Phase 2 implements+reviews them
+//                in parallel, Phase 3 MERGES every branch into the checked-out
+//                branch and CLOSES the issues. That is the "auto-merge" engine,
+//                reserved for later (backlog draining / slice #185).
+//   - this file = human-in-the-loop, ONE issue, and by default it OPENS A PR
+//                 and STOPS. A human reviews and merges. There is no planner
+//                 (the issue is already chosen by the label event) and, in the
+//                 default mode, no merge phase at all.
+//
+// FIRST-RUN SAFETY / AUTO-MERGE TOGGLE
+// ------------------------------------
+//   SANDCASTLE_AUTO_MERGE unset | "false"  (DEFAULT, safe):
+//       implement -> review -> push branch + open a PR (open-pr-prompt.md).
+//       Nothing is merged; the issue is NOT closed; a human merges the PR.
+//   SANDCASTLE_AUTO_MERGE = "true"  (re-enable once the pilot is trusted):
+//       implement -> review -> merge the branch into the checked-out base and
+//       close the issue (the stock merge-prompt.md). NOTE: the stock merge
+//       prompt's push-to-origin semantics are inherited from the engine and are
+//       themselves verify-on-first-run — do not flip this on until the PR path
+//       has been proven and you have confirmed how the merge lands on main.
+//
+// The toggle lives in ONE place (this env var, read below) and is documented in
+// agent-implement.yml and docs/factory-runbook.md.
+//
+// Required env:
+//   SANDCASTLE_ISSUE_NUMBER   the issue to work (github.event.issue.number)
+//   CLAUDE_CODE_OAUTH_TOKEN   Claude Max-plan credential (org secret)
+//   GH_TOKEN                  token with contents:write + pull-requests:write +
+//                             issues:write (the App token in CI)
+//
+// Usage:
+//   SANDCASTLE_ISSUE_NUMBER=123 npx tsx .sandcastle/agent-implement-issue.ts
+//   # or: pnpm sandcastle:implement   (with SANDCASTLE_ISSUE_NUMBER exported)
+
+import { execFileSync } from "node:child_process";
+import * as sandcastle from "@ai-hero/sandcastle";
+import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+import { sandboxSecrets } from "./sandbox-secrets.ts";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const issueNumber = process.env.SANDCASTLE_ISSUE_NUMBER?.trim();
+if (!issueNumber || !/^\d+$/.test(issueNumber)) {
+  throw new Error(
+    "SANDCASTLE_ISSUE_NUMBER must be set to a numeric issue number " +
+      `(got: ${JSON.stringify(process.env.SANDCASTLE_ISSUE_NUMBER)}).`,
+  );
+}
+
+// Default is PR mode. Auto-merge only when the flag is exactly "true".
+const autoMerge = process.env.SANDCASTLE_AUTO_MERGE === "true";
+
+// Deterministic branch name, matching the planner's convention in main.ts so a
+// re-run of the same issue reuses the same branch and accumulated progress.
+const branch = `sandcastle/issue-${issueNumber}`;
+
+// Fetch the issue title on the host so we can pass it to the prompts and name
+// the PR. `gh` authenticates via GH_TOKEN in the environment.
+const issueTitle = execFileSync(
+  "gh",
+  ["issue", "view", issueNumber, "--json", "title", "--jq", ".title"],
+  { encoding: "utf8" },
+).trim();
+
+// swap is a pnpm workspace: install with the committed lockfile so the sandbox
+// resolves the exact dependency tree. Mirrors main.ts (we deliberately do NOT
+// copyToWorktree node_modules — pnpm's symlinked store breaks across the
+// host->worktree bind-mount).
+const hooks = {
+  sandbox: { onSandboxReady: [{ command: "pnpm install --frozen-lockfile" }] },
+};
+
+console.log(
+  `\n=== agent:implement runner — issue #${issueNumber} "${issueTitle}" ===`,
+);
+console.log(`Branch: ${branch}`);
+console.log(
+  `Mode:   ${autoMerge ? "AUTO-MERGE (SANDCASTLE_AUTO_MERGE=true)" : "PR (default — human merges)"}\n`,
+);
+
+// ---------------------------------------------------------------------------
+// Implement -> Review -> (open PR | merge)
+// ---------------------------------------------------------------------------
+
+const sandbox = await sandcastle.createSandbox({
+  branch,
+  // Forward CLAUDE_CODE_OAUTH_TOKEN + GH_TOKEN from the host into the container.
+  // Without this the engine's env resolver never passes them through (they are
+  // not in the gitignored `.sandcastle/.env`), so claude-code is "Not logged in"
+  // and the in-sandbox `git push`/`gh pr create` are unauthenticated. See
+  // ./sandbox-secrets.ts for the full root-cause note.
+  sandbox: docker({ env: sandboxSecrets() }),
+  hooks,
+});
+
+try {
+  // Implement (opus, up to 100 iterations of the RED->GREEN->REFACTOR loop).
+  const implement = await sandbox.run({
+    name: "implementer",
+    maxIterations: 100,
+    agent: sandcastle.claudeCode("claude-opus-4-8"),
+    promptFile: "./.sandcastle/implement-prompt.md",
+    promptArgs: {
+      TASK_ID: issueNumber,
+      ISSUE_TITLE: issueTitle,
+      BRANCH: branch,
+    },
+  });
+
+  if (implement.commits.length === 0) {
+    console.log(
+      "\nImplementer produced no commits — nothing to open a PR for. " +
+        "Leaving the issue as-is. Inspect the logs, then remove/re-apply the " +
+        "agent:implement label to retry.",
+    );
+    process.exit(0);
+  }
+
+  // Review (opus, 1 iteration) on the SAME branch. The engine supplies the
+  // built-in {{TARGET_BRANCH}} used inside review-prompt.md, so we pass only
+  // BRANCH (mirrors main.ts).
+  await sandbox.run({
+    name: "reviewer",
+    maxIterations: 1,
+    agent: sandcastle.claudeCode("claude-opus-4-8"),
+    promptFile: "./.sandcastle/review-prompt.md",
+    promptArgs: { BRANCH: branch },
+  });
+
+  if (autoMerge) {
+    // RE-ENABLE path: merge this one branch into the checked-out base and close
+    // the issue, using the stock merge prompt scoped to the single branch.
+    console.log("\nAuto-merge enabled — merging branch and closing issue.");
+    await sandbox.run({
+      name: "merger",
+      maxIterations: 1,
+      agent: sandcastle.claudeCode("claude-opus-4-8"),
+      promptFile: "./.sandcastle/merge-prompt.md",
+      promptArgs: {
+        BRANCHES: `- ${branch}`,
+        ISSUES: `- ${issueNumber}: ${issueTitle}`,
+      },
+    });
+    console.log("\nMerge phase complete.");
+  } else {
+    // DEFAULT path: push the branch and open a PR for a human to review+merge.
+    // Nothing is merged and the issue is NOT closed here.
+    console.log("\nPR mode — pushing branch and opening a PR for human review.");
+    await sandbox.run({
+      name: "open-pr",
+      maxIterations: 1,
+      agent: sandcastle.claudeCode("claude-opus-4-8"),
+      promptFile: "./.sandcastle/open-pr-prompt.md",
+      promptArgs: {
+        TASK_ID: issueNumber,
+        ISSUE_TITLE: issueTitle,
+        BRANCH: branch,
+      },
+    });
+    console.log("\nPR opened (or already existed). Awaiting human review.");
+  }
+} finally {
+  await sandbox.close();
+}
+
+console.log("\nDone.");

--- a/.sandcastle/agent-review-pr.ts
+++ b/.sandcastle/agent-review-pr.ts
@@ -1,0 +1,106 @@
+// Single-PR review runner — the entry point the `agent:review` label→runner
+// workflow (.github/workflows/agent-review.yml) invokes when `agent:review` is
+// applied to ONE pull request.
+//
+// This is the single-pass replacement for the old 4-round `review-round:*`
+// reviewer loop. It runs the reviewer role (review-prompt.md — refactor for
+// clarity while preserving behavior, enforce CODING_STANDARDS.md) against the
+// PR's head branch, and pushes any refinement commits back to the PR. It NEVER
+// merges the PR and NEVER closes anything — a human still merges.
+//
+// STANDALONE-REVIEW CAVEAT (verify on first run)
+// ----------------------------------------------
+// Sandcastle 0.12.0 exercises the reviewer only INSIDE the parallel loop's
+// Phase 2, on a fresh `sandcastle/issue-*` branch it just created. Driving the
+// same reviewer standalone against an already-existing PR head branch is our
+// interpretation, not a documented engine feature. Two things to confirm on the
+// first live run:
+//   1. createSandbox({ branch: <existing PR head> }) checks out the EXISTING
+//      branch (rather than failing because the ref already exists / creating a
+//      divergent one). The workflow checks out the PR head first to help this.
+//   2. The built-in {{TARGET_BRANCH}} inside review-prompt.md resolves to `main`
+//      for a standalone sandbox. If the diff comes back empty, the base may be
+//      resolving wrong — check the reviewer's logged `git diff` command.
+//
+// Required env:
+//   SANDCASTLE_PR_NUMBER      the PR to review (github.event.pull_request.number)
+//   CLAUDE_CODE_OAUTH_TOKEN   Claude Max-plan credential (org secret)
+//   GH_TOKEN                  token with contents:write + pull-requests:write
+//
+// Usage:
+//   SANDCASTLE_PR_NUMBER=42 npx tsx .sandcastle/agent-review-pr.ts
+//   # or: pnpm sandcastle:review   (with SANDCASTLE_PR_NUMBER exported)
+
+import { execFileSync } from "node:child_process";
+import * as sandcastle from "@ai-hero/sandcastle";
+import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+import { sandboxSecrets } from "./sandbox-secrets.ts";
+
+const prNumber = process.env.SANDCASTLE_PR_NUMBER?.trim();
+if (!prNumber || !/^\d+$/.test(prNumber)) {
+  throw new Error(
+    "SANDCASTLE_PR_NUMBER must be set to a numeric PR number " +
+      `(got: ${JSON.stringify(process.env.SANDCASTLE_PR_NUMBER)}).`,
+  );
+}
+
+// Resolve the PR's head branch on the host. `gh` authenticates via GH_TOKEN.
+const headRef = execFileSync(
+  "gh",
+  ["pr", "view", prNumber, "--json", "headRefName", "--jq", ".headRefName"],
+  { encoding: "utf8" },
+).trim();
+
+if (!headRef) {
+  throw new Error(`Could not resolve head branch for PR #${prNumber}.`);
+}
+
+const hooks = {
+  sandbox: { onSandboxReady: [{ command: "pnpm install --frozen-lockfile" }] },
+};
+
+console.log(
+  `\n=== agent:review runner — PR #${prNumber} (head: ${headRef}) ===\n`,
+);
+
+const sandbox = await sandcastle.createSandbox({
+  branch: headRef,
+  // Forward CLAUDE_CODE_OAUTH_TOKEN + GH_TOKEN into the container (the engine's
+  // env resolver does not — see ./sandbox-secrets.ts). GH_TOKEN is what the
+  // review-push step's in-sandbox `git push` to the PR branch authenticates with.
+  sandbox: docker({ env: sandboxSecrets() }),
+  hooks,
+});
+
+try {
+  const review = await sandbox.run({
+    name: "reviewer",
+    maxIterations: 1,
+    agent: sandcastle.claudeCode("claude-opus-4-8"),
+    promptFile: "./.sandcastle/review-prompt.md",
+    promptArgs: { BRANCH: headRef },
+  });
+
+  if (review.commits.length > 0) {
+    // Push the reviewer's refinement commits back onto the PR branch. No merge,
+    // no close, no new PR — the existing PR just gets updated.
+    console.log(
+      `\nReviewer made ${review.commits.length} commit(s) — pushing to the PR branch.`,
+    );
+    await sandbox.run({
+      name: "push-review",
+      maxIterations: 1,
+      agent: sandcastle.claudeCode("claude-opus-4-8"),
+      promptFile: "./.sandcastle/review-push-prompt.md",
+      promptArgs: { BRANCH: headRef },
+    });
+  } else {
+    console.log(
+      "\nReviewer made no changes — the code was already clean. Nothing to push.",
+    );
+  }
+} finally {
+  await sandbox.close();
+}
+
+console.log("\nReview complete. The PR was NOT merged — a human still merges.");

--- a/.sandcastle/implement-prompt.md
+++ b/.sandcastle/implement-prompt.md
@@ -1,0 +1,69 @@
+# TASK
+
+Fix issue {{TASK_ID}}: {{ISSUE_TITLE}}
+
+Pull in the issue using `gh issue view <ID>`. If it has a parent PRD, pull that in too.
+
+Only work on the issue specified.
+
+Work on branch {{BRANCH}}. Make commits and run tests.
+
+# CONTEXT
+
+Here are the last 10 commits:
+
+<recent-commits>
+
+!`git log -n 10 --format="%H%n%ad%n%B---" --date=short`
+
+</recent-commits>
+
+# EXPLORATION
+
+Explore the repo and fill your context window with relevant information that will allow you to complete the task.
+
+Pay extra attention to test files that touch the relevant parts of the code.
+
+# EXECUTION
+
+If applicable, use RGR to complete the task.
+
+1. RED: write one test
+2. GREEN: write the implementation to pass that test
+3. REPEAT until done
+4. REFACTOR the code
+
+# FEEDBACK LOOPS
+
+swap is a pnpm workspace. Before committing, run swap's real gate and make sure every command passes:
+
+- lint: `eslint .`
+- typecheck: `pnpm run typecheck`
+- test: `vitest run`
+- build: `pnpm -r run build`
+
+Do not commit until lint, typecheck, test, and build all pass.
+
+# COMMIT
+
+Make a git commit. The commit message must:
+
+1. Start with `RALPH:` prefix
+2. Include task completed + PRD reference
+3. Key decisions made
+4. Files changed
+5. Blockers or notes for next iteration
+
+Keep it concise.
+
+# THE ISSUE
+
+If the task is not complete, leave a comment on the issue with what was done.
+
+Do not close the issue - this will be done later.
+
+Once complete, output <promise>COMPLETE</promise>.
+
+# FINAL RULES
+
+ONLY WORK ON A SINGLE TASK.

--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -1,0 +1,236 @@
+// Parallel Planner with Review — four-phase orchestration loop
+//
+// This template drives a multi-phase workflow:
+//   Phase 1 (Plan):             An opus agent analyzes open issues, builds a
+//                               dependency graph, and outputs a <plan> JSON
+//                               listing unblocked issues with branch names.
+//   Phase 2 (Execute + Review): For each issue, a sandbox is created via
+//                               createSandbox(). The implementer runs first
+//                               (100 iterations). If it produces commits, a
+//                               reviewer runs in the same sandbox on the same
+//                               branch (1 iteration). All issue pipelines run
+//                               concurrently via Promise.allSettled().
+//   Phase 3 (Merge):            A single agent merges all completed branches
+//                               into the current branch.
+//
+// The outer loop repeats up to MAX_ITERATIONS times so that newly unblocked
+// issues are picked up after each round of merges.
+//
+// Usage:
+//   npx tsx .sandcastle/main.ts
+// Or add to package.json:
+//   "scripts": { "sandcastle": "npx tsx .sandcastle/main.ts" }
+
+import * as sandcastle from "@ai-hero/sandcastle";
+import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+import { z } from "zod";
+import { sandboxSecrets } from "./sandbox-secrets.ts";
+
+// Forward host secrets into every sandbox this loop spawns. The engine's env
+// resolver only passes vars that appear in the gitignored `.sandcastle/.env`,
+// so in CI CLAUDE_CODE_OAUTH_TOKEN + GH_TOKEN would otherwise never reach the
+// container. See ./sandbox-secrets.ts for the full root-cause note.
+const sandboxEnv = sandboxSecrets();
+
+// The planner emits its plan as JSON inside <plan> tags; Output.object extracts
+// and validates it against this schema. We use Zod here, but any Standard
+// Schema validator works just as well — Valibot, ArkType, etc. See
+// https://standardschema.dev.
+const planSchema = z.object({
+  issues: z.array(
+    z.object({ id: z.string(), title: z.string(), branch: z.string() }),
+  ),
+});
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+// Maximum number of plan→execute→merge cycles before stopping.
+// Raise this if your backlog is large; lower it for a quick smoke-test run.
+const MAX_ITERATIONS = 10;
+
+// Hooks run inside the sandbox before the agent starts each iteration.
+// swap is a pnpm workspace: install with the committed lockfile so the
+// sandbox resolves the exact dependency tree. This replaces the template's
+// default `npm install` (swap does not use npm).
+const hooks = {
+  sandbox: { onSandboxReady: [{ command: "pnpm install --frozen-lockfile" }] },
+};
+
+// NOTE: the stock template copies the host `node_modules` into the worktree
+// (`copyToWorktree: ["node_modules"]`) for fast startup. That is unsafe with
+// pnpm: pnpm's `node_modules` is a symlink farm into a content-addressed store
+// (`.pnpm/`), and copying it across the host→worktree bind-mount breaks those
+// symlinks. We DROP copyToWorktree and rely on the `pnpm install
+// --frozen-lockfile` hook above to populate deps inside the sandbox instead.
+
+// ---------------------------------------------------------------------------
+// Main loop
+// ---------------------------------------------------------------------------
+
+for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
+  console.log(`\n=== Iteration ${iteration}/${MAX_ITERATIONS} ===\n`);
+
+  // -------------------------------------------------------------------------
+  // Phase 1: Plan
+  //
+  // The planning agent (opus, for deeper reasoning) reads the open issue list,
+  // builds a dependency graph, and selects the issues that can be worked in
+  // parallel right now (i.e., no blocking dependencies on other open issues).
+  //
+  // It outputs a <plan> JSON block — Output.object parses and validates it.
+  // -------------------------------------------------------------------------
+  const plan = await sandcastle.run({
+    hooks,
+    sandbox: docker({ env: sandboxEnv }),
+    name: "planner",
+    // One iteration is enough: the planner just needs to read and reason,
+    // not write code. (Structured output requires maxIterations: 1.)
+    maxIterations: 1,
+    // Opus for planning: dependency analysis benefits from deeper reasoning.
+    agent: sandcastle.claudeCode("claude-opus-4-8"),
+    promptFile: "./.sandcastle/plan-prompt.md",
+    // Extract and validate the <plan> JSON into a typed object. Throws
+    // StructuredOutputError if the tag is missing, the JSON is malformed, or
+    // validation fails — which aborts the loop.
+    output: sandcastle.Output.object({ tag: "plan", schema: planSchema }),
+  });
+
+  const issues = plan.output.issues;
+
+  if (issues.length === 0) {
+    // No unblocked work — either everything is done or everything is blocked.
+    console.log("No unblocked issues to work on. Exiting.");
+    break;
+  }
+
+  console.log(
+    `Planning complete. ${issues.length} issue(s) to work in parallel:`,
+  );
+  for (const issue of issues) {
+    console.log(`  ${issue.id}: ${issue.title} → ${issue.branch}`);
+  }
+
+  // -------------------------------------------------------------------------
+  // Phase 2: Execute + Review
+  //
+  // For each issue, create a sandbox via createSandbox() so the implementer
+  // and reviewer share the same sandbox instance per branch. The implementer
+  // runs first; if it produces commits, the reviewer runs in the same sandbox.
+  //
+  // Promise.allSettled means one failing pipeline doesn't cancel the others.
+  // -------------------------------------------------------------------------
+
+  const settled = await Promise.allSettled(
+    issues.map(async (issue) => {
+      const sandbox = await sandcastle.createSandbox({
+        branch: issue.branch,
+        sandbox: docker({ env: sandboxEnv }),
+        hooks,
+      });
+
+      try {
+        // Run the implementer
+        const implement = await sandbox.run({
+          name: "implementer",
+          maxIterations: 100,
+          agent: sandcastle.claudeCode("claude-opus-4-8"),
+          promptFile: "./.sandcastle/implement-prompt.md",
+          promptArgs: {
+            TASK_ID: issue.id,
+            ISSUE_TITLE: issue.title,
+            BRANCH: issue.branch,
+          },
+        });
+
+        // Only review if the implementer produced commits
+        if (implement.commits.length > 0) {
+          const review = await sandbox.run({
+            name: "reviewer",
+            maxIterations: 1,
+            agent: sandcastle.claudeCode("claude-opus-4-8"),
+            promptFile: "./.sandcastle/review-prompt.md",
+            promptArgs: {
+              BRANCH: issue.branch,
+            },
+          });
+
+          // Merge commits from both runs so the merge phase sees all of them.
+          // Each sandbox.run() only returns commits from its own run.
+          return {
+            ...review,
+            commits: [...implement.commits, ...review.commits],
+          };
+        }
+
+        return implement;
+      } finally {
+        await sandbox.close();
+      }
+    }),
+  );
+
+  // Log any agents that threw (network error, sandbox crash, etc.).
+  for (const [i, outcome] of settled.entries()) {
+    if (outcome.status === "rejected") {
+      console.error(
+        `  ✗ ${issues[i]!.id} (${issues[i]!.branch}) failed: ${outcome.reason}`,
+      );
+    }
+  }
+
+  // Only pass branches that actually produced commits to the merge phase.
+  // An agent that ran successfully but made no commits has nothing to merge.
+  const completedIssues = settled
+    .map((outcome, i) => ({ outcome, issue: issues[i]! }))
+    .filter(
+      (entry) =>
+        entry.outcome.status === "fulfilled" &&
+        entry.outcome.value.commits.length > 0,
+    )
+    .map((entry) => entry.issue);
+
+  const completedBranches = completedIssues.map((i) => i.branch);
+
+  console.log(
+    `\nExecution complete. ${completedBranches.length} branch(es) with commits:`,
+  );
+  for (const branch of completedBranches) {
+    console.log(`  ${branch}`);
+  }
+
+  if (completedBranches.length === 0) {
+    // All agents ran but none made commits — nothing to merge this cycle.
+    console.log("No commits produced. Nothing to merge.");
+    continue;
+  }
+
+  // -------------------------------------------------------------------------
+  // Phase 3: Merge
+  //
+  // One agent merges all completed branches into the current branch,
+  // resolving any conflicts and running tests to confirm everything works.
+  //
+  // The {{BRANCHES}} and {{ISSUES}} prompt arguments are lists that the agent
+  // uses to know which branches to merge and which issues to close.
+  // -------------------------------------------------------------------------
+  await sandcastle.run({
+    hooks,
+    sandbox: docker({ env: sandboxEnv }),
+    name: "merger",
+    maxIterations: 1,
+    agent: sandcastle.claudeCode("claude-opus-4-8"),
+    promptFile: "./.sandcastle/merge-prompt.md",
+    promptArgs: {
+      // A markdown list of branch names, one per line.
+      BRANCHES: completedBranches.map((b) => `- ${b}`).join("\n"),
+      // A markdown list of issue IDs and titles, one per line.
+      ISSUES: completedIssues.map((i) => `- ${i.id}: ${i.title}`).join("\n"),
+    },
+  });
+
+  console.log("\nBranches merged.");
+}
+
+console.log("\nAll done.");

--- a/.sandcastle/merge-prompt.md
+++ b/.sandcastle/merge-prompt.md
@@ -1,0 +1,26 @@
+# TASK
+
+Merge the following branches into the current branch:
+
+{{BRANCHES}}
+
+For each branch:
+
+1. Run `git merge <branch> --no-edit`
+2. If there are merge conflicts, resolve them intelligently by reading both sides and choosing the correct resolution
+3. After resolving conflicts, run swap's gate to verify everything works — `eslint .`, `pnpm run typecheck`, `vitest run`, and `pnpm -r run build`
+4. If tests fail, fix the issues before proceeding to the next branch
+
+After all branches are merged, make a single commit summarizing the merge.
+
+# CLOSE ISSUES
+
+For each branch that was merged, close its issue using the following command:
+
+`gh issue close <ID> --comment "Completed by Sandcastle"`
+
+Here are all the issues:
+
+{{ISSUES}}
+
+Once you've merged everything you can, output <promise>COMPLETE</promise>.

--- a/.sandcastle/open-pr-prompt.md
+++ b/.sandcastle/open-pr-prompt.md
@@ -1,0 +1,55 @@
+# TASK
+
+Push branch `{{BRANCH}}` and open a pull request against `main` for issue
+#{{TASK_ID}} ({{ISSUE_TITLE}}). **Do NOT merge anything. Do NOT close the
+issue.** A human reviews and merges the PR.
+
+# STEPS
+
+1. Confirm you are on branch `{{BRANCH}}` and that it has commits ahead of
+   `main`:
+
+   !`git rev-parse --abbrev-ref HEAD`
+   !`git log main..{{BRANCH}} --oneline`
+
+   If there are no commits ahead of `main`, output `<promise>COMPLETE</promise>`
+   and stop — there is nothing to open a PR for.
+
+2. Push the branch to origin:
+
+   `git push -u origin {{BRANCH}}`
+
+3. Check whether a PR for this branch already exists:
+
+   `gh pr list --head {{BRANCH}} --state open --json number --jq '.[].number'`
+
+   - If one already exists, leave it as-is (do not open a duplicate) and stop.
+   - Otherwise open a new PR (step 4).
+
+4. Open the PR:
+
+   ```
+   gh pr create \
+     --base main \
+     --head {{BRANCH}} \
+     --title "{{ISSUE_TITLE}}" \
+     --body "<body below>"
+   ```
+
+   PR body must:
+   - Start with a one-line summary of what changed.
+   - Reference the issue with `Part of #{{TASK_ID}}` — **NOT** `Closes #` or
+     `Fixes #`. The issue only closes once a human has reviewed and merged this
+     PR; do not auto-close it.
+   - Note that this PR was produced by the sandcastle `agent:implement` runner
+     and is awaiting human review.
+   - End with the line:
+     `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
+
+# RULES
+
+- Never run `git merge`, `gh pr merge`, or `gh issue close`.
+- Do not modify code here — implementation and review already happened on this
+  branch. This step only publishes the branch and opens the PR.
+
+Once the PR is open (or already existed), output `<promise>COMPLETE</promise>`.

--- a/.sandcastle/plan-dry-run.ts
+++ b/.sandcastle/plan-dry-run.ts
@@ -1,0 +1,68 @@
+// Dry-run "plan" — Phase 1 of parallel-planner-with-review in isolation.
+//
+// Sandcastle 0.12.0 ships NO `sandcastle plan` / `--dry-run` CLI command
+// (the CLI is only `init` + `docker|podman build-image|remove-image`). The
+// factory's "dry-run plan" is therefore this: run ONLY the planner phase —
+// a read-only, maxIterations:1 opus pass that reads the open `agent:implement`
+// issue list, builds a dependency graph, and emits a validated <plan> — then
+// print it and EXIT WITHOUT implementing, reviewing, or merging anything.
+//
+// Requirements (same as a real run):
+//   - Docker daemon on the host (the planner runs in the sandcastle image).
+//   - The image built:            npx @ai-hero/sandcastle docker build-image
+//   - A Claude credential in      .sandcastle/.env  (CLAUDE_CODE_OAUTH_TOKEN)
+//     — org Actions secret in CI. GH_TOKEN so the in-sandbox `gh issue list`
+//     can read issues.
+//
+// Usage:
+//   npx tsx .sandcastle/plan-dry-run.ts
+//   # or: pnpm sandcastle:plan
+//
+// An empty backlog validly prints <plan>{"issues": []}</plan> — that still
+// proves the mechanism end-to-end (auth + sandbox + gh + schema validation).
+
+import * as sandcastle from "@ai-hero/sandcastle";
+import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+import { z } from "zod";
+import { sandboxSecrets } from "./sandbox-secrets.ts";
+
+// Same schema the real loop validates the planner's <plan> against (main.ts).
+const planSchema = z.object({
+  issues: z.array(
+    z.object({ id: z.string(), title: z.string(), branch: z.string() }),
+  ),
+});
+
+// swap is a pnpm workspace — install with the committed lockfile (mirrors
+// main.ts). We do NOT copyToWorktree node_modules (pnpm's symlinked store
+// breaks across the bind-mount).
+const hooks = {
+  sandbox: { onSandboxReady: [{ command: "pnpm install --frozen-lockfile" }] },
+};
+
+const plan = await sandcastle.run({
+  hooks,
+  // Forward CLAUDE_CODE_OAUTH_TOKEN + GH_TOKEN into the container; the engine's
+  // env resolver does not (see ./sandbox-secrets.ts). The planner needs the
+  // Claude credential and GH_TOKEN for the in-sandbox `gh issue list`.
+  sandbox: docker({ env: sandboxSecrets() }),
+  name: "planner-dry-run",
+  maxIterations: 1,
+  agent: sandcastle.claudeCode("claude-opus-4-8"),
+  promptFile: "./.sandcastle/plan-prompt.md",
+  output: sandcastle.Output.object({ tag: "plan", schema: planSchema }),
+});
+
+const { issues } = plan.output;
+
+console.log(`\n=== DRY-RUN PLAN (${issues.length} unblocked issue(s)) ===\n`);
+if (issues.length === 0) {
+  console.log(
+    "No unblocked agent:implement issues. Empty plan is still a valid pass.",
+  );
+} else {
+  for (const issue of issues) {
+    console.log(`  ${issue.id}: ${issue.title} -> ${issue.branch}`);
+  }
+}
+console.log("\nDry run complete — nothing was implemented, reviewed, or merged.");

--- a/.sandcastle/plan-prompt.md
+++ b/.sandcastle/plan-prompt.md
@@ -1,0 +1,37 @@
+# ISSUES
+
+Here are the open issues in the repo:
+
+<issues-json>
+
+!`gh issue list --state open --label agent:implement --limit 100 --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`
+
+</issues-json>
+
+The list above has already been filtered to issues ready for work.
+
+# TASK
+
+Analyze the open issues and build a dependency graph. For each issue, determine whether it **blocks** or **is blocked by** any other open issue.
+
+An issue B is **blocked by** issue A if:
+
+- B requires code or infrastructure that A introduces
+- B and A modify overlapping files or modules, making concurrent work likely to produce merge conflicts
+- B's requirements depend on a decision or API shape that A will establish
+
+An issue is **unblocked** if it has zero blocking dependencies on other open issues.
+
+For each unblocked issue, assign a branch name using the exact format `sandcastle/issue-{id}` (no slug or other suffix). This must be deterministic so that re-planning the same issue always produces the same branch name and accumulated progress is preserved.
+
+# OUTPUT
+
+Output your plan as a JSON object wrapped in `<plan>` tags:
+
+<plan>
+{"issues": [{"id": "42", "title": "Fix auth bug", "branch": "sandcastle/issue-42"}]}
+</plan>
+
+Include only unblocked issues. If every issue is blocked, include the single highest-priority candidate (the one with the fewest or weakest dependencies).
+
+Always emit the `<plan>` tags, even when there is nothing to do. If there are no issues to work on at all, output `<plan>{"issues": []}</plan>` so the run can exit cleanly.

--- a/.sandcastle/review-prompt.md
+++ b/.sandcastle/review-prompt.md
@@ -1,0 +1,55 @@
+# TASK
+
+Review the code changes on branch `{{BRANCH}}` and improve code clarity, consistency, and maintainability while preserving exact functionality.
+
+# CONTEXT
+
+## Branch diff
+
+!`git diff {{TARGET_BRANCH}}...{{BRANCH}}`
+
+## Commits on this branch
+
+!`git log {{TARGET_BRANCH}}..{{BRANCH}} --oneline`
+
+# REVIEW PROCESS
+
+1. **Understand the change**: Read the diff and commits above to understand the intent.
+
+2. **Analyze for improvements**: Look for opportunities to:
+   - Reduce unnecessary complexity and nesting
+   - Eliminate redundant code and abstractions
+   - Improve readability through clear variable and function names
+   - Consolidate related logic
+   - Remove unnecessary comments that describe obvious code
+   - Avoid nested ternary operators - prefer switch statements or if/else chains
+   - Choose clarity over brevity - explicit code is often better than overly compact code
+
+3. **Check correctness**:
+   - Does the implementation match the intent? Are edge cases handled?
+   - Are new/changed behaviours covered by tests?
+   - Are there unsafe casts, `any` types, or unchecked assumptions?
+   - Does the change introduce injection vulnerabilities, credential leaks, or other security issues?
+
+4. **Maintain balance**: Avoid over-simplification that could:
+   - Reduce code clarity or maintainability
+   - Create overly clever solutions that are hard to understand
+   - Combine too many concerns into single functions or components
+   - Remove helpful abstractions that improve code organization
+   - Make the code harder to debug or extend
+
+5. **Apply project standards**: Follow the coding standards defined in @.sandcastle/CODING_STANDARDS.md
+
+6. **Preserve functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
+
+# EXECUTION
+
+If you find improvements to make:
+
+1. Make the changes directly on this branch
+2. Run swap's gate to ensure nothing is broken — `eslint .`, `pnpm run typecheck`, `vitest run`, and `pnpm -r run build`
+3. Commit describing the refinements
+
+If the code is already clean and well-structured, do nothing.
+
+Once complete, output <promise>COMPLETE</promise>.

--- a/.sandcastle/review-push-prompt.md
+++ b/.sandcastle/review-push-prompt.md
@@ -1,0 +1,25 @@
+# TASK
+
+The reviewer just committed refinements on branch `{{BRANCH}}`. Push them to
+origin so the open pull request picks them up. **Do NOT merge, close, or open a
+new PR.**
+
+# STEPS
+
+1. Confirm the branch has commits to push:
+
+   !`git log origin/{{BRANCH}}..{{BRANCH}} --oneline`
+
+   If there is nothing ahead of `origin/{{BRANCH}}`, output
+   `<promise>COMPLETE</promise>` and stop.
+
+2. Push:
+
+   `git push origin {{BRANCH}}`
+
+# RULES
+
+- Never run `git merge`, `gh pr merge`, or `gh issue close`.
+- Do not open a new PR — the existing PR updates automatically from the push.
+
+Once pushed, output `<promise>COMPLETE</promise>`.

--- a/.sandcastle/sandbox-secrets.ts
+++ b/.sandcastle/sandbox-secrets.ts
@@ -1,0 +1,57 @@
+// Forward host secrets INTO the sandcastle Docker sandbox.
+//
+// WHY THIS EXISTS — root cause of the relay#68 first-run failure
+// -------------------------------------------------------------
+// The `agent:implement` runner reached the sandbox, but claude-code inside it
+// died with `Not logged in · Please run /login`, even though the workflow step
+// exported CLAUDE_CODE_OAUTH_TOKEN (and GH_TOKEN) into the runner's env.
+//
+// The reason: @ai-hero/sandcastle@0.12.0's env resolver does NOT blanket-pass
+// `process.env` into the container. It only forwards a variable whose KEY also
+// appears in `.sandcastle/.env` (see `resolveEnv` in the engine's dist/index.js):
+//
+//     const sandcastleEnv = parseEnvFile(".sandcastle/.env");   // missing -> {}
+//     for (const key of Object.keys(sandcastleEnv))             // keys from the FILE
+//       result[key] = sandcastleEnv[key] || process.env[key];
+//
+// `.sandcastle/.env` is gitignored (only `.env.example` is committed), so in CI
+// the file does not exist -> `parseEnvFile` returns {} -> the loop never runs ->
+// the resolved env is {} -> NEITHER token is passed to `docker run`. The
+// container therefore starts with no credentials and claude-code is unauthed.
+//
+// THE FIX
+// -------
+// Pass the secrets through the sandbox PROVIDER's first-class `env` option
+// (`docker({ env })`), which the README documents as "Environment variables to
+// inject into the sandbox" and merges via `mergeProviderEnv`. `createSandbox`
+// bakes `sandboxProviderEnv` into the `docker run -e KEY=VALUE` flags at
+// container start (`startContainer` in dist/sandboxes -> chunk-CP3TYXZA.js:
+// `Object.entries(env).flatMap(([k, v]) => ["-e", `${k}=${v}`])`). Every
+// in-container exec then inherits them: claude-code (CLAUDE_CODE_OAUTH_TOKEN)
+// AND the implementer's in-sandbox `git push` / `gh pr create` (GH_TOKEN).
+//
+// NOTE: a key is included ONLY when it is actually set on the host. This keeps
+// local dev working — there the tokens come from `.sandcastle/.env` (resolved
+// separately) and we must not clobber those with an `undefined` override, since
+// `mergeProviderEnv` layers sandbox-provider env OVER the resolved `.env` values.
+
+// Host env vars that must reach claude-code and `gh`/`git` inside the sandbox.
+const PASSTHROUGH_KEYS = [
+  "CLAUDE_CODE_OAUTH_TOKEN", // Claude Max-plan credential -> authenticates claude-code
+  "GH_TOKEN", // in-sandbox `git push` / `gh pr create` / `gh issue list`
+] as const;
+
+/**
+ * The subset of {@link PASSTHROUGH_KEYS} that is set on the host, as a
+ * `Record<string, string>` suitable for `docker({ env })`. Undefined vars are
+ * omitted (never emitted as `KEY=undefined`) so the local `.sandcastle/.env`
+ * path is not overridden with empties.
+ */
+export function sandboxSecrets(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of PASSTHROUGH_KEYS) {
+    const value = process.env[key];
+    if (value) env[key] = value;
+  }
+  return env;
+}

--- a/docs/factory-runbook.md
+++ b/docs/factory-runbook.md
@@ -1,0 +1,144 @@
+# Sandcastle factory — first-run runbook (swap)
+
+This is the maintainer runbook for **triggering** swap's sandcastle software
+factory. Authoring the runners is done (workflows + labels + entry scripts);
+pulling the trigger is a deliberate human action. Nothing in this repo starts an
+agent run on its own.
+
+Related:
+- Trigger-label + engine spec: `FACTORY.md` (in `toon-meta`).
+- Engine reference + verified-on-first-run corrections:
+  `scratchpad-sandcastle-engine.md` (in `toon-meta`).
+- The runners: `.github/workflows/agent-implement.yml`,
+  `.github/workflows/agent-review.yml`.
+- The entry scripts: `.sandcastle/agent-implement-issue.ts`,
+  `.sandcastle/agent-review-pr.ts`.
+
+---
+
+## Prerequisites (one-time)
+
+- `agent:implement` (`#1D76DB`) and `agent:review` (`#B392F0`) labels exist in
+  the swap repo. (Created as part of this slice.)
+- Org/repo Actions secrets present:
+  - `CLAUDE_CODE_OAUTH_TOKEN` — Claude Max-plan credential (`claude setup-token`).
+  - `APP_ID` + `APP_PRIVATE_KEY` — the GitHub App the existing loops already use.
+    The engine opens the PR with this App token so the PR triggers `ci.yml`
+    (the green gate). A PR opened with the default `GITHUB_TOKEN` would NOT
+    trigger CI.
+- `agent-implement.yml` / `agent-review.yml` are merged to `main`. Issue- and
+  PR-`labeled` workflows only fire from the default branch, so nothing runs
+  until these land on `main`.
+
+---
+
+## Trigger the implement checkpoint (the pilot proof)
+
+1. **Pick a small, self-contained issue.** It MUST NOT be an epic/PRD parent:
+   no `epic`, `tracking`, or `needs:human` label, and no sub-issues. The runner
+   guards refuse those, but pick a clean target anyway. A tightly-scoped bugfix
+   or a single small feature is ideal for the first run.
+
+2. **Apply the `agent:implement` label** to that issue. That single act is the
+   trigger.
+
+3. **Watch the run** under the repo's Actions tab → **agent:implement**. Two
+   jobs:
+   - `guard` — evaluates the target (actor write-access, no epic/tracking/
+     needs:human label, no sub-issues). If it decides not to proceed you'll see
+     a `::warning::` explaining why and the `implement` job is skipped.
+   - `implement` — the real work, in order:
+     1. checkout + node 22 + `corepack`/`pnpm install`
+     2. **build the agent image** (`sandcastle docker build-image`)
+     3. **run** `pnpm sandcastle:implement`, which inside the sandbox:
+        - **implements** the issue (opus, up to 100 iterations, RED→GREEN→
+          REFACTOR, running swap's gate `eslint . / pnpm run typecheck /
+          vitest run / pnpm -r run build`),
+        - **reviews** the branch (opus, 1 iteration),
+        - **opens a PR** against `main` (`Part of #<issue>`, NOT `Closes`).
+
+4. **Expected result:** a new PR from branch `sandcastle/issue-<n>`, with
+   `ci.yml` running on it. **The issue is NOT auto-closed and nothing is merged.**
+
+5. **Review and merge the PR yourself.** Merging it (and thereby closing the
+   issue) is what satisfies toon-meta#189's "a real agent PR merges" acceptance
+   criterion. This is the human half of the checkpoint.
+
+### Reading the logs
+
+- The `implement` job's step **"Run sandcastle implement runner"** streams the
+  engine output: the branch name, `implementer` / `reviewer` / `open-pr` phase
+  banners, and the agents' tool calls.
+- "Implementer produced no commits" in the log → the agent did nothing. No PR is
+  opened. Inspect why, then **remove and re-apply** the label to retry.
+- A non-zero exit (red job) = the engine or an agent errored. The PR, if any,
+  is whatever was pushed before the failure.
+
+### Rollback / abort
+
+- **Before or during a run:** remove the `agent:implement` label and, in the
+  Actions tab, **Cancel** the in-progress run.
+- **After a bad PR:** just close the PR (and delete the `sandcastle/issue-<n>`
+  branch). Nothing was merged, so there is nothing to revert on `main`.
+- Re-running is safe: the branch name is deterministic (`sandcastle/issue-<n>`),
+  so a retry reuses/updates the same branch rather than spawning duplicates.
+
+---
+
+## Trigger a review pass
+
+1. **Apply `agent:review` to a PULL REQUEST** (not an issue). The
+   `agent-review.yml` runner fires on PR label events.
+2. The runner checks out the PR head, runs the reviewer (opus, 1 iteration) for
+   clarity/standards refinements, and **pushes any commits back onto the PR**.
+   It never merges or closes anything.
+3. Rollback: remove the label / cancel the run. Any pushed review commits live
+   on the PR branch and can be dropped like any other commit.
+
+> **Verify on first review run:** the standalone-review path (reviewing an
+> existing PR branch rather than a fresh loop branch) is our interpretation of
+> the 0.12.0 engine. Confirm the sandbox checks out the existing head branch and
+> that the reviewer's `git diff` against `main` is non-empty. See
+> `.sandcastle/agent-review-pr.ts` for the exact caveats.
+
+---
+
+## The auto-merge toggle (leave OFF for the pilot)
+
+The implement runner ships in **PR mode**: agent opens a PR, human merges. This
+is the safe default and there is no merge code in the default path.
+
+**To re-enable auto-merge later**, once the pilot is trusted:
+
+- In `.github/workflows/agent-implement.yml`, in the **"Run sandcastle implement
+  runner"** step's `env:`, set:
+
+  ```yaml
+  SANDCASTLE_AUTO_MERGE: "true"
+  ```
+
+  With that set, `agent-implement-issue.ts` runs the stock merge phase
+  (`merge-prompt.md`) instead of opening a PR: it merges the branch into the
+  checked-out base and closes the issue.
+
+- **Before trusting it**, prove the merge path on a throwaway issue: the stock
+  merge prompt's exact push-to-`main` semantics are inherited from the engine
+  and are themselves verify-on-first-run. Branch protection on `main` is the
+  recommended backstop even after enabling auto-merge.
+
+The toggle lives in exactly one place — that env var — and is read once in
+`agent-implement-issue.ts`.
+
+---
+
+## Guard limitations (known gaps)
+
+- **Sub-issue detection** uses a GraphQL `subIssues` query. If that field is
+  unavailable on the repo's GitHub plan the query errors; the guard then logs a
+  warning and falls back to the `epic`/`tracking` label check only (it does not
+  hard-block). Keep epics labeled `epic`/`tracking` so they're refused reliably.
+- **PRD-shaped parents** are detected via the `epic`/`tracking` labels + the
+  sub-issue count. A parent that is neither labeled nor has GitHub sub-issues
+  (e.g. a body-only checklist) would not be caught — pick clean targets.
+- **Actor permission** is checked via the collaborator-permission API; only
+  `admin`/`maintain`/`write` proceed.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,6 +65,7 @@ export default tseslint.config(
       'archive/**',
       '.cache/**',
       '.claude/**',
+      '.sandcastle/**',
       'packages/memvid-node/index.d.ts',
     ],
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,12 @@
     "format:check": "prettier --check \"packages/*/src/**/*.ts\"",
     "changeset": "changeset",
     "version": "changeset version",
-    "release": "changeset publish"
+    "release": "changeset publish",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "sandcastle": "npx tsx .sandcastle/main.ts",
+    "sandcastle:plan": "npx tsx .sandcastle/plan-dry-run.ts",
+    "sandcastle:implement": "npx tsx .sandcastle/agent-implement-issue.ts",
+    "sandcastle:review": "npx tsx .sandcastle/agent-review-pr.ts"
   },
   "keywords": [
     "nostr",
@@ -56,6 +61,7 @@
     }
   },
   "devDependencies": {
+    "@ai-hero/sandcastle": "0.12.0",
     "@eslint/js": "^9.0.0",
     "@hono/node-server": "^1.13.7",
     "@noble/curves": "^1.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
         specifier: ^1.15.5
         version: 1.15.7
     devDependencies:
+      '@ai-hero/sandcastle':
+        specifier: 0.12.0
+        version: 0.12.0
       '@changesets/cli':
         specifier: ^2.27.9
         version: 2.31.0(@types/node@20.19.32)
@@ -163,6 +166,21 @@ packages:
 
   /@adraffy/ens-normalize@1.11.1:
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
+
+  /@ai-hero/sandcastle@0.12.0:
+    resolution: {integrity: sha512-kdQ414rM8t1QiWeqZ3Klz4KSd0PqQG4bRVuqGpRDUomWhojSZkEAc1tbcEcThVmBEaHkCt8LmYR49vqEPNIoYQ==}
+    hasBin: true
+    peerDependencies:
+      '@daytona/sdk': ^0.164.0
+      '@vercel/sandbox': '>=1.0.0'
+    peerDependenciesMeta:
+      '@daytona/sdk':
+        optional: true
+      '@vercel/sandbox':
+        optional: true
+    dependencies:
+      '@clack/prompts': 1.7.0
+    dev: true
 
   /@ai-sdk/anthropic@1.2.12(zod@3.25.76):
     resolution: {integrity: sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==}
@@ -1036,6 +1054,24 @@ packages:
       fs-extra: 7.0.1
       human-id: 4.2.0
       prettier: 2.8.8
+    dev: true
+
+  /@clack/core@1.4.3:
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+    dev: true
+
+  /@clack/prompts@1.7.0:
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
+    dependencies:
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
     dev: true
 
   /@coinbase/cdp-sdk@1.44.0(typescript@5.9.3):
@@ -8314,10 +8350,26 @@ packages:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
     requiresBuild: true
 
+  /fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+    dev: true
+
+  /fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+    dev: true
+
   /fast-text-encoding@1.0.6:
     resolution: {integrity: sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==}
     requiresBuild: true
     optional: true
+
+  /fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+    dependencies:
+      fast-string-width: 3.0.2
+    dev: true
 
   /fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}


### PR DESCRIPTION
Closes toon-protocol/toon-meta#189
Part of #178

Stands up swap's **sandcastle software factory** by mirroring relay's merged, proven `.sandcastle/` (toon-meta#182/#183/#184), adapted to swap. **Scaffold only** — no runtime code touched. Coexists with the old loops on disjoint labels (`agent:ready`/`agent:split` vs `agent:implement`/`agent:review`); nothing runs until a human applies a trigger label on the default branch.

## What landed
- `.sandcastle/` — `parallel-planner-with-review` scaffold; exact-pinned devDep `@ai-hero/sandcastle@0.12.0`. Four runner entry points: `main.ts` (autonomous loop), `plan-dry-run.ts` (`sandcastle:plan`), `agent-implement-issue.ts` (single-issue PR mode), `agent-review-pr.ts` (single-PR review) + prompts + `Dockerfile` + `CODING_STANDARDS.md`.
- `package.json` — new `typecheck` script (`tsc -p tsconfig.json --noEmit`) + `sandcastle` / `sandcastle:plan` / `sandcastle:implement` / `sandcastle:review`.
- `.github/workflows/` — `agent-image.yml` (build-only image check), `agent-implement.yml` + `agent-review.yml` (guarded, GitHub App token, **PR mode by default**; auto-merge toggle documented in-file + in the runbook).
- `docs/factory-runbook.md` — maintainer trigger runbook.
- Trigger labels `agent:implement` (`#1D76DB`) / `agent:review` (`#B392F0`) created in the repo.

## Recipe (relay-proven) — deviations for swap
The full pnpm recipe was applied verbatim; swap-specific points:
- **pnpm pin already matches** — swap's `packageManager` is `pnpm@8.15.9`, identical to relay, so the Dockerfile corepack line (root, before the `USER` switch) needed no change.
- corepack `pnpm@8.15.9` before the USER switch; `copyToWorktree` dropped; `pnpm install --frozen-lockfile` in `onSandboxReady`.
- Secrets forwarded via `docker({ env: sandboxSecrets() })` in **every** runner (relay#68 CI-secrets gotcha).
- `.sandcastle/**` added to the eslint `ignores` (relay#66 typed-lint gotcha — swap uses the same `projectService: true` config; without it the `.ts` runners parse-error). `tsc`'s default include glob already skips the dot-directory, so `.sandcastle` adds **no** typecheck errors.
- Gate lines point at swap's real scripts: `eslint .`, `pnpm run typecheck`, `vitest run`, `pnpm -r run build` (identical set to relay).
- `agent-image.yml` image name adapted to `sandcastle:swap`.

## Typecheck debt: **60** (org calibration)
The new `typecheck` script surfaces **60 pre-existing errors across 15 files — ALL test-side** (`*.test.ts` / fixtures / e2e; **zero production-source errors**). Theme is sdk/wire drift (`TS2305` missing exports ×26, `TS2532` possibly-undefined ×20). This is LARGE, so per the recipe the **gate is wired** and the debt is **carved into a sized follow-up (swap#69)** rather than slogged in this slice. (Note: a stale pre-install `dist` inflates this to 118 before `pnpm install` rebuilds the workspace declarations; 60 is the stable clean-install number.)

## Image built locally? **Yes**
`npx @ai-hero/sandcastle@0.12.0 docker build-image` → `sandcastle:swap`, exit 0 on WSL. In-image toolchain verified: node v22.23.0, gh 2.96.0, corepack 0.34.6, `whoami=agent`, `/home/agent/.local/bin/claude` present — exactly what `agent-image.yml` asserts.

## Verify in CI
The dry-run `plan` mechanism exists (`pnpm sandcastle:plan` → `plan-dry-run.ts`); the actual Claude-calling planner run is intentionally **not** exercised here (would require the org OAuth secret and would trigger a live agent run). It verifies in CI / on first human trigger. The standalone-review path retains relay's verify-on-first-run caveat (documented in `agent-review-pr.ts`).

**Do not merge on my behalf** — human review + merge is the checkpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)