### PR TITLE
ci: add CI OK aggregate status job (toon-meta#279)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,24 @@ jobs:
       # runtime-skipping like it does on the plain build job.
       - name: Integration tests (anvil-gated)
         run: devbox run -- bash -c "pnpm --filter @toon-protocol/swap test:integration"
+
+  ci-ok:
+    name: CI OK
+    runs-on: ubuntu-latest
+    needs: [build, devbox-validate]
+    if: always()
+    steps:
+      # Fleet-wide aggregate required check (toon-meta#279): this job is the
+      # single required status for the repo. It must fail unless every gating
+      # job actually SUCCEEDED — a skipped or cancelled gating job must never
+      # read as a pass. Both `build` and `devbox-validate` are expected on
+      # every run; there are no legitimately-skippable jobs in this workflow.
+      - name: Check all gating jobs succeeded
+        run: |
+          echo "build: ${{ needs.build.result }}"
+          echo "devbox-validate: ${{ needs.devbox-validate.result }}"
+          if [ "${{ needs.build.result }}" != "success" ] || [ "${{ needs.devbox-validate.result }}" != "success" ]; then
+            echo "One or more gating jobs did not succeed (failure, cancelled, and skipped all fail)."
+            exit 1
+          fi
+          echo "All gating jobs succeeded."


### PR DESCRIPTION
## What

Appends a single aggregate job `ci-ok` (check-run context **CI OK**) to `.github/workflows/ci.yml`. It runs with `needs: [build, devbox-validate]` and `if: always()`, prints each gating job's result, and exits 1 unless BOTH `build` and `devbox-validate` finished with result `success` — `failure`, `cancelled`, and `skipped` all fail the aggregate.

## Why

This job's context is intended to become the repo's single required check (repointing branch protection is handled by the orchestrator, not this PR):

- Today only `build` is required; `Devbox Environment Validation` runs on every PR but its failure is silently ignored because it is not a required check.
- With `CI OK` required, both jobs gate merges, and a skipped or cancelled gating job can never read as a pass.
- Both jobs are expected on every run; there are no legitimately-skippable jobs in swap's ci.yml.

No existing jobs are modified — the aggregate job is purely additive.

Part of toon-protocol/toon-meta#270
Part of toon-protocol/toon-meta#279

🤖 Generated with [Claude Code](https://claude.com/claude-code)