### PR TITLE
ci: add pr-housekeeping shim (event-driven stuck-PR remediation)

### DIFF
--- a/.github/workflows/pr-housekeeping-shim.yml
+++ b/.github/workflows/pr-housekeeping-shim.yml
@@ -1,0 +1,47 @@
+# pr-housekeeping shim — forwards this repo's PR lifecycle events to the
+# central stuck-PR remediation workflow in toon-meta (toon-meta#276).
+#
+# CANONICAL COPY. This file is fanned out VERBATIM to every factory repo as
+# .github/workflows/pr-housekeeping-shim.yml (toon-meta itself needs no shim —
+# its pr-housekeeping.yml carries the same triggers directly). When onboarding
+# a new factory repo, copy this file unchanged; when changing it, change it
+# here first and re-fan-out.
+#
+# All logic (mergeable settling, check-set verdicts, fix-ticket idempotency,
+# retry cap) lives ONCE in toon-meta — this shim only decides WHEN to invoke
+# it:
+#   * a PR merged into this repo — merges are what create conflicts in the
+#     other open PRs, so re-check them all at that moment;
+#   * a check suite completed on a factory branch (sandcastle/ or agent/) —
+#     the PR's own checks just finished; if red, remediation fires now, not on
+#     the next cron tick.
+#
+# `secrets: inherit` hands the called workflow this repo's FACTORY_OPS_TOKEN
+# (org secret, monitored by toon-meta's factory-ops-credential workflow).
+# Writes are still gated centrally: until the org Actions variable
+# HOUSEKEEPING_APPLY is 'true', every run is a no-write dry-run report.
+
+name: pr-housekeeping-shim
+
+on:
+  pull_request:
+    types: [closed]
+  check_suite:
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  forward:
+    # Only merged PRs matter (a plain close conflicts nobody), and only
+    # factory branches' check suites matter (anything else is noise).
+    if: >-
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
+      (github.event_name == 'check_suite' && (
+        startsWith(github.event.check_suite.head_branch, 'sandcastle/') ||
+        startsWith(github.event.check_suite.head_branch, 'agent/')))
+    uses: toon-protocol/toon-meta/.github/workflows/pr-housekeeping.yml@main
+    with:
+      repos: ${{ github.repository }}
+    secrets: inherit


### PR DESCRIPTION
Adds the identical-across-the-fleet `pr-housekeeping-shim.yml`: on a **merged** PR (merges create conflicts in the other open PRs) or a completed check suite on a `sandcastle/`/`agent/` branch, it `workflow_call`s toon-meta's central `pr-housekeeping` workflow with `secrets: inherit`, which files capped, idempotent remediation issues for stuck factory PRs (close-and-reimplement, retry cap → `needs:human`).

All logic lives once in toon-meta (canonical shim copy: `toon-meta:scripts/factory/pr-housekeeping-shim.yml`, central workflow + script on toon-protocol/toon-meta#295). This shim contains no logic beyond the trigger filter.

**Safe to merge before writes are enabled**: every run is a no-write dry-run report until the org Actions variable `HOUSEKEEPING_APPLY` is set to `true`. Merge toon-meta#295 first — the shim references the reusable workflow `@main`.

Part of toon-protocol/toon-meta#276