### PR TITLE
Part of toon-protocol/toon-meta#202

### DIFF
--- a/.sandcastle/agent-implement-issue.ts
+++ b/.sandcastle/agent-implement-issue.ts
@@ -132,7 +132,7 @@ try {
   const implement = await sandbox.run({
     name: "implementer",
     maxIterations: 100,
-    agent: sandcastle.claudeCode("claude-opus-4-8"),
+    agent: sandcastle.claudeCode("claude-sonnet-5"),
     promptFile: "./.sandcastle/implement-prompt.md",
     promptArgs: {
       TASK_ID: issueNumber,
@@ -156,7 +156,7 @@ try {
   await sandbox.run({
     name: "reviewer",
     maxIterations: 1,
-    agent: sandcastle.claudeCode("claude-opus-4-8"),
+    agent: sandcastle.claudeCode("claude-sonnet-5"),
     promptFile: "./.sandcastle/review-prompt.md",
     promptArgs: { BRANCH: branch },
   });
@@ -183,7 +183,7 @@ try {
     await sandbox.run({
       name: "open-pr",
       maxIterations: 1,
-      agent: sandcastle.claudeCode("claude-opus-4-8"),
+      agent: sandcastle.claudeCode("claude-sonnet-5"),
       promptFile: "./.sandcastle/open-pr-prompt.md",
       promptArgs: {
         TASK_ID: issueNumber,

--- a/.sandcastle/agent-review-pr.ts
+++ b/.sandcastle/agent-review-pr.ts
@@ -109,7 +109,7 @@ try {
   const review = await sandbox.run({
     name: "reviewer",
     maxIterations: 1,
-    agent: sandcastle.claudeCode("claude-opus-4-8"),
+    agent: sandcastle.claudeCode("claude-sonnet-5"),
     promptFile: "./.sandcastle/review-prompt.md",
     promptArgs: { BRANCH: headRef },
   });
@@ -127,7 +127,7 @@ try {
     await sandbox.run({
       name: "push-review",
       maxIterations: 1,
-      agent: sandcastle.claudeCode("claude-opus-4-8"),
+      agent: sandcastle.claudeCode("claude-sonnet-5"),
       promptFile: "./.sandcastle/review-push-prompt.md",
       promptArgs: { BRANCH: headRef },
     });

--- a/.sandcastle/implement-prompt.md
+++ b/.sandcastle/implement-prompt.md
@@ -67,3 +67,7 @@ Once complete, output <promise>COMPLETE</promise>.
 # FINAL RULES
 
 ONLY WORK ON A SINGLE TASK.
+
+## Context budget
+
+If you approach ~60% of your context window, STOP: write a structured handoff note (current state + remaining steps) to `.sandcastle/logs/handoff-<task-id>.md` and end your turn so a fresh agent continues. Do not push past ~60% — small, resumable units beat one degraded run.

--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -147,7 +147,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
         const implement = await sandbox.run({
           name: "implementer",
           maxIterations: 100,
-          agent: sandcastle.claudeCode("claude-opus-4-8"),
+          agent: sandcastle.claudeCode("claude-sonnet-5"),
           promptFile: "./.sandcastle/implement-prompt.md",
           promptArgs: {
             TASK_ID: issue.id,
@@ -161,7 +161,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
           const review = await sandbox.run({
             name: "reviewer",
             maxIterations: 1,
-            agent: sandcastle.claudeCode("claude-opus-4-8"),
+            agent: sandcastle.claudeCode("claude-sonnet-5"),
             promptFile: "./.sandcastle/review-prompt.md",
             promptArgs: {
               BRANCH: issue.branch,

--- a/.sandcastle/review-prompt.md
+++ b/.sandcastle/review-prompt.md
@@ -53,3 +53,7 @@ If you find improvements to make:
 If the code is already clean and well-structured, do nothing.
 
 Once complete, output <promise>COMPLETE</promise>.
+
+## Context budget
+
+If you approach ~60% of your context window, STOP: write a structured handoff note (current state + remaining steps) to `.sandcastle/logs/handoff-<task-id>.md` and end your turn so a fresh agent continues. Do not push past ~60% — small, resumable units beat one degraded run.


### PR DESCRIPTION
Part of toon-protocol/toon-meta#202
Part of #178

Applies the factory model-tiering + 60%-context handoff policy to swap's `.sandcastle/` runners.

## Edit 1 — model tiering
Changed `sandcastle.claudeCode("claude-opus-4-8")` → `sandcastle.claudeCode("claude-sonnet-5")` for the `implementer`, `reviewer`, `open-pr`, and `push-review` roles across all `.sandcastle/*.ts` runners. `planner` and `merger` stay on `claude-opus-4-8`.

| File | Role | Change |
|---|---|---|
| `.sandcastle/agent-implement-issue.ts` | implementer | opus → sonnet-5 |
| `.sandcastle/agent-implement-issue.ts` | reviewer | opus → sonnet-5 |
| `.sandcastle/agent-implement-issue.ts` | merger | opus (unchanged) |
| `.sandcastle/agent-implement-issue.ts` | open-pr | opus → sonnet-5 |
| `.sandcastle/main.ts` | planner | opus (unchanged) |
| `.sandcastle/main.ts` | implementer | opus → sonnet-5 |
| `.sandcastle/main.ts` | reviewer | opus → sonnet-5 |
| `.sandcastle/main.ts` | merger | opus (unchanged) |
| `.sandcastle/agent-review-pr.ts` | reviewer | opus → sonnet-5 |
| `.sandcastle/agent-review-pr.ts` | push-review | opus → sonnet-5 |
| `.sandcastle/plan-dry-run.ts` | planner-dry-run | opus (unchanged — planner-role dry run) |

## Edit 2 — 60% context handoff
Appended a "Context budget" section to both `.sandcastle/implement-prompt.md` and `.sandcastle/review-prompt.md` instructing agents to write a structured handoff note under `.sandcastle/logs/handoff-<task-id>.md` and end their turn if they approach ~60% context, rather than degrading through one long run.

## Scope
Touches only `.sandcastle/*`. swap has no changeset gate (`.changeset/` is release-only, wired to `release.yml`'s push-triggered publish job, not a PR check) — verified, no changeset added. No token/secret changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)