### PR TITLE
fix(sandcastle): PR body uses "Closes #N" to auto-close the issue on merge

### DIFF
--- a/.sandcastle/agent-implement-issue.ts
+++ b/.sandcastle/agent-implement-issue.ts
@@ -212,7 +212,7 @@ try {
     if (alreadyOpen.length === 0) {
       const body =
         "Produced by the sandcastle `agent:implement` runner; awaiting human " +
-        `review.\n\nPart of #${issueNumber}\n\n` +
+        `review.\n\nCloses #${issueNumber}\n\n` +
         "🤖 Generated with [Claude Code](https://claude.com/claude-code)";
       execFileSync(
         "gh",


### PR DESCRIPTION
The deterministic open-pr step wrote `Part of #N`, so merging never closed the ticket. `Closes #N` auto-closes on the human merge (the intended trigger). Part of #210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)