### PR TITLE
shim: grant actions:write — subset-capped caller startup-fails the reusable call

### DIFF
--- a/.github/workflows/auto-merge-shim.yml
+++ b/.github/workflows/auto-merge-shim.yml
@@ -52,6 +52,13 @@ on:
 
 permissions:
   contents: read
+  # actions: write because the CALLED fleet pass (toon-meta auto-merge.yml)
+  # requests it for same-repo fix-runner dispatch (toon-meta#385) — a
+  # reusable workflow's permissions must be a SUBSET of its caller's, so a
+  # shim capped at contents:read startup-fails the whole call. Observed
+  # fleet-wide 2026-08-14 ~16:05Z: every shim run startup_failure, all
+  # event forwarding silently dead.
+  actions: write
 
 jobs:
   forward:


### PR DESCRIPTION
Every shim run since toon-meta#385 has been `startup_failure`: the called fleet pass now requests `actions: write`, and a reusable workflow's permissions must be a subset of its caller's — a `contents: read`-capped shim kills the whole call before it starts. Fleet event forwarding was silently dead. Two-line grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)