### PR TITLE
factory: move planner, merger and reviewer to Opus 5

### DIFF
--- a/.sandcastle/agent-implement-issue.ts
+++ b/.sandcastle/agent-implement-issue.ts
@@ -160,7 +160,7 @@ try {
   await sandbox.run({
     name: "reviewer",
     maxIterations: 1,
-    agent: sandcastle.claudeCode("claude-sonnet-5"),
+    agent: sandcastle.claudeCode("claude-opus-5"),
     promptFile: "./.sandcastle/review-prompt.md",
     promptArgs: { BRANCH: branch },
   });
@@ -172,7 +172,7 @@ try {
     await sandbox.run({
       name: "merger",
       maxIterations: 1,
-      agent: sandcastle.claudeCode("claude-opus-4-8"),
+      agent: sandcastle.claudeCode("claude-opus-5"),
       promptFile: "./.sandcastle/merge-prompt.md",
       promptArgs: {
         BRANCHES: `- ${branch}`,

--- a/.sandcastle/agent-review-pr.ts
+++ b/.sandcastle/agent-review-pr.ts
@@ -113,7 +113,7 @@ try {
   const review = await sandbox.run({
     name: "reviewer",
     maxIterations: 1,
-    agent: sandcastle.claudeCode("claude-sonnet-5"),
+    agent: sandcastle.claudeCode("claude-opus-5"),
     promptFile: "./.sandcastle/review-prompt.md",
     promptArgs: { BRANCH: headRef },
   });

--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -101,7 +101,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
     // not write code. (Structured output requires maxIterations: 1.)
     maxIterations: 1,
     // Opus for planning: dependency analysis benefits from deeper reasoning.
-    agent: sandcastle.claudeCode("claude-opus-4-8"),
+    agent: sandcastle.claudeCode("claude-opus-5"),
     promptFile: "./.sandcastle/plan-prompt.md",
     // Extract and validate the <plan> JSON into a typed object. Throws
     // StructuredOutputError if the tag is missing, the JSON is malformed, or
@@ -161,7 +161,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
           const review = await sandbox.run({
             name: "reviewer",
             maxIterations: 1,
-            agent: sandcastle.claudeCode("claude-sonnet-5"),
+            agent: sandcastle.claudeCode("claude-opus-5"),
             promptFile: "./.sandcastle/review-prompt.md",
             promptArgs: {
               BRANCH: issue.branch,
@@ -232,7 +232,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
     sandbox: docker({ env: sandboxEnv }),
     name: "merger",
     maxIterations: 1,
-    agent: sandcastle.claudeCode("claude-opus-4-8"),
+    agent: sandcastle.claudeCode("claude-opus-5"),
     promptFile: "./.sandcastle/merge-prompt.md",
     promptArgs: {
       // A markdown list of branch names, one per line.

--- a/.sandcastle/plan-dry-run.ts
+++ b/.sandcastle/plan-dry-run.ts
@@ -58,7 +58,7 @@ const plan = await sandcastle.run({
   sandbox: docker({ env: sandboxSecrets() }),
   name: "planner-dry-run",
   maxIterations: 1,
-  agent: sandcastle.claudeCode("claude-opus-4-8"),
+  agent: sandcastle.claudeCode("claude-opus-5"),
   promptFile: "./.sandcastle/plan-prompt.md",
   output: sandcastle.Output.object({ tag: "plan", schema: planSchema }),
 });


### PR DESCRIPTION
Matches the org-wide role tiering in toon-meta `FACTORY.md` ([toon-meta#290](https://github.com/toon-protocol/toon-meta/pull/290)).

| Role | Before | After |
|---|---|---|
| `planner` / `planner-dry-run` | `claude-opus-4-8` | **`claude-opus-5`** |
| `merger` | `claude-opus-4-8` | **`claude-opus-5`** |
| `reviewer` | `claude-sonnet-5` | **`claude-opus-5`** |
| `implementer` | `claude-sonnet-5` | unchanged |

The reviewer moves up a tier, not just a version: it is a single-iteration pass and the last judgement before a human sees the PR. The implementer stays on Sonnet — up to 100 iterations, and the bulk of factory spend.

**Why this is not a find-and-replace:** `reviewer` and `implementer` previously shared the `claude-sonnet-5` string, so replacing the model name globally would silently move the implementer too. This change targets the reviewer's line specifically; every other Sonnet pin in the file is untouched and was asserted unchanged before the commit was written.

Seven edits per repo: 4 × `claude-opus-4-8` → `claude-opus-5`, 3 × reviewer → `claude-opus-5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)