### PR TITLE
ops: factory fan-out — shim triggers, agent:fix runner, agent:review clear

### DIFF
--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -1,0 +1,221 @@
+# agent:fix runner — the sandcastle label→runner for repairing one red PR
+# (toon-meta#357, fanned out under toon-meta#365).
+#
+# WHAT THIS DOES (and does NOT do):
+#   Fires when `agent:fix` is applied to a PULL REQUEST — normally by the
+#   central PR repair pass in toon-meta (scripts/factory/{repair,automerge}-
+#   evaluator.mjs + auto-merge.mjs, under REPAIR_APPLY) when that PR's ONLY
+#   blocker(s) are red checks and/or a merge conflict; every other blocker
+#   (needs:human, an outstanding CHANGES_REQUESTED, ...) leaves the PR
+#   `blocked` instead and never reaches this label at all. It runs the
+#   single-PR repair runner (`pnpm sandcastle:fix`) against the PR's head
+#   branch: the fixer diagnoses the failing check(s)/conflict, makes the
+#   smallest fix, and any commits are pushed back onto the SAME PR — never a
+#   new one.
+#
+#   This repo's gate is ci.yml (plus the Agent image build on .sandcastle/**
+#   PRs) — .sandcastle/fix-prompt.md carries the check inventory the fixer
+#   targets and the local reproduce commands.
+#
+#   It NEVER merges the PR, NEVER submits a review verdict, and NEVER closes
+#   anything — the PR's own `synchronize` trigger re-evaluates auto-merge
+#   (and, if `agent:review` is already on the PR, the review pass) once the
+#   fix lands.
+#
+#   The load-bearing part: the runner removes its own `agent:fix` label when
+#   it finishes, WHATEVER THE OUTCOME — see .sandcastle/agent-fix-pr.ts's
+#   module header. Three labels have already been found that an automated
+#   step applies and nothing automated clears (agent:implement toon-meta#330,
+#   needs:human toon-meta#352, agent:review toon-meta#355); this must not
+#   become a fourth.
+#
+#   Merely committing this file triggers nothing: pull_request-`labeled`
+#   workflows fire only when the label is actually applied.
+#
+# STANDALONE-REPAIR MECHANICS (same as agent-review.yml):
+#   sandcastle checks the PR head branch out in its OWN worktree under
+#   .sandcastle/worktrees/, and git refuses the same branch in two worktrees —
+#   so the checkout below pins `ref: main`, never the PR head. The runner then
+#   materialises the PR head as a local branch itself (see
+#   .sandcastle/agent-fix-pr.ts).
+#
+# Note: label events on PRs opened from FORKS run without secrets (GitHub
+# security), so this runner only works on same-repo PRs — expected for the
+# internal factory flow, same as every other label->runner in this repo.
+
+name: agent:fix
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  guard:
+    if: github.event.label.name == 'agent:fix'
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    steps:
+      - name: Evaluate guards
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          proceed=true
+
+          # The labeler must have write access — refuses drive-by repair
+          # requests from outsiders. The PR repair pass itself labels via
+          # FACTORY_OPS_TOKEN, which authenticates with write access, so this
+          # does not block the normal automated path.
+          perm=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" \
+            --jq '.permission' 2>/dev/null || echo "none")
+          echo "Actor ${ACTOR} permission: ${perm}"
+          case "$perm" in
+            admin|maintain|write) ;;
+            *)
+              echo "::warning::Actor ${ACTOR} lacks write permission (${perm}) — skipping."
+              proceed=false ;;
+          esac
+
+          echo "proceed=${proceed}" >> "$GITHUB_OUTPUT"
+
+  fix:
+    needs: guard
+    if: needs.guard.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    # Forensics split (mirrors agent-review.yml, toon-meta#278): the runner
+    # step gets timeout-minutes: 25 so the always() redact+upload steps keep
+    # job budget even on a wall-clock kill.
+    timeout-minutes: 30
+    concurrency:
+      group: agent-fix-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Check out MAIN, not the PR head — see the standalone-repair
+          # mechanics note above.
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Enable pnpm via corepack
+        run: corepack enable && corepack prepare pnpm@8.15.9 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build sandcastle agent image
+        run: npx --yes @ai-hero/sandcastle@0.12.0 docker build-image
+
+      # App token so fix commits pushed back to the PR re-trigger ci.yml.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Run sandcastle fix runner
+        # Step-level timeout (mirrors agent-review.yml, toon-meta#278): below
+        # the job's, so a wall-clock kill is a step failure and the always()
+        # forensics steps still run.
+        timeout-minutes: 25
+        env:
+          SANDCASTLE_PR_NUMBER: ${{ github.event.pull_request.number }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: pnpm sandcastle:fix
+
+      # REDACT BEFORE UPLOAD — this repository is PUBLIC. Identical three-pass
+      # sweep to agent-review.yml; see that workflow for the full rationale
+      # (exact secret values this job holds, known token/key shapes, BIP-39
+      # mnemonics and labelled private keys).
+      - name: Redact credentials from agent logs
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          [ -d .sandcastle ] || { echo "No .sandcastle directory — nothing to redact."; exit 0; }
+          python3 - <<'PY'
+          import os, pathlib, re
+
+          exact = sorted(
+              (v for v in (os.environ.get(k, "") for k in
+                           ("GH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN", "APP_PRIVATE_KEY"))
+               if v and len(v.strip()) >= 8),
+              key=len, reverse=True,
+          )
+
+          patterns = [
+              (re.compile(r"gh[pousr]_[A-Za-z0-9]{16,}"), "***REDACTED***"),
+              (re.compile(r"github_pat_[A-Za-z0-9_]{20,}"), "***REDACTED***"),
+              (re.compile(r"sk-ant-[A-Za-z0-9_\-]{20,}"), "***REDACTED***"),
+              (re.compile(r"nsec1[a-z0-9]{20,}"), "***REDACTED***"),
+              (re.compile(r"-----BEGIN[^-]*PRIVATE KEY-----.*?-----END[^-]*PRIVATE KEY-----",
+                          re.DOTALL), "***REDACTED***"),
+              (re.compile(
+                  r"((?:private[_\-]?key|secret[_\-]?key|signer[_\-]?key|priv[_\-]?key|keyId)"
+                  r"[\"'\s:=]{0,6})(?:0x)?[0-9a-fA-F]{64}",
+                  re.IGNORECASE,
+               ), r"\1***REDACTED***"),
+          ]
+
+          for n in (24, 21, 18, 15, 12):
+              patterns.append((
+                  re.compile(r"(?<![A-Za-z0-9'\-])(?:[a-z]{3,8}[ \n]+){%d}[a-z]{3,8}(?![A-Za-z0-9'\-])"
+                             % (n - 1)),
+                  "***REDACTED***",
+              ))
+
+          roots = [pathlib.Path(".sandcastle/logs"),
+                   *pathlib.Path(".sandcastle/worktrees").glob("*/.sandcastle/logs")]
+
+          hits = 0
+          for root in roots:
+              if not root.is_dir():
+                  continue
+              for path in root.rglob("*"):
+                  if not path.is_file():
+                      continue
+                  raw = path.read_text(encoding="utf-8", errors="replace")
+                  out = raw
+                  for value in exact:
+                      for form in {value, value.strip(), value.replace("\n", "\\n")}:
+                          if form and form in out:
+                              out = out.replace(form, "***REDACTED***")
+                  for pat, repl in patterns:
+                      out = pat.sub(repl, out)
+                  if out != raw:
+                      hits += 1
+                      path.write_text(out, encoding="utf-8")
+          print(f"Redaction complete. Files modified: {hits}")
+          PY
+
+      # The fixer's reasoning is written to .sandcastle/logs/, NOT to the step
+      # output — see agent-review.yml's identical step for the full rationale
+      # (toon-meta#278).
+      - name: Upload agent logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sandcastle-fix-logs-pr-${{ github.event.pull_request.number }}
+          path: |
+            .sandcastle/logs/
+            .sandcastle/worktrees/*/.sandcastle/logs/
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 14

--- a/.github/workflows/auto-merge-shim.yml
+++ b/.github/workflows/auto-merge-shim.yml
@@ -1,22 +1,28 @@
 # auto-merge shim — forwards this repo's PR lifecycle events to the central
 # auto-merge pass in toon-meta (toon-meta#285, epic #270).
 #
-# CANONICAL COPY. This file is fanned out VERBATIM to every factory repo as
+# Fanned out from toon-meta to every factory repo as
 # .github/workflows/auto-merge-shim.yml (toon-meta itself needs no shim — its
-# auto-merge.yml carries the same triggers directly). When onboarding a new
-# factory repo, copy this file unchanged; when changing it, change it here
-# first and re-fan-out.
+# auto-merge.yml carries its own triggers directly). When changing this file,
+# change it in toon-meta first and re-fan-out; the only per-repo part is the
+# workflow_run list, which must name THIS repo's own pull_request workflows.
 #
 # All logic (the five merge preconditions, the check-set honesty rule, the
-# native-auto-merge seam, the merge cap) lives ONCE in toon-meta — this shim
-# only decides WHEN to invoke it:
-#   * a check suite completed on a factory branch (sandcastle/ or agent/) —
-#     the PR's gate just finished, the usual moment a PR becomes eligible;
+# native-auto-merge seam, the merge cap, and the PR repair pass #357) lives
+# ONCE in toon-meta — this shim only decides WHEN to invoke it:
+#   * a pull_request workflow completed on a factory branch (sandcastle/ or
+#     agent/) — the PR's gate just finished, the usual moment a PR becomes
+#     eligible;
 #   * a review was submitted on a factory PR — the factory-ops APPROVE (#282)
 #     is the precondition that often flips last;
 #   * a PR merged into this repo — under strict protection (#272) that merge
 #     just put every other open PR behind `main`, and updating those branches
-#     is part of the pass.
+#     is part of the pass;
+#   * a label change or push on a factory PR (labeled/unlabeled/synchronize,
+#     toon-meta#357/#358) — clearing `needs:human` is an `unlabeled` event and
+#     is the one state change that can make a PR mergeable with no other
+#     event, and a repair push must be re-evaluated as soon as it lands, not
+#     on the next cron.
 #
 # `secrets: inherit` hands the called workflow this repo's FACTORY_OPS_TOKEN
 # (org secret, monitored by toon-meta's factory-ops-credential workflow) —
@@ -27,12 +33,22 @@
 name: auto-merge-shim
 
 on:
-  check_suite:
-    types: [completed]
   pull_request_review:
     types: [submitted]
   pull_request:
-    types: [closed]
+    types: [closed, labeled, unlabeled, synchronize]
+  # NO check_suite trigger: it is dead — check suites for Actions runs are
+  # created via GITHUB_TOKEN, and GITHUB_TOKEN-created events never trigger
+  # workflows, so a check_suite block here never fires. workflow_run below is
+  # the working replacement for "the PR's gate just finished".
+  #
+  # The list names this repo's own workflows that run on pull_request. The
+  # forwarding shims themselves (auto-merge-shim, pr-housekeeping-shim) are
+  # deliberately NOT listed — forwarding on a forwarder would only chain runs
+  # without adding any new PR state.
+  workflow_run:
+    workflows: ["CI", "Agent image", "agent:review", "agent:fix"]
+    types: [completed]
 
 permissions:
   contents: read
@@ -40,15 +56,20 @@ permissions:
 jobs:
   forward:
     # Only factory branches matter, and only merged PRs (a plain close changes
-    # nobody's mergeability).
+    # nobody's mergeability). workflow_run events carry no pull_request ref,
+    # so they are guarded by the run's head_branch instead.
     if: >-
-      (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
+      (github.event_name == 'pull_request' && (
+        github.event.pull_request.merged == true ||
+        ((github.event.action == 'labeled' || github.event.action == 'unlabeled' || github.event.action == 'synchronize') && (
+          startsWith(github.event.pull_request.head.ref, 'sandcastle/') ||
+          startsWith(github.event.pull_request.head.ref, 'agent/'))))) ||
       (github.event_name == 'pull_request_review' && (
         startsWith(github.event.pull_request.head.ref, 'sandcastle/') ||
         startsWith(github.event.pull_request.head.ref, 'agent/'))) ||
-      (github.event_name == 'check_suite' && (
-        startsWith(github.event.check_suite.head_branch, 'sandcastle/') ||
-        startsWith(github.event.check_suite.head_branch, 'agent/')))
+      (github.event_name == 'workflow_run' && (
+        startsWith(github.event.workflow_run.head_branch, 'sandcastle/') ||
+        startsWith(github.event.workflow_run.head_branch, 'agent/')))
     uses: toon-protocol/toon-meta/.github/workflows/auto-merge.yml@main
     with:
       repos: ${{ github.repository }}

--- a/.sandcastle/agent-fix-pr.ts
+++ b/.sandcastle/agent-fix-pr.ts
@@ -1,0 +1,265 @@
+// Single-PR repair runner — the entry point the `agent:fix` label→runner
+// workflow (.github/workflows/agent-fix.yml) invokes when the central PR
+// repair pass (toon-meta#357 — toon-meta's scripts/factory/
+// {repair,automerge}-evaluator.mjs + auto-merge.mjs) applies `agent:fix` to a
+// PR whose ONLY blocker(s) are red checks and/or a merge conflict. Fanned out
+// from toon-meta under toon-meta#365.
+//
+// Mirrors .sandcastle/agent-review-pr.ts's single-PR mechanics (fetch the PR
+// head as a local branch, run one sandboxed agent pass against it, push any
+// commits back to the SAME PR — never a new one), swapping the reviewer role
+// for a fixer role (sonnet, up to 60 iterations — a repair is scoped and
+// bounded by the evaluator's own retry/repair budgets, DEFAULT_REPAIR_BUDGET
+// = 2, so this runner does not also need implement's full 100-iteration
+// budget).
+//
+// THE LOAD-BEARING PART (#357's own words): this runner REMOVES its own
+// `agent:fix` label when it finishes, WHATEVER THE OUTCOME (fix pushed, no
+// changes made, or the run itself threw) — never only on success. Three
+// labels have already been found that an automated step applies and nothing
+// automated clears: `agent:implement` (#330), `needs:human` (#352),
+// `agent:review` (#355). This must not become a fourth. Removing the label
+// unconditionally also re-arms `repair-evaluator.mjs`'s
+// `hasAgentFixInFlight` gate, so the NEXT auto-merge pass evaluates this PR
+// fresh (still red → another `repair` attempt against the budget, or
+// `escalate` once the budget is spent — never silently stuck "in flight"
+// forever).
+//
+// RESIDUAL GAP, stated rather than hidden: "whatever the outcome" covers every
+// outcome of THIS PROCESS — the outermost `finally` runs whether the fixer
+// pushed, changed nothing, or threw. It cannot cover the process never getting
+// that far: a throw in the setup above it (the `gh pr view` / `git fetch`
+// before the try), or a job-level kill (the 25-minute step timeout, a cancel).
+// Those leave `agent:fix` on the PR, and nothing else clears it — the same
+// exposure `agent-review-pr.ts` has for `agent:review`. If it bites, the fix
+// is an `if: always()` label-clearing step in agent-fix.yml, which survives a
+// runner kill in a way an in-process `finally` cannot.
+//
+// STANDALONE MECHANICS: same worktree conflict agent-review-pr.ts documents
+// (sandcastle checks the PR head out in its own worktree, so the workflow
+// checks out `main` and this runner materialises the PR head as a local
+// branch itself before createSandbox()).
+//
+// This runner NEVER submits a review verdict and NEVER merges — it only
+// pushes fix commits back to the PR. The existing review pass (agent:review)
+// and auto-merge pass re-evaluate the PR on its own `synchronize` trigger.
+//
+// Required env:
+//   SANDCASTLE_PR_NUMBER      the PR to repair (github.event.pull_request.number)
+//   CLAUDE_CODE_OAUTH_TOKEN   Claude Max-plan credential (org secret)
+//   GH_TOKEN                  token with contents:write + pull-requests:write +
+//                             issues:write (labels)
+//
+// Usage:
+//   SANDCASTLE_PR_NUMBER=42 npx tsx .sandcastle/agent-fix-pr.ts
+//   # or: pnpm sandcastle:fix   (with SANDCASTLE_PR_NUMBER exported)
+
+import { execFileSync } from "node:child_process";
+import * as sandcastle from "@ai-hero/sandcastle";
+import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+import { sandboxSecrets } from "./sandbox-secrets.ts";
+
+// Deliberately NOT imported from scripts/factory/repair-evaluator.mjs: that
+// directory is toon-meta-only tooling (toon-meta#354's own lesson — verified
+// against all nine other factory repos at the time, none had it), while
+// .sandcastle/ is what actually gets copied into every fleet repo so its
+// runner works standalone there. Mirrors AGENT_REVIEW_LABEL's own local
+// definition in review-verdict.ts, one directory over.
+const AGENT_FIX_LABEL = "agent:fix";
+
+const prNumber = process.env.SANDCASTLE_PR_NUMBER?.trim();
+if (!prNumber || !/^\d+$/.test(prNumber)) {
+  throw new Error(
+    "SANDCASTLE_PR_NUMBER must be set to a numeric PR number " +
+      `(got: ${JSON.stringify(process.env.SANDCASTLE_PR_NUMBER)}).`,
+  );
+}
+
+function gh(args: string[]): string {
+  return execFileSync("gh", args, { encoding: "utf8" });
+}
+
+function repoNwo(): string {
+  return gh([
+    "repo",
+    "view",
+    "--json",
+    "nameWithOwner",
+    "--jq",
+    ".nameWithOwner",
+  ]).trim();
+}
+
+/**
+ * Remove `agent:fix` from the PR. Idempotent: a 404 (label absent — a prior
+ * pass already cleared it, or this is a re-run) is the expected no-op and
+ * must not fail the job; any other error still throws, matching
+ * `review-verdict.ts`'s `agent:review` clear (#355) — silently losing this
+ * removal would recreate the exact stuck-label problem #357 exists to fix.
+ */
+function removeAgentFixLabel(): void {
+  const nwo = repoNwo();
+  try {
+    execFileSync(
+      "gh",
+      [
+        "api",
+        "-X",
+        "DELETE",
+        // The colon MUST stay percent-encoded — `gh api` does not encode path
+        // segments, and an unencoded `agent:fix` silently no-ops (200, label
+        // untouched). Same gotcha documented in review-verdict.ts.
+        `repos/${nwo}/issues/${prNumber}/labels/${encodeURIComponent(AGENT_FIX_LABEL)}`,
+      ],
+      { stdio: "pipe" },
+    );
+    console.log(`Cleared '${AGENT_FIX_LABEL}' on PR #${prNumber} — repair run finished.`);
+  } catch (error) {
+    const stderr =
+      error instanceof Error && "stderr" in error
+        ? String((error as { stderr?: unknown }).stderr ?? "")
+        : "";
+    if (!/\b404\b|Not Found/i.test(stderr)) {
+      if (stderr) process.stderr.write(stderr);
+      throw error;
+    }
+    console.log(
+      `'${AGENT_FIX_LABEL}' was not on PR #${prNumber} — nothing to clear.`,
+    );
+  }
+}
+
+// Resolve the PR's head branch on the host. `gh` authenticates via GH_TOKEN.
+const headRef = execFileSync(
+  "gh",
+  ["pr", "view", prNumber, "--json", "headRefName", "--jq", ".headRefName"],
+  { encoding: "utf8" },
+).trim();
+
+if (!headRef) {
+  throw new Error(`Could not resolve head branch for PR #${prNumber}.`);
+}
+
+// Materialise the PR head as a local branch at origin's tip (the host clone
+// is on main — see the standalone mechanics note above). Forced so a
+// re-labeled PR re-repairs the CURRENT head even after a force-push.
+execFileSync("git", ["fetch", "origin", `+${headRef}:${headRef}`], {
+  stdio: "inherit",
+});
+
+const hooks = {
+  sandbox: {
+    onSandboxReady: [
+      // Same git-push-auth wiring as agent-review-pr.ts / agent-implement-issue.ts
+      // — see either file's onSandboxReady for the full root-cause note.
+      {
+        command:
+          'if [ -n "$GH_TOKEN" ]; then gh auth setup-git; ' +
+          "git config --unset-all 'http.https://github.com/.extraheader' 2>/dev/null || true; fi",
+      },
+      { command: "pnpm install --frozen-lockfile" },
+    ],
+  },
+};
+
+console.log(`\n=== agent:fix runner — PR #${prNumber} (head: ${headRef}) ===\n`);
+
+// Set to a non-null message in the push-verification step below when the
+// fixer reported commits but the PR branch did NOT actually advance. Recorded
+// here (rather than process.exit inside the try) so the finally blocks below
+// still close the sandbox and clear the label before we fail the job.
+let pushVerificationError: string | null = null;
+
+try {
+  const sandbox = await sandcastle.createSandbox({
+    branch: headRef,
+    // Forward CLAUDE_CODE_OAUTH_TOKEN + GH_TOKEN into the container — see
+    // ./sandbox-secrets.ts.
+    sandbox: docker({ env: sandboxSecrets() }),
+    hooks,
+  });
+
+  try {
+    const fix = await sandbox.run({
+      name: "fixer",
+      // Scoped to a bounded repair, not a full implement — the evaluator's
+      // own DEFAULT_REPAIR_BUDGET (2 agent:fix dispatches per PR) is what
+      // actually bounds retries across runs; this just keeps ONE run from
+      // wandering indefinitely.
+      maxIterations: 60,
+      agent: sandcastle.claudeCode("claude-sonnet-5"),
+      promptFile: "./.sandcastle/fix-prompt.md",
+      promptArgs: {
+        PR_NUMBER: prNumber,
+        BRANCH: headRef,
+      },
+    });
+
+    if (fix.commits.length > 0) {
+      console.log(
+        `\nFixer made ${fix.commits.length} commit(s) — pushing to the PR branch.`,
+      );
+      // DETERMINISTIC (no agent) — same rationale as the review/implement
+      // runners' push step: `git push` is pure plumbing with no judgement
+      // call, so it is run directly rather than handed to another agent pass.
+      const push = await sandbox.exec(`git push origin ${headRef}`, {
+        onLine: (line) => console.log(`  [push] ${line}`),
+      });
+      if (push.exitCode !== 0) {
+        throw new Error(
+          `git push of '${headRef}' failed (exit ${push.exitCode}).\n${push.stderr}`,
+        );
+      }
+
+      // FAIL LOUD: verify from the HOST that the PR branch head now points at
+      // the fixer's last commit.
+      const expectedSha = fix.commits[fix.commits.length - 1]!.sha;
+      const nwo = repoNwo();
+      const remoteSha = JSON.parse(
+        execFileSync("gh", ["api", `repos/${nwo}/git/ref/heads/${headRef}`], {
+          encoding: "utf8",
+        }),
+      ).object?.sha as string | undefined;
+
+      if (remoteSha === expectedSha) {
+        console.log(
+          `\nVerified: PR branch '${headRef}' advanced to ${expectedSha} (the fix commits are pushed).`,
+        );
+      } else {
+        pushVerificationError =
+          `\nERROR: the fix phase reported COMPLETE, but the PR branch ` +
+          `'${headRef}' did NOT advance to the fixer's commits.\n` +
+          `  Expected head SHA (last fix commit): ${expectedSha}\n` +
+          `  Actual remote head SHA:              ${remoteSha ?? "<branch not found>"}\n` +
+          `  The in-sandbox \`git push\` failed silently. Inspect the fixer ` +
+          `phase logs above. The Actions job is failing deliberately so this ` +
+          `is not mistaken for success.`;
+      }
+    } else {
+      console.log(
+        "\nFixer made no changes — either the PR was not actually fixable " +
+          "from this branch, or it determined nothing needed changing.",
+      );
+    }
+  } finally {
+    await sandbox.close();
+  }
+} finally {
+  // ALWAYS clear agent:fix, even if the run above threw — see the module
+  // header. This must be the LAST thing that can be skipped by an exception,
+  // so it lives in the outermost finally.
+  removeAgentFixLabel();
+}
+
+// Fail loud AFTER the sandbox is closed and the label is cleared: a
+// silently-failed push must turn the Actions job red, never green.
+if (pushVerificationError) {
+  console.error(pushVerificationError);
+  process.exit(1);
+}
+
+console.log(
+  "\nRepair run complete. The PR was NOT merged and NOT re-reviewed here — " +
+    "its own `synchronize` trigger re-evaluates auto-merge and, if `agent:review` " +
+    "was already applied, the review pass.",
+);

--- a/.sandcastle/fix-prompt.md
+++ b/.sandcastle/fix-prompt.md
@@ -1,0 +1,74 @@
+# TASK
+
+Repair pull request #{{PR_NUMBER}} on branch `{{BRANCH}}` so its checks pass and it is
+mergeable.
+
+You were dispatched by the factory's PR repair pass (toon-meta#357): this PR's ONLY
+blocker(s) are a merge conflict and/or failing checks — every other precondition
+(approval, review state, `needs:human`) already holds. Make the smallest change that
+gets it green; do not expand scope.
+
+# DIAGNOSE
+
+First, find out exactly why this PR is red:
+
+    gh pr view {{PR_NUMBER}} --json mergeable,statusCheckRollup
+
+- If `mergeable` is `CONFLICTING`, resolve the conflict against `main` (see CONFLICTS
+  below).
+- For every failing check, read its logs before touching anything:
+
+      gh run view <run-id> --log-failed
+
+  (`<run-id>` is the numeric id in the failing check's `detailsUrl`.)
+
+# CONFLICTS
+
+If the PR conflicts with `main`:
+
+    git fetch origin main
+    git merge origin/main
+
+Resolve conflicts by reading BOTH sides and choosing the resolution that preserves both
+changes' intent (the same convention `.sandcastle/merge-prompt.md` uses) — never blindly
+take "ours" or "theirs". If a conflict needs a judgement call only a human should make,
+say so plainly in your final output instead of guessing.
+
+# FAILING CHECKS
+
+This is **swap** — a pnpm workspace (Node 22, pnpm 8.15.9). The checks that can go red:
+
+- **CI / build** (`.github/workflows/ci.yml`), the gate run on EVERY PR (CI installs
+  with `pnpm install --no-frozen-lockfile`): the correctness gate
+  (`pnpm run gate:correctness` — build/typecheck/lint/format via
+  `.sandcastle/scripts/gate-correctness.ts`) plus `pnpm test`. Reproduce locally with
+  the same commands, and run the BUILD before the TYPECHECK — typecheck resolves
+  workspace `dist/` output, so an unbuilt tree produces phantom module-not-found
+  errors.
+- **CI / Devbox Environment Validation** — a devbox smoke build plus the
+  `@toon-protocol/swap` integration tests
+  (`pnpm --filter @toon-protocol/swap test:integration`); usually red only when tool
+  versions drift or an integration test regresses.
+- **CI / CI OK** — an aggregator over the gating jobs; fix the failing upstream job,
+  never this one.
+- **Agent image** (`.github/workflows/agent-image.yml`) — a build-only check over
+  `.sandcastle/Dockerfile`, run only on PRs touching `.sandcastle/**` or that workflow.
+
+Fix the ROOT CAUSE of the failure, not the symptom — e.g. a failing test means fix the
+code (or an actually-wrong test), not delete the check that caught it. If a failing
+check looks like infrastructure flakiness (a CDN, package registry, or setup-step
+timeout with no code-level cause), say so plainly in your final output instead of
+inventing a change just to make the diff "look different."
+
+# EXECUTION
+
+1. Diagnose the actual cause before editing anything.
+2. Make the smallest change that fixes it.
+3. Re-run what failed locally (`pnpm run gate:correctness`, `pnpm test` as applicable)
+   and confirm it passes before you consider the job done.
+4. Commit on the current branch (`{{BRANCH}}`) — this is the PR's own branch; do not open
+   a new PR.
+5. Do not touch anything outside what's needed to turn this PR green.
+
+Once you've made your fix commit(s) (or determined the failure is not fixable from this
+branch — say so clearly in your final output), output <promise>COMPLETE</promise>.

--- a/.sandcastle/review-verdict.ts
+++ b/.sandcastle/review-verdict.ts
@@ -292,6 +292,7 @@ export function resolveIssueFromPrBody(prNumber: string): TargetIssue | null {
 }
 
 const NEEDS_HUMAN_LABEL = "needs:human";
+const AGENT_REVIEW_LABEL = "agent:review";
 
 // ---------------------------------------------------------------------------
 // factory-ops formal verdict (toon-meta#282)
@@ -464,6 +465,14 @@ function factoryOpsApprovalBody(issue: TargetIssue | null): string {
  *   clean    → APPROVE
  *   blocking → REQUEST_CHANGES with the findings, plus the `needs:human` label
  *
+ * Either way, `agent:review` — the label that triggered this run — is removed
+ * once the verdict lands (toon-meta#355). Unlike `needs:human`, `agent:review`
+ * is unambiguously a machine trigger, never a human control point, so no
+ * ownership check applies: whoever applied it, a submitted verdict means the
+ * review it asked for is done. That also makes re-review symmetrical with the
+ * first review — apply the label again — instead of the undocumented
+ * remove-then-re-add dance the `labeled`-event trigger otherwise demands.
+ *
  * Resolves the approver identity and re-asserts the self-approval guard
  * itself, so no caller can reach the submission without the guard. After
  * submission the created review's state is verified from the API response —
@@ -562,6 +571,57 @@ export function submitFactoryOpsVerdict(
     );
     console.log(
       `Requested changes with the findings and applied '${NEEDS_HUMAN_LABEL}' on PR #${prNumber}.`,
+    );
+  }
+
+  // Clear the trigger label now that the verdict it requested has been
+  // submitted — see the function doc comment (toon-meta#355). No ownership
+  // check (unlike needs:human above): agent:review is a pure trigger, so
+  // whoever applied it, "a verdict was just submitted" is reason enough to
+  // remove it.
+  //
+  // The label is legitimately ABSENT on two paths: the implement runner's
+  // verdict (agent-implement-issue.ts submits a verdict on a PR that was
+  // never labelled agent:review) and a re-run of an already-cleared review.
+  // GitHub answers a DELETE of an absent label with 404, which `gh api`
+  // surfaces as a non-zero exit — so a 404 here is the expected no-op and
+  // must not fail the run. Any OTHER error still throws: silently losing
+  // the removal on the review-runner path would re-create the exact
+  // stale-label unreadability this function exists to fix.
+  try {
+    execFileSync(
+      "gh",
+      [
+        "api",
+        "-X",
+        "DELETE",
+        // The colon MUST stay percent-encoded: `gh api` does not encode path
+        // segments, and an unencoded `agent:review` silently no-ops (200,
+        // label untouched) rather than erroring.
+        `repos/${nwo}/issues/${prNumber}/labels/${encodeURIComponent(AGENT_REVIEW_LABEL)}`,
+      ],
+      {
+        // "pipe" (not inherit) so the catch below can read gh's stderr to
+        // tell the benign 404 apart from a real failure.
+        stdio: "pipe",
+        env: { ...process.env, GH_TOKEN: approver.token },
+      },
+    );
+    console.log(
+      `Cleared '${AGENT_REVIEW_LABEL}' on PR #${prNumber} — the review verdict is submitted.`,
+    );
+  } catch (error) {
+    const stderr =
+      error instanceof Error && "stderr" in error
+        ? String((error as { stderr?: unknown }).stderr ?? "")
+        : "";
+    if (!/\b404\b|Not Found/i.test(stderr)) {
+      if (stderr) process.stderr.write(stderr);
+      throw error;
+    }
+    console.log(
+      `'${AGENT_REVIEW_LABEL}' was not on PR #${prNumber} — nothing to clear. ` +
+        `Expected on the implement runner's verdict path and on re-runs.`,
     );
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "sandcastle": "npx tsx .sandcastle/main.ts",
     "sandcastle:plan": "npx tsx .sandcastle/plan-dry-run.ts",
     "sandcastle:implement": "npx tsx .sandcastle/agent-implement-issue.ts",
-    "sandcastle:review": "npx tsx .sandcastle/agent-review-pr.ts"
+    "sandcastle:review": "npx tsx .sandcastle/agent-review-pr.ts",
+    "sandcastle:fix": "npx tsx .sandcastle/agent-fix-pr.ts"
   },
   "keywords": [
     "nostr",


### PR DESCRIPTION
Fan-out of toon-meta#364 / toon-meta#363 to this repo. Three factory components, copied/adapted from `toon-protocol/toon-meta@main`.

### 1. `auto-merge-shim.yml` trigger refresh
- Drops `check_suite` — it is a **dead trigger**: check suites for Actions runs are created via `GITHUB_TOKEN`, and GITHUB_TOKEN-created events never trigger workflows, so the old block never fired.
- Forwards on `pull_request_review [submitted]`, `pull_request [closed, labeled, unlabeled, synchronize]` (toon-meta#357/#358 — clearing `needs:human` is an `unlabeled` event, and a repair push must be re-evaluated immediately, not on the next cron), and `workflow_run [completed]` of this repo's own pull_request workflows (`CI`, `Agent image`, `agent:review`, `agent:fix`), with a job-level guard restricting `workflow_run` forwards to `sandcastle/` / `agent/` head branches.
- Dispatch mechanics unchanged: still `uses: toon-protocol/toon-meta/.github/workflows/auto-merge.yml@main` with `repos: ${{ github.repository }}` and `secrets: inherit`; writes stay centrally gated behind the org `AUTOMERGE_APPLY` variable.

### 2. PR-repair runner port (toon-meta#365)
`agent-fix.yml` + `.sandcastle/agent-fix-pr.ts` + `.sandcastle/fix-prompt.md` + the `sandcastle:fix` package script. Mirrors this repo's existing `agent-review.yml` for checkout (`ref: main` — worktree mechanics), corepack/pnpm setup, the write-permission guard, `permissions:`, timeout split (job 30 / step 25 so `always()` forensics keep budget), and the **same redact-before-upload artifact discipline** (this repo is public; three-pass sweep identical to agent-review's). The runner takes `SANDCASTLE_PR_NUMBER`, pushes fix commits back to the **same** PR (never a new one), fail-loud-verifies the remote branch actually advanced, and **always clears its own `agent:fix` label** in the outermost `finally`. This is the label→runner the central repair pass dispatches, so the org `REPAIR_APPLY` knob can go live fleet-wide.

### 3. `agent:review` label clear (toon-meta#355 propagation)
`.sandcastle/review-verdict.ts` now removes the `agent:review` trigger label once the formal verdict lands: an unconditional-but-404-tolerant DELETE (`stdio: "pipe"`, stderr matching `/\b404\b|Not Found/i` is the benign absent-label no-op and is logged; anything else rethrows), with the colon percent-encoded via `encodeURIComponent` — an unencoded colon silently no-ops.

Part of toon-meta#365

Verified: YAML parses; `.sandcastle` TypeScript builds/typechecks under the repo toolchain. **Do not merge without owner review** — factory-ops change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Per-repo note
swap's `review-verdict.ts` predates the toon-meta#354 needs-human clean-verdict clear (it has no `needs-human-evaluator.mjs` and no `clearsNeedsHuman` branch), so ONLY the #355 `agent:review` block was hand-ported here, keeping the file's local shape. The missing #354 clear is a pre-existing gap in this repo, out of scope for this PR — worth a separate follow-up ticket.
