### PR TITLE
docs(prompts): replace the ~60% context ceiling with the absolute ~200k cap

### DIFF
--- a/.sandcastle/implement-prompt.md
+++ b/.sandcastle/implement-prompt.md
@@ -69,4 +69,16 @@ ONLY WORK ON A SINGLE TASK.
 
 ## Context budget
 
-If you approach ~60% of your context window, STOP: write a structured handoff note (current state + remaining steps) to `.sandcastle/logs/handoff-<task-id>.md` and end your turn so a fresh agent continues. Do not push past ~60% — small, resumable units beat one degraded run.
+Operate as if your context is capped at **~200k tokens**, whatever your model's actual window
+is (org policy: toon-meta's `CLAUDE.md` → *Context budget policy* — the cap is absolute, not a
+percentage of the window, because a percentage means different things on different models).
+Treat ~200k as a hard ceiling, not a target, and do the real work well below it.
+
+Start preparing a handoff at roughly **120k** tokens of context, and hand off no later than
+roughly **160k** — never run to the ceiling. Handing off means: write a structured handoff note
+(goal and remaining work as a concrete task list; what has been done and where — files,
+branches, commits; key decisions and why; exact paths/line numbers instead of "see above") to
+`.sandcastle/logs/handoff-<task-id>.md`, **commit it on this branch** (use `git add -f` —
+`.sandcastle/.gitignore` ignores `logs/`, and the sandbox is destroyed when the run ends, so an
+uncommitted note is lost), and end your turn so a fresh agent continues. Small, resumable units
+beat one degraded run.

--- a/.sandcastle/review-prompt.md
+++ b/.sandcastle/review-prompt.md
@@ -56,4 +56,13 @@ Once complete, output <promise>COMPLETE</promise>.
 
 ## Context budget
 
-If you approach ~60% of your context window, STOP: write a structured handoff note (current state + remaining steps) to `.sandcastle/logs/handoff-<task-id>.md` and end your turn so a fresh agent continues. Do not push past ~60% — small, resumable units beat one degraded run.
+Operate as if your context is capped at **~200k tokens**, whatever your model's actual window
+is (org policy: toon-meta's `CLAUDE.md` → *Context budget policy* — the cap is absolute, not a
+percentage of the window). Treat ~200k as a hard ceiling, not a target.
+
+Start preparing a handoff at roughly **120k** tokens of context, and hand off no later than
+roughly **160k** — never run to the ceiling. Handing off means: write a structured handoff note
+(what you reviewed, what you changed, what is left to check, and exact file/line pointers) to
+`.sandcastle/logs/handoff-<task-id>.md`, **commit it on this branch** (use `git add -f` —
+`.sandcastle/.gitignore` ignores `logs/`, and the sandbox is destroyed when the run ends, so an
+uncommitted note is lost), and end your turn so a fresh agent continues.


### PR DESCRIPTION
Replaces the old ~60%-of-context-window handoff wording in `.sandcastle/implement-prompt.md` and `.sandcastle/review-prompt.md` with the org-canonical absolute ~200k-token cap, matching toon-meta's `CLAUDE.md` *Context budget policy*. Also adds explicit instructions to commit the handoff note on the branch with `git add -f` (verified `.sandcastle/.gitignore` ignores `logs/`, and the sandbox is destroyed when the run ends, so an uncommitted note would be lost).

Only the paragraph(s) under the `## Context budget` heading in each file were changed; nothing else was touched.

Part of toon-protocol/toon-meta#270
Part of toon-protocol/toon-meta#273

🤖 Generated with [Claude Code](https://claude.com/claude-code)