### PR TITLE
Rolling RFQ intake: the maker can finally hear a rolling session on the wire (kind:20033/20034)

### DIFF
--- a/.changeset/rolling-rfq-wire-intake.md
+++ b/.changeset/rolling-rfq-wire-intake.md
@@ -1,0 +1,8 @@
+---
+---
+
+The maker now accepts a rolling-swap session **from the wire**: an inbound kind:20033 RFQ (NIP-59 gift wrap, rolling-swap spec §2.2) registers the session and is answered with a gift-wrapped kind:20034 quote carrying `R₀`, `rateTimestamp`, quote expiry, `spread`, `maxRateAge`, `minAmount`/`maxAmount` and the leg-B `swapSignerAddress`.
+
+Previously the rolling protocol shipped in the released image but was unreachable: the only way to put a session in the `RollingSessionStore` was the in-process `SwapNodeInstance.registerRollingSession`, which `cli.ts` — what the container runs — never calls. Every rolling fill reaching a deployed maker therefore rejected F06 `unknown_session`, and every real swap fell through to the legacy SDK gift-wrap handler.
+
+Intake sits in `startSwapNode`'s existing `setPacketHandler` callback, ahead of the legacy branch, and is identified purely by the inner rumor kind — anything it cannot positively identify as an RFQ (including any unwrap failure) falls through to the legacy path byte-for-byte unchanged. Knobs are `rolling.rfq.{enabled,quoteTtlMs,spreadBps}`, all optional and defaulted (intake defaults ON); the CLI now also forwards the whole optional `rolling` config block. No new required config key. No announce change: per spec §10.3 step 2, rolling capability is discovered by probing the RFQ, not by an advertised flag.

--- a/packages/swap/src/cli.ts
+++ b/packages/swap/src/cli.ts
@@ -106,6 +106,13 @@ interface CliRawConfig {
    * (rolling-swap §8). Same keying as `inventory`.
    */
   windowBudget?: Record<string, string | number>;
+  /**
+   * Rolling-path knobs, forwarded verbatim to `startSwapNode()` (which owns
+   * every default). Entirely optional — a config file that omits it gets the
+   * shipped defaults, including RFQ intake ON. File-only, no env overlay,
+   * matching `peerInfoIlpDestination`/`btpEndpoint`.
+   */
+  rolling?: SwapNodeConfig['rolling'];
   relayUrls?: string[];
   blsPort?: number;
   btpServerPort?: number;
@@ -221,6 +228,7 @@ function parseRawConfig(raw: CliRawConfig): SwapNodeConfig {
     relayUrls: raw.relayUrls ?? [],
   };
   if (windowBudget) cfg.windowBudget = windowBudget;
+  if (raw.rolling) cfg.rolling = raw.rolling;
   if (raw.mnemonic) cfg.mnemonic = raw.mnemonic;
   if (raw.secretKey) {
     // Strict 64-char hex validation — `Buffer.from(str, 'hex')` silently

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -153,6 +153,26 @@ export type {
   ConnectorLegBSenderOptions,
 } from './rolling-engine.js';
 
+// Rolling RFQ intake — the kind:20033/20034 session transport (spec §2.2)
+export {
+  createRollingRfqIntake,
+  parseRollingRfqRequest,
+  findRfqPair,
+  ROLLING_RFQ_REQUEST_KIND,
+  ROLLING_RFQ_RESPONSE_KIND,
+  ROLLING_RFQ_REJECT_REASONS,
+  DEFAULT_RFQ_QUOTE_TTL_MS,
+} from './rolling-rfq.js';
+export type {
+  RollingRfqRequest,
+  RollingRfqResponse,
+  RollingRfqAsset,
+  RollingRfqConfig,
+  RollingRfqIntakeConfig,
+  RollingRfqOutcome,
+  RfqQuote,
+} from './rolling-rfq.js';
+
 // HTTP rate provider — CLI `rateProvider` wiring (issue #47 AC-3)
 export {
   createHttpRateProvider,

--- a/packages/swap/src/rolling-rfq.ts
+++ b/packages/swap/src/rolling-rfq.ts
@@ -1,0 +1,485 @@
+/**
+ * Rolling-swap RFQ intake (rolling-swap spec §2.2, §10.3 step 2).
+ *
+ * ## Why this module exists
+ *
+ * Before it, the rolling protocol shipped in the released maker image but was
+ * **unreachable on the wire**. `RollingSwapEngine.handleFill` rejects any fill
+ * whose `streamNonce` is not in the {@link RollingSessionStore} (F06
+ * `unknown_session`, `rolling-engine.ts`), and the only way to put a session in
+ * that store was `SwapNodeInstance.registerRollingSession` — an in-process
+ * method that `cli.ts` (what the container actually runs) never calls. So the
+ * deployed maker could never have a session, and every real swap fell through
+ * to the legacy SDK gift-wrap handler.
+ *
+ * This module is the missing transport: the **RFQ round trip** that mints a
+ * session from an inbound packet.
+ *
+ * ## The wire contract
+ *
+ * Per spec §2.2 the RFQ request is a *paid ILP write carrying a NIP-59 gift
+ * wrap*: `rumor kind:20033 → seal → kind:1059`, addressed to the maker's
+ * kind:10032 pubkey. It therefore arrives on the **same** local-delivery packet
+ * seam as a legacy swap request — zero/absent `executionCondition`, TOON-encoded
+ * gift wrap in `data` — and is distinguished only by its INNER rumor kind. The
+ * response (`rumor kind:20034`) is gift-wrapped back to the sender pubkey
+ * recovered from the request's seal layer and returned synchronously as the
+ * PREPARE's FULFILL `data` (base64 JSON of the kind:1059 wrap).
+ *
+ * The hot path is unaffected: fills stay plain, unwrapped ILP packets under the
+ * shared condition (spec §2.2, "This keeps the hot path off Nostr").
+ *
+ * ## Capability discovery
+ *
+ * There is deliberately **no `rollingCapable` announce flag**. Spec §10.3 step 2
+ * defines discovery as probe-by-RFQ: "A maker without it is legacy; `toon_swap`
+ * keeps the legacy path until the RFQ succeeds." A maker that does not implement
+ * this module answers a kind:20033 with a legacy-handler reject, which is
+ * exactly the negative signal the sender needs. Advertising a flag would add a
+ * second, unspecified source of truth that no client reads.
+ */
+
+import type { SwapPair } from '@toon-protocol/core';
+import type { NostrEvent, UnsignedEvent } from 'nostr-tools';
+import { unwrapSwapPacketFromToon, wrapSwapPacket } from '@toon-protocol/sdk';
+
+import {
+  ROLLING_PROTOCOL,
+  buildRollingReject,
+  type RollingSession,
+} from './rolling-engine.js';
+
+/** Inner rumor kind of an RFQ request (spec §2.2). */
+export const ROLLING_RFQ_REQUEST_KIND = 20033;
+/** Inner rumor kind of an RFQ response (spec §2.2). */
+export const ROLLING_RFQ_RESPONSE_KIND = 20034;
+
+/** `streamNonce` — 16 bytes, lowercase hex (spec §2.1). */
+const STREAM_NONCE_REGEX = /^[0-9a-f]{32}$/;
+
+/** Default lifetime of a quote/session minted by an RFQ, when unconfigured. */
+export const DEFAULT_RFQ_QUOTE_TTL_MS = 60_000;
+
+/** `data.reason` discriminators emitted by RFQ rejects. */
+export const ROLLING_RFQ_REJECT_REASONS = {
+  /** Rumor is kind:20033 but its content violates the request shape. */
+  MALFORMED_RFQ: 'malformed_rfq',
+  /** The requested pair is not one this maker advertises. */
+  UNSUPPORTED_PAIR: 'unsupported_pair',
+  /** No rate available for the pair (feed down / stale beyond the bound). */
+  RATE_UNAVAILABLE: 'rate_unavailable',
+  /** Session store full, or the nonce collided with a live session. */
+  SESSION_REJECTED: 'session_rejected',
+} as const;
+
+/**
+ * Leg-0 RFQ request: the `content` of the kind:20033 rumor, UTF-8 JSON.
+ *
+ * Field list is spec §2.2's RFQ-request row ("pair, size hint,
+ * `chainRecipient`, `streamNonce`, sender chain-B pubkeys"); `senderIlpAddress`
+ * is the concrete form of "sender chain-B pubkeys" this implementation needs,
+ * because it is the ILP destination every leg-B PREPARE of the session is sent
+ * to ({@link RollingSession.senderIlpAddress}).
+ */
+export interface RollingRfqRequest {
+  proto: typeof ROLLING_PROTOCOL;
+  type: 'rfq';
+  /** Session id the sender mints (spec §2.1) — 16 bytes, lowercase hex. */
+  streamNonce: string;
+  /** The pair every fill in the session is priced against. */
+  pair: { from: RollingRfqAsset; to: RollingRfqAsset };
+  /** Sender's payout address on `pair.to.chain` — the leg-B claim recipient. */
+  chainRecipient: string;
+  /** ILP address the maker sends this session's leg-B PREPAREs to. */
+  senderIlpAddress: string;
+  /** Optional total notional hint, source-asset micro-units (decimal string). */
+  sizeHint?: string;
+}
+
+export interface RollingRfqAsset {
+  assetCode: string;
+  assetScale: number;
+  chain: string;
+}
+
+/**
+ * Leg-0 RFQ response: the `content` of the kind:20034 rumor, UTF-8 JSON.
+ * Field list is spec §2.2's RFQ-response row (quote `R₀`, `spread`,
+ * `maxRateAge`, `minAmount`/`maxAmount`, quote expiry).
+ */
+export interface RollingRfqResponse {
+  proto: typeof ROLLING_PROTOCOL;
+  type: 'quote';
+  streamNonce: string;
+  /** `R₀` — target units per source unit, decimal string. */
+  rate: string;
+  /** Unix-ms tick time of the rate source for `rate`. */
+  rateTimestamp: number;
+  /** Unix-ms after which the quote — and the session — expire. */
+  expiresAt: number;
+  /** Maker's advertised two-sided spread, basis points. Omitted if unknown. */
+  spreadBps?: number;
+  /** Maker's own freshness bound on its rate source, ms (spec §4). */
+  maxRateAge?: number;
+  /** Per-packet bounds, source-asset micro-units (decimal strings). */
+  minAmount?: string;
+  maxAmount?: string;
+  /**
+   * The maker's on-chain signer for `pair.to.chain`. Lets the sender arm its
+   * R5 leg-B verification before the first fill instead of trusting the
+   * `swapSignerAddress` echoed on the first advance.
+   */
+  swapSignerAddress?: string;
+}
+
+function isPositiveIntString(v: unknown): v is string {
+  return typeof v === 'string' && /^[0-9]+$/.test(v) && v.length > 0;
+}
+
+function parseAsset(v: unknown): RollingRfqAsset | null {
+  if (typeof v !== 'object' || v === null) return null;
+  const rec = v as Record<string, unknown>;
+  const assetCode = rec['assetCode'];
+  const assetScale = rec['assetScale'];
+  const chain = rec['chain'];
+  if (typeof assetCode !== 'string' || assetCode.length === 0) return null;
+  if (
+    typeof assetScale !== 'number' ||
+    !Number.isSafeInteger(assetScale) ||
+    assetScale < 0
+  ) {
+    return null;
+  }
+  if (typeof chain !== 'string' || chain.length === 0) return null;
+  return { assetCode, assetScale, chain };
+}
+
+/**
+ * Parse the `content` of a kind:20033 rumor as an RFQ request.
+ *
+ * Returns `'malformed'` when the payload self-identifies as `rolling/1` (or is
+ * simply unparseable) but violates the shape — the caller rejects rather than
+ * letting a kind:20033 fall through to the legacy handler, which would answer
+ * with a misleading legacy error. Returns `null` only when the content is not
+ * rolling traffic at all.
+ */
+export function parseRollingRfqRequest(
+  content: string
+): RollingRfqRequest | 'malformed' | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return 'malformed';
+  }
+  if (typeof parsed !== 'object' || parsed === null) return 'malformed';
+  const rec = parsed as Record<string, unknown>;
+  if (rec['proto'] !== ROLLING_PROTOCOL) return null;
+  if (rec['type'] !== 'rfq') return 'malformed';
+
+  const streamNonce = rec['streamNonce'];
+  if (
+    typeof streamNonce !== 'string' ||
+    !STREAM_NONCE_REGEX.test(streamNonce)
+  ) {
+    return 'malformed';
+  }
+  const pairRaw = rec['pair'];
+  if (typeof pairRaw !== 'object' || pairRaw === null) return 'malformed';
+  const from = parseAsset((pairRaw as Record<string, unknown>)['from']);
+  const to = parseAsset((pairRaw as Record<string, unknown>)['to']);
+  if (!from || !to) return 'malformed';
+
+  const chainRecipient = rec['chainRecipient'];
+  if (typeof chainRecipient !== 'string' || chainRecipient.length === 0) {
+    return 'malformed';
+  }
+  const senderIlpAddress = rec['senderIlpAddress'];
+  if (typeof senderIlpAddress !== 'string' || senderIlpAddress.length === 0) {
+    return 'malformed';
+  }
+  const sizeHint = rec['sizeHint'];
+  if (sizeHint !== undefined && !isPositiveIntString(sizeHint)) {
+    return 'malformed';
+  }
+
+  return {
+    proto: ROLLING_PROTOCOL,
+    type: 'rfq',
+    streamNonce,
+    pair: { from, to },
+    chainRecipient,
+    senderIlpAddress,
+    ...(sizeHint !== undefined ? { sizeHint } : {}),
+  };
+}
+
+/** Match an RFQ's requested pair against the maker's advertised pairs. */
+export function findRfqPair(
+  pairs: readonly SwapPair[],
+  requested: RollingRfqRequest['pair']
+): SwapPair | undefined {
+  return pairs.find(
+    (p) =>
+      p.from.assetCode === requested.from.assetCode &&
+      p.from.assetScale === requested.from.assetScale &&
+      p.from.chain === requested.from.chain &&
+      p.to.assetCode === requested.to.assetCode &&
+      p.to.assetScale === requested.to.assetScale &&
+      p.to.chain === requested.to.chain
+  );
+}
+
+/** Optional, all-defaulted RFQ knobs (no new REQUIRED config key). */
+export interface RollingRfqConfig {
+  /**
+   * Master switch. Defaults to `true`: the path is only reachable by a packet
+   * whose inner rumor kind is 20033, which today has no other handler at all,
+   * so enabling it cannot regress any traffic that currently works.
+   */
+  enabled?: boolean;
+  /**
+   * How long the quoted `R₀` stays a valid basis for the sender's session
+   * floor (spec §5), default {@link DEFAULT_RFQ_QUOTE_TTL_MS} — the 60s of the
+   * spec's §11 worked example.
+   *
+   * This is deliberately NOT the session lifetime. Every fill is priced at a
+   * fresh `R_i` and guarded by `maxRateAge` (spec §4), so an old quote is a
+   * sender-side concern only; capping the session at the quote's expiry would
+   * kill any stream that outlives one quote. Session lifetime stays the
+   * `RollingSessionStore`'s TTL (`rolling.sessionTtlMs`, default 1h).
+   */
+  quoteTtlMs?: number;
+  /** Advertised two-sided spread in bps. Omitted from the quote when unset. */
+  spreadBps?: number;
+}
+
+/** A timestamped quote for one pair, as the intake needs it. */
+export interface RfqQuote {
+  rate: string;
+  rateTimestamp: number;
+}
+
+export interface RollingRfqIntakeConfig {
+  /** The maker's advertised pairs — the RFQ's pair must be one of them. */
+  swapPairs: readonly SwapPair[];
+  /** Quote source. Returning `null` fails the RFQ closed (rate_unavailable). */
+  quote: (pair: SwapPair) => Promise<RfqQuote | null> | RfqQuote | null;
+  /** Commits the session. Throwing → `session_rejected` (store full, etc.). */
+  registerSession: (session: RollingSession) => void;
+  /** Maker's Nostr secret key: unwraps the request, seals the response. */
+  secretKey: Uint8Array;
+  /** Per-chain on-chain signer addresses, keyed as `pair.to.chain`. */
+  signerAddresses?: Readonly<Record<string, string>>;
+  /** Maker's freshness bound per pair, ms — advertised in the quote (spec §4). */
+  maxRateAgeMs?: (pair: SwapPair) => number | undefined;
+  rfq?: RollingRfqConfig;
+  now?: () => number;
+  logger?: {
+    debug?: (msg: string, meta?: Record<string, unknown>) => void;
+    warn?: (msg: string, meta?: Record<string, unknown>) => void;
+  };
+}
+
+/** Accept/reject shape the packet handler returns, structurally. */
+export type RollingRfqOutcome =
+  | { accept: true; data: string; message?: string }
+  | {
+      accept: false;
+      code: string;
+      message: string;
+      data: string;
+      rejectReason: { code: string; message: string };
+    };
+
+/**
+ * Decide whether an inbound local-delivery packet is an RFQ request, and if so
+ * answer it.
+ *
+ * Returns `null` when the packet is NOT an RFQ — it could not be unwrapped, or
+ * its inner rumor is not kind:20033 — in which case the caller MUST fall
+ * through to its existing legacy path with behaviour byte-for-byte unchanged.
+ * Every failure mode inside this function is expressed as a returned reject or
+ * as `null`; it never throws.
+ */
+export function createRollingRfqIntake(config: RollingRfqIntakeConfig): {
+  /** `null` ⇒ not an RFQ, fall through to legacy. */
+  handle(dataB64: string): Promise<RollingRfqOutcome | null>;
+} {
+  const enabled = config.rfq?.enabled ?? true;
+  const quoteTtlMs = config.rfq?.quoteTtlMs ?? DEFAULT_RFQ_QUOTE_TTL_MS;
+  const spreadBps = config.rfq?.spreadBps;
+  const now = config.now ?? Date.now;
+  const logger = config.logger;
+
+  const reject = (
+    code: string,
+    semantic: string,
+    message: string,
+    reason: string
+  ): RollingRfqOutcome =>
+    buildRollingReject({
+      code,
+      semantic,
+      message,
+      reason,
+    }) as RollingRfqOutcome;
+
+  return {
+    async handle(dataB64: string): Promise<RollingRfqOutcome | null> {
+      if (!enabled) return null;
+      if (typeof dataB64 !== 'string' || dataB64.length === 0) return null;
+
+      // Unwrap to read the INNER rumor kind. The outer envelope of an RFQ and
+      // of a legacy swap request are both kind:1059, so the kind is only
+      // visible after NIP-59 decryption. ANY failure here means "not an RFQ we
+      // can read" → fall through, leaving the legacy path exactly as it was.
+      let rumor: UnsignedEvent;
+      let senderPubkey: string;
+      try {
+        const unwrapped = unwrapSwapPacketFromToon({
+          toonData: Buffer.from(dataB64, 'base64'),
+          recipientSecretKey: config.secretKey,
+        });
+        rumor = unwrapped.rumor;
+        senderPubkey = unwrapped.senderPubkey;
+      } catch {
+        return null;
+      }
+      if (rumor?.kind !== ROLLING_RFQ_REQUEST_KIND) return null;
+
+      const parsed = parseRollingRfqRequest(
+        typeof rumor.content === 'string' ? rumor.content : ''
+      );
+      if (parsed === null || parsed === 'malformed') {
+        // Kind:20033 is unambiguously rolling traffic. Falling through would
+        // hand it to the legacy handler, whose error would misdescribe the
+        // failure, so reject here with the actionable reason.
+        logger?.warn?.('swap.rfq.malformed', { senderPubkey });
+        return reject(
+          'F01',
+          'invalid_request',
+          'malformed rolling RFQ request',
+          ROLLING_RFQ_REJECT_REASONS.MALFORMED_RFQ
+        );
+      }
+
+      const pair = findRfqPair(config.swapPairs, parsed.pair);
+      if (!pair) {
+        logger?.debug?.('swap.rfq.unsupported_pair', {
+          streamNonce: parsed.streamNonce,
+        });
+        return reject(
+          'F06',
+          'unsupported_pair',
+          `pair ${parsed.pair.from.assetCode}:${parsed.pair.from.chain} → ` +
+            `${parsed.pair.to.assetCode}:${parsed.pair.to.chain} is not advertised`,
+          ROLLING_RFQ_REJECT_REASONS.UNSUPPORTED_PAIR
+        );
+      }
+
+      let quote: RfqQuote | null;
+      try {
+        quote = await config.quote(pair);
+      } catch {
+        quote = null;
+      }
+      if (!quote || typeof quote.rate !== 'string' || quote.rate.length === 0) {
+        logger?.warn?.('swap.rfq.rate_unavailable', {
+          streamNonce: parsed.streamNonce,
+        });
+        return reject(
+          'T99',
+          'rate_unavailable',
+          'no rate available for the requested pair',
+          ROLLING_RFQ_REJECT_REASONS.RATE_UNAVAILABLE
+        );
+      }
+
+      // Quote validity only. The session's own lifetime is left to the store's
+      // TTL (see `RollingRfqConfig.quoteTtlMs`) by omitting `expiresAt` below.
+      const quoteExpiresAt = now() + quoteTtlMs;
+
+      // Commit the session BEFORE answering: a sender that receives a quote
+      // must be able to send fill seq 1 immediately. Registering after the
+      // response would open a window where the very first fill F06s.
+      try {
+        config.registerSession({
+          streamNonce: parsed.streamNonce,
+          pair,
+          chainRecipient: parsed.chainRecipient,
+          senderIlpAddress: parsed.senderIlpAddress,
+          senderPubkey,
+        });
+      } catch (err) {
+        logger?.warn?.('swap.rfq.session_rejected', {
+          streamNonce: parsed.streamNonce,
+          err: err instanceof Error ? err.message : String(err),
+        });
+        return reject(
+          'T03',
+          'session_rejected',
+          'rolling session could not be registered',
+          ROLLING_RFQ_REJECT_REASONS.SESSION_REJECTED
+        );
+      }
+
+      const maxRateAge = config.maxRateAgeMs?.(pair);
+      const swapSignerAddress = config.signerAddresses?.[pair.to.chain];
+      const response: RollingRfqResponse = {
+        proto: ROLLING_PROTOCOL,
+        type: 'quote',
+        streamNonce: parsed.streamNonce,
+        rate: quote.rate,
+        rateTimestamp: quote.rateTimestamp,
+        expiresAt: quoteExpiresAt,
+        ...(spreadBps !== undefined ? { spreadBps } : {}),
+        ...(maxRateAge !== undefined ? { maxRateAge } : {}),
+        ...(pair.minAmount !== undefined ? { minAmount: pair.minAmount } : {}),
+        ...(pair.maxAmount !== undefined ? { maxAmount: pair.maxAmount } : {}),
+        ...(swapSignerAddress !== undefined ? { swapSignerAddress } : {}),
+      };
+
+      // Gift-wrap the quote back to the RFQ's reply key (spec §2.2). The quote
+      // and the session's `chainRecipient` are not broadcast in plaintext.
+      let giftWrap: NostrEvent;
+      try {
+        giftWrap = wrapSwapPacket({
+          rumor: {
+            kind: ROLLING_RFQ_RESPONSE_KIND,
+            content: JSON.stringify(response),
+            tags: [],
+            created_at: Math.floor(now() / 1000),
+            pubkey: '',
+          } as unknown as UnsignedEvent,
+          senderSecretKey: config.secretKey,
+          recipientPubkey: senderPubkey,
+        }).giftWrap;
+      } catch (err) {
+        // The session is already registered and its TTL will reap it; the
+        // sender simply never gets a usable quote.
+        logger?.warn?.('swap.rfq.wrap_failed', {
+          streamNonce: parsed.streamNonce,
+          err: err instanceof Error ? err.message : String(err),
+        });
+        return reject(
+          'T00',
+          'application_error',
+          'failed to seal the RFQ response',
+          ROLLING_RFQ_REJECT_REASONS.SESSION_REJECTED
+        );
+      }
+
+      logger?.debug?.('swap.rfq.session_registered', {
+        streamNonce: parsed.streamNonce,
+        pair: `${pair.from.assetCode}:${pair.from.chain}→${pair.to.assetCode}:${pair.to.chain}`,
+        quoteExpiresAt,
+      });
+
+      return {
+        accept: true,
+        data: Buffer.from(JSON.stringify(giftWrap), 'utf8').toString('base64'),
+      };
+    },
+  };
+}

--- a/packages/swap/src/swap-node.rolling-rfq.test.ts
+++ b/packages/swap/src/swap-node.rolling-rfq.test.ts
@@ -1,0 +1,539 @@
+/**
+ * Rolling RFQ intake — WIRE-LEVEL reachability tests.
+ *
+ * These deliberately exercise the same seam as `swap-node.rolling-dispatch.test.ts`:
+ * boot a real `startSwapNode()` against a fake connector, capture the
+ * `setPacketHandler` callback, and drive it with real packets. Nothing here
+ * calls `registerRollingSession` — that is the whole point. A unit test of
+ * `registerRollingSession` proves nothing about reachability, because the
+ * defect was that no wire path ever reached it.
+ *
+ * The headline test is `rfq → fill`: a gift-wrapped kind:20033 followed by a
+ * rolling fill for the SAME `streamNonce`, asserting the fill is not
+ * F06 `unknown_session`. That sequence is exactly what a stock client does and
+ * exactly what failed before this module existed.
+ */
+import { describe, it, expect } from 'vitest';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { schnorr } from '@noble/curves/secp256k1.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
+import { wrapSwapPacketToToon, unwrapSwapPacket } from '@toon-protocol/sdk';
+import type { UnsignedEvent } from 'nostr-tools';
+
+import { startSwapNode } from './swap-node.js';
+import type { SwapNodeConfig, SwapNodeInstance } from './swap-node.js';
+import { ROLLING_PROTOCOL, ROLLING_REJECT_REASONS } from './rolling-engine.js';
+import type { LegBPrepare, LegBResult } from './rolling-engine.js';
+import {
+  ROLLING_RFQ_REQUEST_KIND,
+  ROLLING_RFQ_RESPONSE_KIND,
+  ROLLING_RFQ_REJECT_REASONS,
+  type RollingRfqRequest,
+  type RollingRfqResponse,
+} from './rolling-rfq.js';
+
+const VALID_MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+const CHAIN = 'evm:8453';
+const STREAM_NONCE = '1f'.repeat(16);
+const CHAIN_RECIPIENT = '0x' + '11'.repeat(20);
+const SENDER_ILP = 'g.toon.client.sender01';
+
+type PacketHandlerFn = (request: {
+  amount: string;
+  destination: string;
+  data: string;
+  executionCondition?: string;
+  expiresAt?: string;
+}) => Promise<{
+  accept: boolean;
+  code?: string;
+  message?: string;
+  data?: string;
+  fulfillment?: string;
+  rejectReason?: { code: string; message: string };
+}>;
+
+function capturingConnector(): {
+  connector: SwapNodeConfig['connector'];
+  handler: () => PacketHandlerFn;
+} {
+  let captured: PacketHandlerFn | undefined;
+  const connector = {
+    sendPacket: async () => ({
+      type: 'reject' as const,
+      code: 'F02',
+      message: 'no route (fixture)',
+    }),
+    registerPeer: async () => undefined,
+    removePeer: async () => undefined,
+    setPacketHandler: (h: unknown) => {
+      captured = h as PacketHandlerFn;
+    },
+    close: async () => undefined,
+  };
+  return {
+    connector: connector as unknown as SwapNodeConfig['connector'],
+    handler: () => {
+      if (!captured) throw new Error('setPacketHandler was never called');
+      return captured;
+    },
+  };
+}
+
+async function bootNode(overrides?: Partial<SwapNodeConfig>): Promise<{
+  instance: SwapNodeInstance;
+  handler: () => PacketHandlerFn;
+}> {
+  const { connector, handler } = capturingConnector();
+  const instance = await startSwapNode({
+    mnemonic: VALID_MNEMONIC,
+    connector,
+    swapPairs: [
+      {
+        from: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+        to: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+        rate: '1.0',
+        minAmount: '1000',
+        maxAmount: '25000000',
+      },
+    ],
+    chains: ['evm'],
+    channels: {
+      [CHAIN]: [
+        {
+          channelId: '0x' + 'cd'.repeat(32),
+          cumulativeAmount: 0n,
+          nonce: 0n,
+          updatedAt: 0,
+        },
+      ],
+    },
+    inventory: { [CHAIN]: 1_000_000_000n },
+    chainProviders: [
+      {
+        chainType: 'evm',
+        chainId: CHAIN,
+        rpcUrl: 'http://127.0.0.1:1',
+        registryAddress: '0x' + '11'.repeat(20),
+        tokenAddress: '0x' + '22'.repeat(20),
+        tokenNetworkAddress: '0x' + '44'.repeat(20),
+        channelAddress: '0x' + '33'.repeat(20),
+      },
+    ],
+    relayUrls: ['ws://localhost:0'],
+    blsPort: 0,
+    publisher: { publish: async () => undefined },
+    ...overrides,
+  });
+  return { instance, handler };
+}
+
+/** A throwaway sender identity — the client side of the RFQ. */
+function senderKeys(): { secretKey: Uint8Array; pubkey: string } {
+  const secretKey = schnorr.utils.randomSecretKey();
+  return { secretKey, pubkey: bytesToHex(schnorr.getPublicKey(secretKey)) };
+}
+
+/**
+ * Build the base64 PREPARE `data` of a real NIP-59 gift wrap carrying an
+ * arbitrary inner rumor — the exact envelope spec §2.2 puts an RFQ in.
+ */
+function giftWrappedDataB64(params: {
+  kind: number;
+  content: string;
+  senderSecretKey: Uint8Array;
+  makerPubkey: string;
+}): string {
+  const rumor = {
+    kind: params.kind,
+    content: params.content,
+    tags: [],
+    created_at: Math.floor(Date.now() / 1000),
+    pubkey: '',
+  } as unknown as UnsignedEvent;
+  const { ilpPrepare } = wrapSwapPacketToToon({
+    rumor,
+    senderSecretKey: params.senderSecretKey,
+    recipientPubkey: params.makerPubkey,
+    destination: 'g.toon.swap.x',
+    amount: 1000n,
+  });
+  // `wrapSwapPacketToToon` already base64s the TOON bytes into `data` — the
+  // exact string the connector hands the packet handler.
+  return ilpPrepare.data;
+}
+
+function rfqRequest(overrides?: Partial<RollingRfqRequest>): string {
+  return JSON.stringify({
+    proto: ROLLING_PROTOCOL,
+    type: 'rfq',
+    streamNonce: STREAM_NONCE,
+    pair: {
+      from: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+      to: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+    },
+    chainRecipient: CHAIN_RECIPIENT,
+    senderIlpAddress: SENDER_ILP,
+    ...overrides,
+  });
+}
+
+/** Unwrap the kind:20034 quote out of an accepted RFQ's FULFILL `data`. */
+function decodeQuote(
+  dataB64: string | undefined,
+  senderSecretKey: Uint8Array
+): { kind: number; quote: RollingRfqResponse } {
+  if (!dataB64) throw new Error('RFQ accept carried no data');
+  const giftWrap = JSON.parse(Buffer.from(dataB64, 'base64').toString('utf8'));
+  const { rumor } = unwrapSwapPacket({
+    giftWrap,
+    recipientSecretKey: senderSecretKey,
+  });
+  return {
+    kind: rumor.kind,
+    quote: JSON.parse(rumor.content) as RollingRfqResponse,
+  };
+}
+
+function fillDataB64(seq = 1, streamNonce = STREAM_NONCE): string {
+  return Buffer.from(
+    JSON.stringify({ proto: ROLLING_PROTOCOL, type: 'fill', streamNonce, seq }),
+    'utf8'
+  ).toString('base64');
+}
+
+function mint(): { preimage: Uint8Array; conditionB64: string } {
+  const preimage = new Uint8Array(32);
+  globalThis.crypto.getRandomValues(preimage);
+  return {
+    preimage,
+    conditionB64: Buffer.from(sha256(preimage)).toString('base64'),
+  };
+}
+
+function decodeReason(dataB64?: string): unknown {
+  return dataB64
+    ? (
+        JSON.parse(Buffer.from(dataB64, 'base64').toString('utf8')) as Record<
+          string,
+          unknown
+        >
+      )['reason']
+    : undefined;
+}
+
+describe('rolling RFQ intake — wire reachability', () => {
+  it('a gift-wrapped kind:20033 on the packet handler is answered with a kind:20034 quote', async () => {
+    const sender = senderKeys();
+    const { instance, handler } = await bootNode();
+    try {
+      const res = await handler()({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: giftWrappedDataB64({
+          kind: ROLLING_RFQ_REQUEST_KIND,
+          content: rfqRequest(),
+          senderSecretKey: sender.secretKey,
+          makerPubkey: instance.identity.pubkey,
+        }),
+      });
+
+      expect(res.accept).toBe(true);
+      const { kind, quote } = decodeQuote(res.data, sender.secretKey);
+      expect(kind).toBe(ROLLING_RFQ_RESPONSE_KIND);
+      expect(quote.proto).toBe(ROLLING_PROTOCOL);
+      expect(quote.type).toBe('quote');
+      expect(quote.streamNonce).toBe(STREAM_NONCE);
+      expect(quote.rate).toBe('1.0');
+      expect(quote.minAmount).toBe('1000');
+      expect(quote.maxAmount).toBe('25000000');
+      expect(quote.expiresAt).toBeGreaterThan(Date.now());
+      // The maker's leg-B signer, so the sender can arm R5 verification.
+      expect(quote.swapSignerAddress).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('REACHABILITY: rfq then fill — the session comes from the wire, never registerRollingSession', async () => {
+    const sender = senderKeys();
+    const { preimage, conditionB64 } = mint();
+    const legBCalls: LegBPrepare[] = [];
+
+    const { instance, handler } = await bootNode({
+      rollingLegBSender: async (prepare): Promise<LegBResult> => {
+        legBCalls.push(prepare);
+        // Compliant sender daemon: reveal the preimage for this condition.
+        return { type: 'fulfill', fulfillment: preimage };
+      },
+    });
+    try {
+      // Step 1 — RFQ over the wire. No in-process registration anywhere.
+      const rfqRes = await handler()({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: giftWrappedDataB64({
+          kind: ROLLING_RFQ_REQUEST_KIND,
+          content: rfqRequest(),
+          senderSecretKey: sender.secretKey,
+          makerPubkey: instance.identity.pubkey,
+        }),
+      });
+      expect(rfqRes.accept).toBe(true);
+
+      // Step 2 — a fill for the session the RFQ just minted.
+      const fillRes = await handler()({
+        amount: '250000',
+        destination: 'g.toon.swap.x',
+        data: fillDataB64(1),
+        executionCondition: conditionB64,
+        expiresAt: new Date(Date.now() + 30_000).toISOString(),
+      });
+
+      // The defect this fixes: without wire intake this is F06 unknown_session.
+      expect(decodeReason(fillRes.data)).not.toBe(
+        ROLLING_REJECT_REASONS.UNKNOWN_SESSION
+      );
+      expect(fillRes.accept).toBe(true);
+      // The session's routing data came off the RFQ, not a test fixture.
+      expect(legBCalls).toHaveLength(1);
+      expect(legBCalls[0]?.destination).toBe(SENDER_ILP);
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('without the RFQ, the same fill is still F06 unknown_session (the pre-fix behaviour)', async () => {
+    const { conditionB64 } = mint();
+    const { instance, handler } = await bootNode();
+    try {
+      const res = await handler()({
+        amount: '250000',
+        destination: 'g.toon.swap.x',
+        data: fillDataB64(1),
+        executionCondition: conditionB64,
+        expiresAt: new Date(Date.now() + 30_000).toISOString(),
+      });
+      expect(res.accept).toBe(false);
+      expect(res.code).toBe('F06');
+      expect(decodeReason(res.data)).toBe(
+        ROLLING_REJECT_REASONS.UNKNOWN_SESSION
+      );
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('an unadvertised pair is refused and mints no session', async () => {
+    const sender = senderKeys();
+    const { conditionB64 } = mint();
+    const { instance, handler } = await bootNode();
+    try {
+      const res = await handler()({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: giftWrappedDataB64({
+          kind: ROLLING_RFQ_REQUEST_KIND,
+          content: rfqRequest({
+            pair: {
+              from: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+              to: { assetCode: 'MINA', assetScale: 9, chain: 'mina:devnet' },
+            },
+          }),
+          senderSecretKey: sender.secretKey,
+          makerPubkey: instance.identity.pubkey,
+        }),
+      });
+      expect(res.accept).toBe(false);
+      expect(res.code).toBe('F06');
+      expect(decodeReason(res.data)).toBe(
+        ROLLING_RFQ_REJECT_REASONS.UNSUPPORTED_PAIR
+      );
+
+      // and no session was minted for that nonce
+      const fill = await handler()({
+        amount: '250000',
+        destination: 'g.toon.swap.x',
+        data: fillDataB64(1),
+        executionCondition: conditionB64,
+        expiresAt: new Date(Date.now() + 30_000).toISOString(),
+      });
+      expect(decodeReason(fill.data)).toBe(
+        ROLLING_REJECT_REASONS.UNKNOWN_SESSION
+      );
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('a kind:20033 with a malformed body is rejected F01, not handed to the legacy handler', async () => {
+    const sender = senderKeys();
+    const { instance, handler } = await bootNode();
+    try {
+      const res = await handler()({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: giftWrappedDataB64({
+          kind: ROLLING_RFQ_REQUEST_KIND,
+          // valid proto tag, but streamNonce is not 32 lowercase hex
+          content: rfqRequest({ streamNonce: 'nope' }),
+          senderSecretKey: sender.secretKey,
+          makerPubkey: instance.identity.pubkey,
+        }),
+      });
+      expect(res.accept).toBe(false);
+      expect(res.code).toBe('F01');
+      expect(decodeReason(res.data)).toBe(
+        ROLLING_RFQ_REJECT_REASONS.MALFORMED_RFQ
+      );
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('a short quote TTL does NOT cap the session — every fill is repriced anyway', async () => {
+    const sender = senderKeys();
+    const { preimage, conditionB64 } = mint();
+    const { instance, handler } = await bootNode({
+      rolling: { rfq: { quoteTtlMs: 1 } },
+      rollingLegBSender: async (): Promise<LegBResult> => ({
+        type: 'fulfill',
+        fulfillment: preimage,
+      }),
+    });
+    try {
+      const rfqRes = await handler()({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: giftWrappedDataB64({
+          kind: ROLLING_RFQ_REQUEST_KIND,
+          content: rfqRequest(),
+          senderSecretKey: sender.secretKey,
+          makerPubkey: instance.identity.pubkey,
+        }),
+      });
+      expect(rfqRes.accept).toBe(true);
+      const { quote } = decodeQuote(rfqRes.data, sender.secretKey);
+      expect(quote.expiresAt).toBeLessThanOrEqual(Date.now() + 1);
+
+      // Quote is stale, session is not: the stream keeps working.
+      await new Promise((r) => setTimeout(r, 5));
+      const fill = await handler()({
+        amount: '250000',
+        destination: 'g.toon.swap.x',
+        data: fillDataB64(1),
+        executionCondition: conditionB64,
+        expiresAt: new Date(Date.now() + 30_000).toISOString(),
+      });
+      expect(fill.accept).toBe(true);
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('the session honours rolling.sessionTtlMs — a fill after it F06s again', async () => {
+    const sender = senderKeys();
+    const { conditionB64 } = mint();
+    const { instance, handler } = await bootNode({
+      rolling: { sessionTtlMs: 1 },
+    });
+    try {
+      const rfqRes = await handler()({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: giftWrappedDataB64({
+          kind: ROLLING_RFQ_REQUEST_KIND,
+          content: rfqRequest(),
+          senderSecretKey: sender.secretKey,
+          makerPubkey: instance.identity.pubkey,
+        }),
+      });
+      expect(rfqRes.accept).toBe(true);
+
+      await new Promise((r) => setTimeout(r, 5));
+      const fill = await handler()({
+        amount: '250000',
+        destination: 'g.toon.swap.x',
+        data: fillDataB64(1),
+        executionCondition: conditionB64,
+        expiresAt: new Date(Date.now() + 30_000).toISOString(),
+      });
+      expect(decodeReason(fill.data)).toBe(
+        ROLLING_REJECT_REASONS.UNKNOWN_SESSION
+      );
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('rolling.rfq.enabled=false leaves the RFQ to the legacy handler (opt-out is real)', async () => {
+    const sender = senderKeys();
+    const { instance, handler } = await bootNode({
+      rolling: { rfq: { enabled: false } },
+    });
+    try {
+      const res = await handler()({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: giftWrappedDataB64({
+          kind: ROLLING_RFQ_REQUEST_KIND,
+          content: rfqRequest(),
+          senderSecretKey: sender.secretKey,
+          makerPubkey: instance.identity.pubkey,
+        }),
+      });
+      // Falls through to the legacy swap handler, which does not know kind:20033.
+      expect(res.accept).toBe(false);
+      expect(res.code).not.toBe('F01');
+      expect(decodeReason(res.data)).not.toBe(
+        ROLLING_RFQ_REJECT_REASONS.MALFORMED_RFQ
+      );
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('a gift wrap whose inner kind is NOT 20033 still takes the legacy path unchanged', async () => {
+    const sender = senderKeys();
+    const { instance, handler } = await bootNode();
+    try {
+      const res = await handler()({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: giftWrappedDataB64({
+          kind: 20032, // the legacy swap-request rumor kind
+          content: '{}',
+          senderSecretKey: sender.secretKey,
+          makerPubkey: instance.identity.pubkey,
+        }),
+      });
+      // Whatever the legacy handler says, it must not be an RFQ verdict.
+      expect(decodeReason(res.data)).not.toBe(
+        ROLLING_RFQ_REJECT_REASONS.MALFORMED_RFQ
+      );
+      expect(decodeReason(res.data)).not.toBe(
+        ROLLING_RFQ_REJECT_REASONS.UNSUPPORTED_PAIR
+      );
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('an unparseable (non-gift-wrap) payload is untouched — legacy F06 Invalid TOON payload', async () => {
+    const { instance, handler } = await bootNode();
+    try {
+      const res = await handler()({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: Buffer.from('junk', 'utf8').toString('base64'),
+      });
+      expect(res.accept).toBe(false);
+      expect(res.code).toBe('F06');
+      expect(res.message).toBe('Invalid TOON payload');
+    } finally {
+      await instance.stop();
+    }
+  });
+});

--- a/packages/swap/src/swap-node.ts
+++ b/packages/swap/src/swap-node.ts
@@ -94,6 +94,8 @@ import {
   parseRollingFillPayload,
 } from './rolling-engine.js';
 import type { LegBSender, RollingSession } from './rolling-engine.js';
+import { createRollingRfqIntake } from './rolling-rfq.js';
+import type { RollingRfqConfig } from './rolling-rfq.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -373,6 +375,13 @@ export interface SwapNodeConfig {
      * slot right after they could no longer fulfill). Default 5s.
      */
     reservationGraceMs?: number;
+    /**
+     * RFQ intake knobs (spec §2.2). Entirely optional and defaulted — the
+     * intake is ON by default because the path it adds is only reachable by a
+     * packet whose inner rumor kind is 20033, a kind that has no other handler
+     * at all, so it cannot regress traffic that works today.
+     */
+    rfq?: RollingRfqConfig;
   };
   /**
    * Leg-B egress override (tests / custom connectors). When omitted, the
@@ -1733,6 +1742,37 @@ export async function startSwapNode(
     }),
   });
 
+  // 10c. Rolling RFQ intake (spec §2.2) — the transport that mints a session.
+  //
+  // Without it `rollingSessions` can only ever be populated by the in-process
+  // `registerRollingSession`, which `cli.ts` (what the container runs) never
+  // calls — so every rolling fill reaching a deployed maker F06s
+  // `unknown_session` and the rolling protocol is unreachable on the wire.
+  //
+  // Quote source mirrors the engine's: the timestamped `rateProvider` when the
+  // operator configured one, else the pair's static advertised rate.
+  const rfqIntake = createRollingRfqIntake({
+    swapPairs: config.swapPairs,
+    secretKey: identity.secretKey,
+    signerAddresses,
+    registerSession: (session) => rollingEngine.registerSession(session),
+    ...(stalenessGuard && {
+      maxRateAgeMs: (pair: SwapPair) =>
+        stalenessGuard.resolveMaxRateAgeMs(pair),
+    }),
+    quote: async (pair: SwapPair) => {
+      if (config.rateProvider) {
+        const quoted = await config.rateProvider(pair);
+        return typeof quoted === 'string'
+          ? { rate: quoted, rateTimestamp: Date.now() }
+          : { rate: quoted.rate, rateTimestamp: quoted.at };
+      }
+      return { rate: pair.rate, rateTimestamp: Date.now() };
+    },
+    ...(config.rolling?.rfq && { rfq: config.rolling.rfq }),
+    logger: { debug: logger.debug, warn: logger.warn },
+  });
+
   // 11a. Wire the HandlerRegistry to the connector's local-delivery path.
   //
   // Story 50.3 (SOL settlement leg, AC#4): inbound kind:1059 (NIP-59 gift-wrap)
@@ -1843,6 +1883,15 @@ export async function startSwapNode(
         reason: ROLLING_REJECT_REASONS.CONDITION_REQUIRED,
       }) as HandlePacketResponse;
     }
+
+    // Rolling RFQ (spec §2.2) — a zero-condition kind:1059 gift wrap, exactly
+    // like a legacy swap request, distinguished ONLY by its inner rumor kind
+    // (20033). It therefore has to be sniffed here, before the legacy branch,
+    // by unwrapping and reading that kind. `handle()` returns null for
+    // everything it cannot positively identify as an RFQ (including any unwrap
+    // failure), so the legacy path below stays byte-for-byte as it was.
+    const rfq = await rfqIntake.handle(request.data);
+    if (rfq) return rfq as HandlePacketResponse;
 
     // Legacy path (zero-condition gift-wrap) — unchanged below.
     let meta;


### PR DESCRIPTION
## The defect

The rolling swap protocol ships in the released maker image and is **unreachable on the wire**. Verified before building:

- `registerRollingSession` (`packages/swap/src/swap-node.ts:2255`) is the only way to put a session into the `RollingSessionStore`, and its **only callers repo-wide are tests** — `swap-node.rolling-dispatch.test.ts:273`, `swap-node.peer-info.test.ts:336`, and the two rolling integration tests. `cli.ts`, which is what the container runs, never calls it.
- `20033`/`20034` appeared **only in docblock prose** (`rolling-engine.ts:69`, `swap-node.ts:546`). Nothing handled them.
- So every rolling fill reaching a deployed maker hits `rolling-engine.ts:746-756` → F06 `unknown_session`, and every real swap falls through to the legacy SDK gift-wrap handler.

## One correction to the brief

The brief said the client side shipped and "can speak rolling to a maker that can never hear it". That is only half true, and it changes what "done" means here.

**The client has no RFQ either.** `toon-client/packages/client/src/swap/rolling-protocol.ts:34-45` says so in its own docblock:

> There is no RFQ (kind:20033/20034) session-negotiation transport yet … so the streamNonce this mints must be registered with the maker **OUT OF BAND**

and `client-runner.ts:1991-1993` repeats it in a thrown error. There is also **no rolling-capability predicate** anywhere in toon-client: `/swap` takes the rolling path iff the *caller* passes `senderConditions` (`client-runner.ts:1984`), and `toon_swap`'s MCP schema does not even expose that field. Nothing reads any announce field to decide.

So this PR makes the maker genuinely rolling-capable at the wire; a stock client still cannot drive it until toon-client grows an RFQ sender. That half is filed, not half-built — see below.

## The wire contract

Established from `toon-meta/docs/rolling-swap.md` §2.2 (`:129-135`), §10.3 (`:591-601`), §11 (`:612-616`).

**RFQ request** — spec §2.2 row 1: *"paid ILP write, NIP-59 gift wrap to the maker pubkey; rumor kind:20033 → seal → kind:1059"*, contents *"pair, size hint, `chainRecipient`, `streamNonce`, sender chain-B pubkeys"*.

It therefore arrives on the **same** local-delivery seam as a legacy swap request — zero/absent `executionCondition`, TOON gift wrap in `data` — and is distinguishable **only by its inner rumor kind**, which is visible only after NIP-59 decryption. `content` is UTF-8 JSON:

```jsonc
{ "proto": "rolling/1", "type": "rfq",
  "streamNonce": "…32 lowercase hex…",
  "pair": { "from": {"assetCode","assetScale","chain"}, "to": {…} },
  "chainRecipient": "…payout address on pair.to.chain…",
  "senderIlpAddress": "g.toon.client.…",   // where leg-B PREPAREs go
  "sizeHint": "100000000" }                // optional
```

`senderIlpAddress` is the concrete form of the spec's "sender chain-B pubkeys": `RollingSession.senderIlpAddress` (`rolling-engine.ts:262`) is used verbatim as the leg-B destination, and **the maker literally cannot address leg B without it** — which is exactly why the round trip is mandatory and why no fill packet can carry enough to self-establish a session.

**RFQ response** — spec §2.2 row 2: *"NIP-59 gift wrap back to the RFQ's reply key; rumor kind:20034"*, carrying *"quote `R₀`, `spread`, `maxRateAge`, `minAmount`/`maxAmount`, quote expiry"*. Sealed to the sender pubkey recovered from the request's seal layer, returned synchronously as the PREPARE's FULFILL `data` (base64 JSON of the kind:1059 wrap):

```jsonc
{ "proto": "rolling/1", "type": "quote",
  "streamNonce": "…", "rate": "4.0000", "rateTimestamp": 1783936201437,
  "expiresAt": 1783936261437,
  "spreadBps": 40, "maxRateAge": 15000,
  "minAmount": "1000", "maxAmount": "25000000",
  "swapSignerAddress": "0x…" }
```

`swapSignerAddress` is an addition beyond the spec's list: it lets the sender arm its R5 leg-B verification before the first fill instead of trusting the value echoed on the first advance.

**Session establishment**: the RFQ response *is* the establishment. The maker commits the session before answering, so a sender that has a quote can send `seq 1` immediately.

**Capability discovery is a probe, not a field.** Spec §10.3 step 2:

> RFQ (kind:20033) advertises `proto: "rolling/1"`. **A maker without it is legacy; `toon_swap` keeps the legacy path until the RFQ succeeds.**

So there is deliberately **no announce change in this PR**. That also satisfies the "don't advertise what you can't honour" constraint by construction — there is no flag to get out of sync. Worth noting the announce (`swap-node.ts:2179-2241`) has **zero tags** today and `buildIlpPeerInfoEvent` emits `tags: []`, so any flag would have been net-new surface that no client reads.

## What I implemented

Wire-level intake, in `packages/swap/src/rolling-rfq.ts` + a ~10-line hook in `handlePacket`:

- kind:20033 handled at the existing `setPacketHandler` seam, **ahead of** the legacy branch.
- Sessions registered **from the wire**, into the same `RollingSessionStore` (bounded, TTL'd, pruned on register — lifecycle was already sound, it just had no producer).
- Pair validated against `config.swapPairs`; priced from the configured `rateProvider` when present, else the pair's static advertised rate; `maxRateAge` sourced from the live staleness guard.
- Rejects: F01 `malformed_rfq`, F06 `unsupported_pair`, T99 `rate_unavailable`, T03 `session_rejected`.

Because it hangs off the packet handler, **the CLI-run container gets it with no CLI change** — which is precisely why the previous seam failed.

**Fail-soft by construction**: `handle()` returns `null` for anything it cannot positively identify as an RFQ, including any unwrap failure, and the legacy path below is untouched. A kind:20033 with a bad body is rejected rather than falling through, because the legacy handler's error would misdescribe it.

**Quote expiry ≠ session expiry.** Every fill is repriced at a fresh `R_i` and guarded by `maxRateAge` (§4), so a stale quote is a sender-side concern only; capping the session at the quote's 60s would kill any stream that outlives one quote. Session lifetime stays the store's TTL (`rolling.sessionTtlMs`, default 1h).

**Config**: `rolling.rfq.{enabled,quoteTtlMs,spreadBps}` — all optional and defaulted. Intake defaults **ON**, which is safe rather than bold: the path is reachable only by a packet whose inner rumor kind is 20033, a kind that had *no handler at all*, so it cannot regress anything that works today. `enabled: false` is a real opt-out (tested). Per the swap#134 lesson (one required key → 21 files touched → crash-looped the live maker on `:release` auto-deploy), **no new required key**; the CLI now also forwards the whole optional `rolling` block, which it previously dropped entirely.

## Tests

`packages/swap/src/swap-node.rolling-rfq.test.ts` — 10 tests at the **wire seam**, the same one `swap-node.rolling-dispatch.test.ts` uses: boot a real `startSwapNode()`, capture the `setPacketHandler` callback, drive it with real NIP-59 gift wraps built by the SDK's `wrapSwapPacketToToon`. **Nothing in the file calls `registerRollingSession`** — a unit test of that method proves nothing about reachability, which was the whole defect.

The headline case, `REACHABILITY: rfq then fill`, sends an RFQ and then a fill for the same `streamNonce`, and asserts the fill is **not** `unknown_session`, that it accepts, and that leg B went to the `senderIlpAddress` **the RFQ carried**. Its control, `without the RFQ, the same fill is still F06 unknown_session`, pins the pre-fix behaviour. Plus: quote round-trip and field assertions, unsupported pair (and that it mints no session), malformed body, quote-TTL-does-not-cap-session, `sessionTtlMs` expiry, `enabled:false` opt-out, non-20033 inner kind still legacy, and non-gift-wrap payload still legacy F06.

Local gate: `gate:correctness` PASS (lint 0 errors / 352 warnings — **frozen 352, zero new**; typecheck 0 errors), full suite 377 passed / 2 skipped across 28 files, prettier clean on every file touched.

## Deferred

The client-side RFQ sender is filed as toon-protocol/toon-client#585. Nothing here advertises a capability the maker cannot honour, so the deferral is safe: rolling clients that exist today are unaffected and keep working on the legacy path.

Part of toon-meta#394
