### PR TITLE
fix(factory): deterministic in-sandbox git push auth + fail-loud PR verification

### DIFF
--- a/.sandcastle/agent-implement-issue.ts
+++ b/.sandcastle/agent-implement-issue.ts
@@ -75,7 +75,27 @@ const issueTitle = execFileSync(
 // copyToWorktree node_modules — pnpm's symlinked store breaks across the
 // host->worktree bind-mount).
 const hooks = {
-  sandbox: { onSandboxReady: [{ command: "pnpm install --frozen-lockfile" }] },
+  sandbox: {
+    onSandboxReady: [
+      // Wire `git push` auth DETERMINISTICALLY inside the container.
+      //
+      // ROOT CAUSE: @ai-hero/sandcastle@0.12.0 only configures git
+      // `safe.directory` + `user.name`/`user.email` in the sandbox — it does
+      // NO credential setup (verified in dist: `withSandboxLifecycle`). `gh`
+      // authenticates from GH_TOKEN, but a bare `git push` uses git's own
+      // credential system, which is not wired to the token. Pushes therefore
+      // succeed only by luck (relay#70) and fail silently otherwise (store#50).
+      //
+      // `gh auth setup-git` installs `gh` as git's credential helper for
+      // github.com in the container-global gitconfig, so every subsequent
+      // `git push` reuses GH_TOKEN. The helper stores NO token in any file — it
+      // shells out to `gh auth git-credential`, which reads GH_TOKEN at push
+      // time. Guarded on GH_TOKEN so local dev without a token no-ops instead
+      // of aborting sandbox setup (onSandboxReady failures are fatal).
+      { command: 'if [ -n "$GH_TOKEN" ]; then gh auth setup-git; fi' },
+      { command: "pnpm install --frozen-lockfile" },
+    ],
+  },
 };
 
 console.log(
@@ -89,6 +109,12 @@ console.log(
 // ---------------------------------------------------------------------------
 // Implement -> Review -> (open PR | merge)
 // ---------------------------------------------------------------------------
+
+// Set to a non-null message in the PR-verification step below when the open-pr
+// phase reported success but no PR actually landed. We record it here (rather
+// than calling process.exit inside the try) so the `finally` still closes the
+// sandbox before we fail the job non-zero.
+let openPrVerificationError: string | null = null;
 
 const sandbox = await sandcastle.createSandbox({
   branch,
@@ -165,10 +191,68 @@ try {
         BRANCH: branch,
       },
     });
-    console.log("\nPR opened (or already existed). Awaiting human review.");
+    // FAIL LOUD. The open-pr phase logs COMPLETE from the prompt regardless of
+    // whether the in-sandbox `git push` / `gh pr create` actually succeeded, so
+    // we must NOT trust it. Verify from the HOST (whose `gh` is authenticated
+    // via GH_TOKEN) that an OPEN PR now exists for this branch. If not, dump the
+    // push/PR state and exit non-zero so the Actions job FAILS instead of
+    // green-lying (store#50: implementer committed, but push failed silently and
+    // no PR was ever created, yet the job went green).
+    const openPrs = JSON.parse(
+      execFileSync(
+        "gh",
+        ["pr", "list", "--head", branch, "--state", "open", "--json", "number,url"],
+        { encoding: "utf8" },
+      ),
+    ) as Array<{ number: number; url: string }>;
+
+    if (openPrs.length > 0) {
+      const pr = openPrs[0]!;
+      console.log(`\nVerified: PR #${pr.number} is open — ${pr.url}`);
+      console.log("Awaiting human review.");
+    } else {
+      // No open PR. Gather diagnostics (all via the authenticated host `gh`).
+      const nwo = execFileSync(
+        "gh",
+        ["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+        { encoding: "utf8" },
+      ).trim();
+
+      let branchPushed = false;
+      try {
+        execFileSync("gh", ["api", `repos/${nwo}/git/ref/heads/${branch}`], {
+          stdio: "pipe",
+        });
+        branchPushed = true;
+      } catch {
+        branchPushed = false;
+      }
+
+      const anyStatePrs = execFileSync(
+        "gh",
+        ["pr", "list", "--head", branch, "--state", "all", "--json", "number,state,url"],
+        { encoding: "utf8" },
+      ).trim();
+
+      openPrVerificationError =
+        `\nERROR: the open-pr phase reported COMPLETE, but no OPEN PR exists ` +
+        `for branch '${branch}'.\n` +
+        `  Remote branch pushed to origin: ${branchPushed}\n` +
+        `  PRs for this branch (any state): ${anyStatePrs}\n` +
+        `  The in-sandbox \`git push\` and/or \`gh pr create\` failed ` +
+        `silently. Inspect the open-pr phase logs above. The Actions job is ` +
+        `failing deliberately so this is not mistaken for success.`;
+    }
   }
 } finally {
   await sandbox.close();
+}
+
+// Fail loud AFTER the sandbox is closed: a silently-failed push/PR-create must
+// turn the Actions job red, never green.
+if (openPrVerificationError) {
+  console.error(openPrVerificationError);
+  process.exit(1);
 }
 
 console.log("\nDone.");

--- a/.sandcastle/agent-review-pr.ts
+++ b/.sandcastle/agent-review-pr.ts
@@ -56,12 +56,45 @@ if (!headRef) {
 }
 
 const hooks = {
-  sandbox: { onSandboxReady: [{ command: "pnpm install --frozen-lockfile" }] },
+  sandbox: {
+    onSandboxReady: [
+      // Wire `git push` auth deterministically inside the container. The engine
+      // (@ai-hero/sandcastle@0.12.0) configures git identity + safe.directory
+      // but NO credential helper, so the review-push step's in-sandbox
+      // `git push` to the PR branch is unauthenticated and only succeeds by
+      // luck. `gh auth setup-git` installs `gh` as git's credential helper
+      // (reads GH_TOKEN at push time, stores no token in any file). Guarded on
+      // GH_TOKEN so token-less local dev no-ops rather than aborting setup. See
+      // ./agent-implement-issue.ts for the full root-cause note.
+      { command: 'if [ -n "$GH_TOKEN" ]; then gh auth setup-git; fi' },
+      { command: "pnpm install --frozen-lockfile" },
+    ],
+  },
 };
+
+// Reads origin's current tip SHA for a branch via the authenticated host `gh`.
+// Returns null when the ref does not exist (or gh errors) — the caller treats a
+// null as "cannot conclude" and does not fail on it.
+function remoteBranchSha(ref: string): string | null {
+  try {
+    return execFileSync(
+      "gh",
+      ["api", `repos/{owner}/{repo}/git/ref/heads/${ref}`, "--jq", ".object.sha"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    ).trim();
+  } catch {
+    return null;
+  }
+}
 
 console.log(
   `\n=== agent:review runner — PR #${prNumber} (head: ${headRef}) ===\n`,
 );
+
+// Set to a non-null message below when the review-push phase reported success
+// but origin's PR branch tip did not advance. Recorded here so the `finally`
+// still closes the sandbox before we fail the job non-zero.
+let reviewPushVerificationError: string | null = null;
 
 const sandbox = await sandcastle.createSandbox({
   branch: headRef,
@@ -87,6 +120,10 @@ try {
     console.log(
       `\nReviewer made ${review.commits.length} commit(s) — pushing to the PR branch.`,
     );
+    // Record origin's PR-branch tip BEFORE the push so we can prove afterwards
+    // that it actually advanced.
+    const remoteShaBefore = remoteBranchSha(headRef);
+
     await sandbox.run({
       name: "push-review",
       maxIterations: 1,
@@ -94,6 +131,27 @@ try {
       promptFile: "./.sandcastle/review-push-prompt.md",
       promptArgs: { BRANCH: headRef },
     });
+
+    // FAIL LOUD. The push-review phase logs COMPLETE from its prompt regardless
+    // of whether the in-sandbox `git push` actually landed, so we must NOT trust
+    // it. Verify from the HOST that origin's PR-branch tip advanced. If the
+    // reviewer produced commits but the remote tip did not move, the push failed
+    // silently — exit non-zero so the Actions job goes red instead of green.
+    // Same class of silent-push failure as store#50.
+    const remoteShaAfter = remoteBranchSha(headRef);
+    if (remoteShaAfter !== null && remoteShaAfter === remoteShaBefore) {
+      reviewPushVerificationError =
+        `\nERROR: the push-review phase reported COMPLETE, but origin's tip for ` +
+        `branch '${headRef}' did not advance (still ${remoteShaAfter}).\n` +
+        `  The reviewer made ${review.commits.length} commit(s), so the ` +
+        `in-sandbox \`git push\` failed silently. Inspect the push-review phase ` +
+        `logs above. The Actions job is failing deliberately so this is not ` +
+        `mistaken for success.`;
+    } else {
+      console.log(
+        `\nVerified: origin/${headRef} advanced to ${remoteShaAfter ?? "(unknown)"}.`,
+      );
+    }
   } else {
     console.log(
       "\nReviewer made no changes — the code was already clean. Nothing to push.",
@@ -101,6 +159,13 @@ try {
   }
 } finally {
   await sandbox.close();
+}
+
+// Fail loud AFTER the sandbox is closed: a silently-failed push must turn the
+// Actions job red, never green.
+if (reviewPushVerificationError) {
+  console.error(reviewPushVerificationError);
+  process.exit(1);
 }
 
 console.log("\nReview complete. The PR was NOT merged — a human still merges.");

--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -55,7 +55,19 @@ const MAX_ITERATIONS = 10;
 // sandbox resolves the exact dependency tree. This replaces the template's
 // default `npm install` (swap does not use npm).
 const hooks = {
-  sandbox: { onSandboxReady: [{ command: "pnpm install --frozen-lockfile" }] },
+  sandbox: {
+    onSandboxReady: [
+      // Wire `git push` auth deterministically inside the container. The engine
+      // (@ai-hero/sandcastle@0.12.0) configures git identity + safe.directory
+      // but NO credential helper, so a bare `git push` is unauthenticated and
+      // only succeeds by luck. `gh auth setup-git` installs `gh` as git's
+      // credential helper (reads GH_TOKEN at push time, stores no token in any
+      // file). Guarded on GH_TOKEN so token-less local dev no-ops rather than
+      // aborting setup. See ./agent-implement-issue.ts for the full note.
+      { command: 'if [ -n "$GH_TOKEN" ]; then gh auth setup-git; fi' },
+      { command: "pnpm install --frozen-lockfile" },
+    ],
+  },
 };
 
 // NOTE: the stock template copies the host `node_modules` into the worktree

--- a/.sandcastle/open-pr-prompt.md
+++ b/.sandcastle/open-pr-prompt.md
@@ -15,18 +15,33 @@ issue.** A human reviews and merges the PR.
    If there are no commits ahead of `main`, output `<promise>COMPLETE</promise>`
    and stop — there is nothing to open a PR for.
 
-2. Push the branch to origin:
+2. Wire `git push` authentication so the push below is NOT unauthenticated.
+   `gh` is authenticated from `GH_TOKEN`, but a bare `git push` uses git's own
+   credential system. Install `gh` as git's credential helper (idempotent; the
+   onSandboxReady hook already did this, but re-run it here so this step is
+   self-contained):
+
+   `gh auth setup-git`
+
+3. Push the branch to origin, then CONFIRM the remote ref actually exists — a
+   push can fail without an obvious error:
 
    `git push -u origin {{BRANCH}}`
+   `git ls-remote --heads origin {{BRANCH}}`
 
-3. Check whether a PR for this branch already exists:
+   If `git ls-remote` prints NO line for `{{BRANCH}}`, the push FAILED. Do
+   **not** output `<promise>COMPLETE</promise>`. Instead print the push error
+   and stop — the runner will detect the missing PR and fail the job.
+
+4. Check whether a PR for this branch already exists:
 
    `gh pr list --head {{BRANCH}} --state open --json number --jq '.[].number'`
 
-   - If one already exists, leave it as-is (do not open a duplicate) and stop.
-   - Otherwise open a new PR (step 4).
+   - If one already exists, leave it as-is (do not open a duplicate) and go to
+     step 6 to verify.
+   - Otherwise open a new PR (step 5).
 
-4. Open the PR:
+5. Open the PR:
 
    ```
    gh pr create \
@@ -46,10 +61,22 @@ issue.** A human reviews and merges the PR.
    - End with the line:
      `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
 
+6. VERIFY a PR now exists before claiming success:
+
+   `gh pr list --head {{BRANCH}} --state open --json number,url`
+
+   If this prints an empty list (`[]`), the push or PR creation did NOT land.
+   Do **not** output `<promise>COMPLETE</promise>` — print what went wrong and
+   stop.
+
 # RULES
 
 - Never run `git merge`, `gh pr merge`, or `gh issue close`.
 - Do not modify code here — implementation and review already happened on this
   branch. This step only publishes the branch and opens the PR.
+- Only output `<promise>COMPLETE</promise>` once you have CONFIRMED (step 3 +
+  step 6) that the branch is pushed AND an open PR exists. A failed push or a
+  missing PR is a failure, not a COMPLETE.
 
-Once the PR is open (or already existed), output `<promise>COMPLETE</promise>`.
+Once the branch is pushed and an open PR is confirmed to exist, output
+`<promise>COMPLETE</promise>`.

--- a/.sandcastle/plan-dry-run.ts
+++ b/.sandcastle/plan-dry-run.ts
@@ -37,7 +37,17 @@ const planSchema = z.object({
 // main.ts). We do NOT copyToWorktree node_modules (pnpm's symlinked store
 // breaks across the bind-mount).
 const hooks = {
-  sandbox: { onSandboxReady: [{ command: "pnpm install --frozen-lockfile" }] },
+  sandbox: {
+    onSandboxReady: [
+      // Wire `git push` auth deterministically inside the container (see
+      // ./agent-implement-issue.ts). The planner is read-only and never pushes,
+      // but every runner entrypoint installs the credential helper identically
+      // so the sandbox setup is uniform and any future push here is authed.
+      // Guarded on GH_TOKEN so token-less local dev no-ops rather than aborting.
+      { command: 'if [ -n "$GH_TOKEN" ]; then gh auth setup-git; fi' },
+      { command: "pnpm install --frozen-lockfile" },
+    ],
+  },
 };
 
 const plan = await sandcastle.run({


### PR DESCRIPTION
Propagates the validated store#51 fix (proven in store, validated by store#52) into swap's `.sandcastle/` factory, plus a gotcha-#7 sweep across every runner entrypoint. Touches ONLY `.sandcastle/*`.

## Problem
sandcastle 0.12.0 does NO git-credential setup in its sandbox. An in-sandbox `git push` over HTTPS therefore has no deterministic auth: it succeeds only by luck, and otherwise fails silently while the runner logs false success and the Actions job goes green (store#50).

## Fix (two parts)

**Part A — deterministic push auth.** `gh auth setup-git` installs `gh` as git's credential helper (reads `GH_TOKEN` at push time; writes no token to any file), added as the FIRST `onSandboxReady` hook, guarded on `GH_TOKEN` so token-less local dev no-ops instead of aborting sandbox setup. Applied to ALL runner entrypoints — `agent-implement-issue.ts`, `agent-review-pr.ts`, `main.ts`, `plan-dry-run.ts`. The existing `pnpm install --frozen-lockfile` hook is preserved (prepended, not replaced).

**Part B — fail loud.** The open-pr / push-review phases log `COMPLETE` from their prompts regardless of whether the push actually landed, so the host must not trust them:
- `agent-implement-issue.ts`: after the open-pr phase, verify from the authenticated host `gh` that an OPEN PR exists for the branch; if not, dump push/PR state and `process.exit(1)`.
- `agent-review-pr.ts`: after the push-review phase, verify origin's PR-branch tip actually advanced; if the reviewer made commits but the remote tip did not move, exit non-zero.

Also hardens `open-pr-prompt.md`: `gh auth setup-git` before the push, `git ls-remote` verify after, and `COMPLETE` only once push + PR are both confirmed.

No token is written to any committed file or log.

## Validation
- TypeScript: 0 errors in `.sandcastle` (`pnpm typecheck`; unrelated pre-existing errors in `packages/swap/tests/integration/*` are not introduced here and not run in CI).
- `.sandcastle` is eslint-ignored and outside `pnpm -r build`, so `pnpm lint` / build gates are unaffected.
- Changeset: none needed — no CI changeset gate exists (changesets run only in `release.yml`), and `.sandcastle/*` is not a published package.
- Style preserved to match the rest of `.sandcastle` and store (the dir is not covered by the repo prettier config).

Part of toon-protocol/toon-meta#178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)