### PR TITLE
Maker refuses every swap after the first with a silent, unactionable T00 — and each failure leaks inventory (#136)

### DIFF
--- a/.changeset/issue-136-silent-t00-and-inventory-leak.md
+++ b/.changeset/issue-136-silent-t00-and-inventory-leak.md
@@ -1,0 +1,20 @@
+---
+---
+
+**A swap refusal is now logged and actionable, and a failed swap no longer leaks inventory.**
+
+Two defects that together turned a mundane live condition into a multi-hour outage diagnosis.
+
+**1 — the rejection that logged nothing.** After one successful swap the maker refused every subsequent swap with `T00 Internal error` and wrote not a single line. Two causes, both fixed:
+
+- `cli.ts` — the entrypoint the published image runs — never supplied `config.logger`, so `startSwapNode()` installed its no-op default and *every* log statement in the swap node **and** in the SDK swap handler was a no-op. The CLI now installs a JSON-line console logger (`createConsoleLogger()`), verbosity via the optional `SWAP_LOG_LEVEL` env var (`debug|info|warn|error|silent`, default `info`). No new config key, and no new *required* anything.
+- The SDK swap handler collapses everything except `INSUFFICIENT_INVENTORY` into `ctx.reject('T00', 'Internal error')`, discarding a perfectly good diagnosis. `claim-refusal.ts` now classifies what the claim issuer threw, logs it at warn/error, and replaces that blanket T00 on the wire:
+  - unredeemed channel → **T04** / `insufficient_funds`, `channel_unredeemed: the maker's payment channel <id> on <chain> still has <n> unredeemed unit(s); redeem or settle the previous claim before swapping again`
+  - no channel provisioned for the sender → **F99** / `application_error`, `no_channel_available: …`
+  - persist / signing / encrypt failures stay T-class but say which one they are.
+
+  Every refusal also carries base64-JSON reject `data` whose `reason` field is the machine discriminator, matching the `stale_rate` and rolling-engine reject contracts. The rolling coupled-leg path had the same silent-`T00` collapse and gets the same treatment.
+
+**2 — a failed swap leaked inventory.** `issueClaim()`'s rollback called `SwapInventory.credit()`, the operator-refill primitive (`available += n` **and** `total += n`), to undo a `debit()` (`available -= n`). So `total` — what the maker advertises in kind:10032 and reports on `/health` — ratcheted upward on every failure (observed live: 15 001 000 against a configured 15 000 000). The unwind now uses a new `SwapInventory.refundDebit()`, the exact inverse of `debit`. A failed issuance is byte-identical on both buckets.
+
+Still owed upstream: the SDK's `swap_handler.encrypt_failed` branch discards its error object entirely, so this package can only *infer* that path (claim issued, then a blanket T00) and name it. Surfacing the real error belongs in `@toon-protocol/sdk`'s `swap-handler.ts`.

--- a/deploy/swap/README.md
+++ b/deploy/swap/README.md
@@ -70,6 +70,12 @@ inject the secret from a mount rather than baking it into the config file.
 | `SWAP_RATE_URL`, `SWAP_RATE_TIMEOUT_MS` | HTTP JSON rate feed (issue #47 AC-3). |
 | `SWAP_AUTOGEN_IDENTITY` | `1`/`true` (issue #126) — overlay for `identityAutogen`. |
 | `SWAP_IDENTITY_FILE` | Overrides the self-generated identity file path (default: beside `statePath`, or the cwd when `statePath` is unset). |
+| `SWAP_LOG_LEVEL` | swap#136 — verbosity of the JSON-line logger the CLI installs: `debug`\|`info`\|`warn`\|`error`\|`silent` (default `info`). Optional; an unrecognised value degrades to the default. |
+
+Refusals show up in `docker logs` as one JSON object per line — grep
+`swap.claim.refused` for a swap the maker turned away, and `reason` for why
+(e.g. `channel_unredeemed`). Before swap#136 the container logged nothing at
+all for a refused swap.
 
 `peerInfoIlpDestination` / `peerInfoPricePerByte` are config-file-only (no
 env override), matching `btpEndpoint`. (`ilpAddress` is the exception among

--- a/packages/swap/src/channel-state.ts
+++ b/packages/swap/src/channel-state.ts
@@ -147,12 +147,37 @@ function poolPrefix(p: { assetCode: string; chain: string }): string {
   return `${p.assetCode}:${p.chain}:`;
 }
 
+/**
+ * One refused rebind candidate (swap#136 — structured, so the numbers reach
+ * the log line and the ILP reject `data` instead of only a prose string).
+ */
+export interface ChannelRebindRefusal {
+  channelId: string;
+  /**
+   * `'unredeemed'` — the candidate's off-chain watermark is ahead of its
+   * on-chain `cumulativePaid`, so rebinding would strand a claim.
+   * `'read_failed'` — the on-chain read threw; fail closed for that candidate.
+   */
+  reason: 'unredeemed' | 'read_failed';
+  /** `'unredeemed'` only: off-chain watermark − on-chain cumulativePaid. */
+  unredeemed?: bigint;
+  /** `'read_failed'` only: the reader's error message. */
+  detail?: string;
+}
+
+/** Human-readable rendering of one refusal (kept byte-stable — see swap#113 tests). */
+export function describeChannelRebindRefusal(r: ChannelRebindRefusal): string {
+  return r.reason === 'unredeemed'
+    ? `${r.channelId}: ${(r.unredeemed ?? 0n).toString()} unredeemed`
+    : `${r.channelId}: on-chain read failed (${r.detail ?? 'unknown'})`;
+}
+
 /** Result of a rebind attempt — see {@link SwapChannelState.reclaimFullyRedeemedChannel}. */
 interface ReclaimResult {
   /** The rebound channel, or `null` when no candidate was safe to rebind. */
   entry: ChannelEntry | null;
-  /** One human-readable reason per refused candidate (empty on success). */
-  refusals: string[];
+  /** One refusal per refused candidate (empty on success). */
+  refusals: ChannelRebindRefusal[];
 }
 
 export class SwapChannelState {
@@ -290,7 +315,7 @@ export class SwapChannelState {
     if (candidateKeys.length === 0) return { entry: null, refusals: [] };
     for (const storedKey of candidateKeys) this.reclaiming.add(storedKey);
     try {
-      const refusals: string[] = [];
+      const refusals: ChannelRebindRefusal[] = [];
       for (const storedKey of candidateKeys) {
         const channelId = this.channels.get(storedKey)?.channelId;
         if (channelId === undefined) continue; // dropped since the scan above
@@ -308,7 +333,7 @@ export class SwapChannelState {
             chain: p.chain,
             err,
           });
-          refusals.push(`${channelId}: on-chain read failed (${detail})`);
+          refusals.push({ channelId, reason: 'read_failed', detail });
           continue; // fail closed for this candidate; try the next
         }
         // The read was in flight across an await: the entry may have been
@@ -318,7 +343,7 @@ export class SwapChannelState {
         if (!entry || !this.boundChannels.has(storedKey)) continue;
         if (onChainCumulativePaid < entry.cumulativeAmount) {
           const unredeemed = entry.cumulativeAmount - onChainCumulativePaid;
-          refusals.push(`${channelId}: ${unredeemed.toString()} unredeemed`);
+          refusals.push({ channelId, reason: 'unredeemed', unredeemed });
           continue;
         }
         this.rebind(bindingKey(p), storedKey);
@@ -357,9 +382,44 @@ export class SwapChannelState {
       const reclaimed = await this.reclaimFullyRedeemedChannel(p);
       entry = reclaimed.entry;
       if (!entry) {
+        const unredeemed = reclaimed.refusals.filter(
+          (r) => r.reason === 'unredeemed'
+        );
+        // swap#136 — the refusal is thrown WITH its numbers, and logged here
+        // as well. Before this the only record of "1000 unredeemed" was the
+        // message string of an exception the SDK swap handler swallowed into
+        // a no-op logger, so a live maker refused every swap in total silence.
+        this.logger?.warn?.('swap.channelState.reserve_refused', {
+          chain: p.chain,
+          assetCode: p.assetCode,
+          senderPubkey: p.senderPubkey,
+          reason:
+            unredeemed.length > 0
+              ? 'channel_unredeemed'
+              : 'no_channel_available',
+          refusals: reclaimed.refusals.map((r) => ({
+            channelId: r.channelId,
+            reason: r.reason,
+            ...(r.unredeemed !== undefined && {
+              unredeemed: r.unredeemed.toString(),
+            }),
+            ...(r.detail !== undefined && { detail: r.detail }),
+          })),
+        });
         throw new SwapWalletError(
           'UNSUPPORTED_CHAIN',
-          buildNoChannelMessage(p.chain, reclaimed.refusals)
+          buildNoChannelMessage(p.chain, reclaimed.refusals),
+          {
+            details: {
+              reason:
+                unredeemed.length > 0
+                  ? 'channel_unredeemed'
+                  : 'no_channel_available',
+              chain: p.chain,
+              assetCode: p.assetCode,
+              refusals: reclaimed.refusals,
+            },
+          }
         );
       }
     }
@@ -466,12 +526,15 @@ export class SwapChannelState {
 }
 
 /** Issue #113 — actionable UNSUPPORTED_CHAIN message for a failed reserve(). */
-function buildNoChannelMessage(chain: string, refusals: string[]): string {
+function buildNoChannelMessage(
+  chain: string,
+  refusals: ChannelRebindRefusal[]
+): string {
   const base = `No channel provisioned for sender on ${chain}`;
   if (refusals.length === 0) return base;
   return (
     `${base} — ${refusals.length} bound channel(s) are not safe to rebind ` +
-    `(${refusals.join('; ')}). Wait for the sender to redeem, ` +
+    `(${refusals.map(describeChannelRebindRefusal).join('; ')}). Wait for the sender to redeem, ` +
     `cooperativeClose the channel, or provision another channel in ` +
     `config.channels.`
   );

--- a/packages/swap/src/claim-issuer.inventory-rollback.test.ts
+++ b/packages/swap/src/claim-issuer.inventory-rollback.test.ts
@@ -1,0 +1,192 @@
+/**
+ * swap#136 defect 2 — a FAILED swap must be a no-op on the inventory.
+ *
+ * `issueClaim()`'s legacy hold is `inventory.debit()` (available −= n).
+ * Its unwind used `inventory.credit()`, which is the operator-REFILL
+ * primitive: available += n AND **total += n**. So every failed swap
+ * ratcheted `total` upward — and `total` is what the maker advertises in
+ * kind:10032 (`swap-node.ts`'s peer-info builder) and reports as `inventory`
+ * on `/health`. Observed live: a maker configured with 15 000 000 reporting
+ * 15 001 000 after one failed swap.
+ *
+ * The assertion here is deliberately "byte-identical to before the attempt"
+ * across BOTH buckets, on every failure mode the issuer has.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { SwapPair } from '@toon-protocol/core';
+
+import { MultiChainClaimIssuer } from './claim-issuer.js';
+import { SwapInventory } from './inventory.js';
+import { SwapChannelState } from './channel-state.js';
+
+const SENDER = 'b'.repeat(64);
+const RECIPIENT = '0x' + '11'.repeat(20);
+const CHAIN = 'evm:base:8453';
+const POOL = `ETH:${CHAIN}`;
+
+const PAIR: SwapPair = {
+  from: { assetCode: 'USDC', chain: CHAIN, assetScale: 6 },
+  to: { assetCode: 'ETH', chain: CHAIN, assetScale: 18 },
+  rate: '0.0005',
+};
+
+function snapshotPool(inv: SwapInventory): {
+  available: bigint;
+  total: bigint;
+  unsettled: bigint;
+} {
+  const b = inv.get('ETH', CHAIN);
+  if (!b) throw new Error('pool missing');
+  return { available: b.available, total: b.total, unsettled: b.unsettled };
+}
+
+function makeInventory(): SwapInventory {
+  return new SwapInventory({
+    balances: { [POOL]: { available: 15_000_000n, total: 15_000_000n } },
+  });
+}
+
+function makeChannelState(): SwapChannelState {
+  return new SwapChannelState({
+    channels: {
+      [`ETH:${CHAIN}:0xchan`]: {
+        channelId: '0xchan',
+        cumulativeAmount: 0n,
+        nonce: 0n,
+        updatedAt: 0,
+      },
+    },
+  });
+}
+
+const ISSUE_PARAMS = {
+  sourceAmount: 100_000n,
+  targetAmount: 1_000n,
+  pair: PAIR,
+  senderPubkey: SENDER,
+  chainRecipient: RECIPIENT,
+  rumor: {
+    pubkey: SENDER,
+    created_at: 1_700_000_000,
+    kind: 1,
+    tags: [],
+    content: '',
+  },
+};
+
+describe('swap#136 — a failed issuance leaves the inventory byte-identical', () => {
+  it('[P0] signer failure: available AND total are unchanged (credit-as-unwind leaked total)', async () => {
+    const inventory = makeInventory();
+    const before = snapshotPool(inventory);
+
+    const issuer = new MultiChainClaimIssuer({
+      inventory,
+      channelState: makeChannelState(),
+      signers: {
+        [CHAIN]: {
+          chain: CHAIN,
+          chainKind: 'evm' as const,
+          signBalanceProof: vi.fn(async () => {
+            throw new Error('hsm offline');
+          }),
+        },
+      },
+    });
+
+    await expect(issuer.issueClaim(ISSUE_PARAMS)).rejects.toThrow();
+    expect(snapshotPool(inventory)).toEqual(before);
+  });
+
+  it('[P0] channel-reservation failure (the live "N unredeemed" refusal): inventory untouched', async () => {
+    const inventory = makeInventory();
+    const before = snapshotPool(inventory);
+
+    // No channel provisioned for the pool at all → reserve() throws after the
+    // debit has already been taken. This is the exact ordering that produced
+    // the live "total: 15001000 vs configured 15000000" drift.
+    const issuer = new MultiChainClaimIssuer({
+      inventory,
+      channelState: new SwapChannelState({ channels: {} }),
+      signers: {
+        [CHAIN]: {
+          chain: CHAIN,
+          chainKind: 'evm' as const,
+          signBalanceProof: vi.fn(async () => new Uint8Array([1])),
+        },
+      },
+    });
+
+    await expect(issuer.issueClaim(ISSUE_PARAMS)).rejects.toThrow();
+    expect(snapshotPool(inventory)).toEqual(before);
+  });
+
+  it('[P0] write-ahead persist failure: inventory untouched', async () => {
+    const inventory = makeInventory();
+    const before = snapshotPool(inventory);
+
+    const issuer = new MultiChainClaimIssuer({
+      inventory,
+      channelState: makeChannelState(),
+      signers: {
+        [CHAIN]: {
+          chain: CHAIN,
+          chainKind: 'evm' as const,
+          signBalanceProof: vi.fn(async () => new Uint8Array([1])),
+        },
+      },
+      persistState: () => {
+        throw new Error('disk full');
+      },
+    });
+
+    await expect(issuer.issueClaim(ISSUE_PARAMS)).rejects.toThrow();
+    expect(snapshotPool(inventory)).toEqual(before);
+  });
+
+  it('[P1] repeated failures do not ratchet total (the live symptom was cumulative)', async () => {
+    const inventory = makeInventory();
+    const before = snapshotPool(inventory);
+
+    const issuer = new MultiChainClaimIssuer({
+      inventory,
+      channelState: makeChannelState(),
+      signers: {
+        [CHAIN]: {
+          chain: CHAIN,
+          chainKind: 'evm' as const,
+          signBalanceProof: vi.fn(async () => {
+            throw new Error('hsm offline');
+          }),
+        },
+      },
+    });
+
+    for (let i = 0; i < 5; i += 1) {
+      await expect(issuer.issueClaim(ISSUE_PARAMS)).rejects.toThrow();
+    }
+    expect(snapshotPool(inventory)).toEqual(before);
+    expect(snapshotPool(inventory).total).toBe(15_000_000n);
+  });
+
+  it('[P1] `credit` remains the operator refill (raises BOTH buckets) — refundDebit only restores available', () => {
+    const inventory = makeInventory();
+
+    inventory.debit('ETH', CHAIN, 1_000n);
+    expect(snapshotPool(inventory)).toMatchObject({
+      available: 14_999_000n,
+      total: 15_000_000n,
+    });
+
+    inventory.refundDebit('ETH', CHAIN, 1_000n);
+    expect(snapshotPool(inventory)).toMatchObject({
+      available: 15_000_000n,
+      total: 15_000_000n,
+    });
+
+    inventory.credit('ETH', CHAIN, 1_000n);
+    expect(snapshotPool(inventory)).toMatchObject({
+      available: 15_001_000n,
+      total: 15_001_000n,
+    });
+  });
+});

--- a/packages/swap/src/claim-issuer.ts
+++ b/packages/swap/src/claim-issuer.ts
@@ -235,8 +235,12 @@ export class MultiChainClaimIssuer implements ClaimIssuer {
       //    exhausted — Story 12.3's handler maps this to ILP T04.
       this.inventory.debit(targetAsset, targetChain, targetAmount);
       return {
+        // swap#136: `refundDebit`, NOT `credit`. `credit` is the operator
+        // refill (available += n AND total += n); using it to unwind a
+        // failed issuance leaked `total` upward on every failure. The
+        // rollback must restore exactly what `debit` took: `available`.
         undo: () =>
-          this.inventory.credit(targetAsset, targetChain, targetAmount),
+          this.inventory.refundDebit(targetAsset, targetChain, targetAmount),
       };
     });
     return result;
@@ -339,6 +343,20 @@ export class MultiChainClaimIssuer implements ClaimIssuer {
       });
     } catch (err) {
       hold.undo();
+      // swap#136 — this catch used to be completely silent: it unwound the
+      // hold and rethrew into the SDK swap handler, which collapsed the
+      // error into `T00 Internal error` and logged it to a NO-OP logger.
+      // A live maker refused every swap after the first one and wrote not a
+      // single line. The reason (`<channelId>: <n> unredeemed`) is already
+      // on the error — log it here, at the boundary that owns it.
+      this.logger?.warn?.('swap.issueClaim.channel_reserve_failed', {
+        chain: targetChain,
+        asset: targetAsset,
+        senderPubkey,
+        reason: (err as { details?: { reason?: string } })?.details?.reason,
+        code: (err as { code?: string })?.code,
+        err: err instanceof Error ? err.message : String(err),
+      });
       throw err;
     }
 

--- a/packages/swap/src/claim-refusal.test.ts
+++ b/packages/swap/src/claim-refusal.test.ts
@@ -1,0 +1,244 @@
+/**
+ * swap#136 — unit coverage for the claim-refusal classifier and the two
+ * wrappers that reclaim what the SDK swap handler throws away.
+ *
+ * The end-to-end proof (a real gift-wrapped swap producing a logged,
+ * actionable refusal) lives in `swap-node.claim-refusal.test.ts`; this file
+ * pins the per-condition mapping and the concurrency property that makes the
+ * handler wrapper safe.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  CLAIM_REFUSAL_REASONS,
+  classifyClaimIssuerError,
+  buildClaimRefusalReject,
+  createClaimRefusalDiagnostics,
+} from './claim-refusal.js';
+import { SwapWalletError, SwapInventoryError } from './errors.js';
+
+const GENERIC = { accept: false, code: 'T00', message: 'Internal error' };
+
+function unredeemedError(channelId = '0x0124a370', unredeemed = 1_000n) {
+  return new SwapWalletError(
+    'UNSUPPORTED_CHAIN',
+    `No channel provisioned for sender on evm:8453 — 1 bound channel(s) are not safe to rebind (${channelId}: ${unredeemed} unredeemed).`,
+    {
+      details: {
+        reason: CLAIM_REFUSAL_REASONS.CHANNEL_UNREDEEMED,
+        chain: 'evm:8453',
+        assetCode: 'USDC',
+        refusals: [{ channelId, reason: 'unredeemed', unredeemed }],
+      },
+    }
+  );
+}
+
+describe('classifyClaimIssuerError', () => {
+  it('[P0] unredeemed channel → T04/insufficient_funds, naming the channel and the delta', () => {
+    const refusal = classifyClaimIssuerError(unredeemedError());
+    expect(refusal.reason).toBe(CLAIM_REFUSAL_REASONS.CHANNEL_UNREDEEMED);
+    expect(refusal.code).toBe('T04');
+    expect(refusal.semantic).toBe('insufficient_funds');
+    expect(refusal.level).toBe('warn');
+    expect(refusal.message).toContain('0x0124a370');
+    expect(refusal.message).toContain('1000');
+    expect(refusal.message.toLowerCase()).toContain('redeem');
+    expect(refusal.detail).toMatchObject({
+      channelId: '0x0124a370',
+      unredeemed: '1000',
+      chain: 'evm:8453',
+    });
+  });
+
+  it('[P0] no channel provisioned at all → F99/application_error (retrying cannot help)', () => {
+    const refusal = classifyClaimIssuerError(
+      new SwapWalletError('UNSUPPORTED_CHAIN', 'No channel provisioned', {
+        details: {
+          reason: CLAIM_REFUSAL_REASONS.NO_CHANNEL_AVAILABLE,
+          chain: 'evm:8453',
+        },
+      })
+    );
+    expect(refusal.reason).toBe(CLAIM_REFUSAL_REASONS.NO_CHANNEL_AVAILABLE);
+    expect(refusal.code).toBe('F99');
+    expect(refusal.semantic).toBe('application_error');
+  });
+
+  it('[P1] persist / signing failures stay T00 but stop saying "Internal error"', () => {
+    const persist = classifyClaimIssuerError(
+      new SwapWalletError('PERSISTENCE_FAILED', 'write-ahead persist failed')
+    );
+    expect(persist.reason).toBe(CLAIM_REFUSAL_REASONS.PERSIST_FAILED);
+    expect(persist.code).toBe('T00');
+    expect(persist.level).toBe('error');
+    expect(persist.message).not.toBe('Internal error');
+
+    const signing = classifyClaimIssuerError(
+      new SwapWalletError('SIGNING_FAILED', 'Balance-proof signing failed')
+    );
+    expect(signing.reason).toBe(CLAIM_REFUSAL_REASONS.SIGNING_FAILED);
+    expect(signing.message).toContain('sign');
+  });
+
+  it('[P1] an unrecognised throw still carries its message out', () => {
+    const refusal = classifyClaimIssuerError(new Error('kaboom'));
+    expect(refusal.reason).toBe(CLAIM_REFUSAL_REASONS.CLAIM_ISSUE_FAILED);
+    expect(refusal.message).toContain('kaboom');
+  });
+});
+
+describe('buildClaimRefusalReject', () => {
+  it('[P0] carries reason + numbers in base64-JSON `data` and sets rejectReason', () => {
+    const reject = buildClaimRefusalReject(
+      classifyClaimIssuerError(unredeemedError())
+    );
+    expect(reject.accept).toBe(false);
+    expect(reject.code).toBe('T04');
+    expect(reject.rejectReason).toEqual({
+      code: 'insufficient_funds',
+      message: reject.message,
+    });
+    const data = JSON.parse(
+      Buffer.from(reject.data, 'base64').toString('utf8')
+    ) as Record<string, unknown>;
+    expect(data['reason']).toBe(CLAIM_REFUSAL_REASONS.CHANNEL_UNREDEEMED);
+    expect(data['unredeemed']).toBe('1000');
+  });
+});
+
+describe('createClaimRefusalDiagnostics', () => {
+  it('[P0] instrument() logs the refusal and rethrows unchanged', async () => {
+    const warn = vi.fn();
+    const diagnostics = createClaimRefusalDiagnostics({
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn,
+        error: vi.fn(),
+      },
+    });
+    const thrown = unredeemedError();
+    const issuer = diagnostics.instrument({
+      issueClaim: async () => {
+        throw thrown;
+      },
+    });
+
+    await expect(issuer.issueClaim({})).rejects.toBe(thrown);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [event, fields] = warn.mock.calls[0] ?? [];
+    expect(event).toBe('swap.claim.refused');
+    expect(fields).toMatchObject({
+      reason: CLAIM_REFUSAL_REASONS.CHANNEL_UNREDEEMED,
+      ilpCode: 'T04',
+      channelId: '0x0124a370',
+      unredeemed: '1000',
+    });
+  });
+
+  it('[P0] INSUFFICIENT_INVENTORY is left to the SDK (T04 "Insufficient liquidity" is unchanged)', async () => {
+    const warn = vi.fn();
+    const error = vi.fn();
+    const diagnostics = createClaimRefusalDiagnostics({
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error },
+    });
+    const issuer = diagnostics.instrument({
+      issueClaim: async () => {
+        throw new SwapInventoryError('INSUFFICIENT_INVENTORY', 'no reserves');
+      },
+    });
+    await expect(issuer.issueClaim({})).rejects.toThrow('no reserves');
+    expect(warn).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+
+    // …and the handler wrapper leaves the SDK's own T04 alone.
+    const handler = diagnostics.wrap(async () => ({
+      accept: false,
+      code: 'T04',
+      message: 'Insufficient liquidity',
+    }));
+    expect(await handler({})).toEqual({
+      accept: false,
+      code: 'T04',
+      message: 'Insufficient liquidity',
+    });
+  });
+
+  it("[P0] wrap() replaces the SDK's blanket T00 with the captured refusal", async () => {
+    const diagnostics = createClaimRefusalDiagnostics({});
+    const issuer = diagnostics.instrument({
+      issueClaim: async () => {
+        throw unredeemedError();
+      },
+    });
+    const handler = diagnostics.wrap(async () => {
+      // stand-in for the SDK handler: calls the issuer, swallows the throw
+      await issuer.issueClaim({}).catch(() => undefined);
+      return GENERIC;
+    });
+
+    const result = (await handler({})) as { code: string; message: string };
+    expect(result.code).toBe('T04');
+    expect(result.message).toContain(CLAIM_REFUSAL_REASONS.CHANNEL_UNREDEEMED);
+  });
+
+  it('[P0] concurrent packets never cross-contaminate (per-packet AsyncLocalStorage slot)', async () => {
+    const diagnostics = createClaimRefusalDiagnostics({});
+    const issuer = diagnostics.instrument({
+      issueClaim: async (params: { fail?: string }) => {
+        await new Promise((r) => setTimeout(r, params.fail === 'a' ? 20 : 1));
+        if (params.fail === 'a') throw unredeemedError('0xAAA', 111n);
+        if (params.fail === 'b') throw unredeemedError('0xBBB', 222n);
+        return { ok: true };
+      },
+    });
+    const handler = diagnostics.wrap(async (ctx: { fail?: string }) => {
+      await issuer.issueClaim(ctx).catch(() => undefined);
+      return GENERIC;
+    });
+
+    const [a, b] = (await Promise.all([
+      handler({ fail: 'a' }),
+      handler({ fail: 'b' }),
+    ])) as { message: string }[];
+    expect(a.message).toContain('0xAAA');
+    expect(a.message).toContain('111');
+    expect(b.message).toContain('0xBBB');
+    expect(b.message).toContain('222');
+  });
+
+  it("[P1] a successful issuance followed by the SDK's T00 is named as the encrypt path", async () => {
+    const error = vi.fn();
+    const diagnostics = createClaimRefusalDiagnostics({
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error },
+    });
+    const issuer = diagnostics.instrument({
+      issueClaim: async () => ({ claim: new Uint8Array([1]) }),
+    });
+    const handler = diagnostics.wrap(async () => {
+      await issuer.issueClaim({});
+      return GENERIC; // the SDK's `swap_handler.encrypt_failed` branch
+    });
+
+    const result = (await handler({})) as { code: string; message: string };
+    expect(result.message).toContain(
+      CLAIM_REFUSAL_REASONS.CLAIM_ENCRYPT_FAILED
+    );
+    expect(error).toHaveBeenCalledTimes(1);
+  });
+
+  it('[P1] a T00 with no issuance attempted at all is passed through untouched', async () => {
+    const diagnostics = createClaimRefusalDiagnostics({});
+    const handler = diagnostics.wrap(async () => GENERIC);
+    expect(await handler({})).toEqual(GENERIC);
+  });
+
+  it('[P1] accepts and non-generic rejects are passed through untouched', async () => {
+    const diagnostics = createClaimRefusalDiagnostics({});
+    const accept = { accept: true, metadata: { claim: 'x' } };
+    expect(await diagnostics.wrap(async () => accept)({})).toBe(accept);
+    const stale = { accept: false, code: 'T99', message: 'stale_rate' };
+    expect(await diagnostics.wrap(async () => stale)({})).toBe(stale);
+  });
+});

--- a/packages/swap/src/claim-refusal.ts
+++ b/packages/swap/src/claim-refusal.ts
@@ -1,0 +1,372 @@
+/**
+ * swap#136 — turning a swallowed claim-issuance failure into a diagnosable
+ * refusal, on both the log side and the wire side.
+ *
+ * ## The defect
+ *
+ * The SDK swap handler (`@toon-protocol/sdk`, `createSwapHandler`) wraps its
+ * `claimIssuer.issueClaim()` call in a catch that recognises exactly one
+ * condition — `INSUFFICIENT_INVENTORY` → `T04 Insufficient liquidity` — and
+ * collapses *everything else* into:
+ *
+ * ```js
+ * logger.error({ event: 'swap_handler.issuer_failed', error: message });
+ * return ctx.reject('T00', 'Internal error');
+ * ```
+ *
+ * Live on devnet the thrown message was a perfectly actionable
+ * `0x0124a370…: 1000 unredeemed` (from `channel-state.ts`'s `reserve()`), and
+ * the client saw `{"code":"T00","message":"Internal error"}`. The SDK is a
+ * pinned dependency, so this module reclaims both halves on our side:
+ *
+ *   - **logs** — the issuer wrapper below logs the classified refusal with a
+ *     real logger before the SDK ever sees the error;
+ *   - **wire** — the handler wrapper rewrites the SDK's generic
+ *     `T00 Internal error` into the classified code/message/`data`, using the
+ *     refusal captured for *that packet* (an `AsyncLocalStorage` slot, so
+ *     concurrent `handlePacket` calls cannot cross-contaminate).
+ *
+ * ## Code choices
+ *
+ * Consistent with the refusals already in this repo — `INSUFFICIENT_INVENTORY`
+ * → T04/`insufficient_funds` (SDK), `stale_rate` → T99/`stale_rate`
+ * (`rate-staleness.ts`), rolling-engine refusals → F-class for "don't retry"
+ * and T-class for "retry later" (`rolling-engine.ts`) — and with the semantic
+ * reasons the connector's `REJECT_CODE_MAP` actually knows:
+ *
+ * | reason                 | wire | semantic            | why                                                     |
+ * |------------------------|------|---------------------|---------------------------------------------------------|
+ * | `channel_unredeemed`   | T04  | `insufficient_funds`| maker's channel capital is locked in an unredeemed claim; the sender fixes it by redeeming → T-class, retryable |
+ * | `no_channel_available` | F99  | `application_error` | no channel is provisioned for this sender at all — retrying now cannot help; pick another maker |
+ * | `persist_failed`       | T00  | `internal_error`    | genuinely internal and transient (disk), but now says so |
+ * | `signing_failed`       | T00  | `internal_error`    | genuinely internal, but now says so                      |
+ * | `claim_encrypt_failed` | T00  | `internal_error`    | see the SDK note below                                   |
+ *
+ * Every refusal also carries base64-JSON `data` whose `reason` field is the
+ * authoritative discriminator — the same contract `buildStaleRateReject()`
+ * and `buildRollingReject()` already publish.
+ *
+ * ## Still owed by the SDK
+ *
+ * `swap_handler.encrypt_failed` (the SDK's *other* `T00 Internal error`)
+ * discards its error object entirely — it never reaches a caller-supplied
+ * seam, so no wrapper on this side can recover the message. What we can do,
+ * and do below, is *identify* it: a T00/`Internal error` from the SDK handler
+ * after a claim was issued successfully can only have come from the encrypt
+ * branch. We log that and name it on the wire. The real fix — surfacing the
+ * error and rejecting with something better than `T00 Internal error` —
+ * belongs in `packages/sdk/src/swap-handler.ts` upstream.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+import type { SwapNodeLogger } from './swap-node.js';
+
+// ---------------------------------------------------------------------------
+// Refusal contract
+// ---------------------------------------------------------------------------
+
+/** `data.reason` discriminators — the client's authoritative marker. */
+export const CLAIM_REFUSAL_REASONS = {
+  /** Every provisioned channel still carries unredeemed value. */
+  CHANNEL_UNREDEEMED: 'channel_unredeemed',
+  /** No channel is provisioned for this sender on the target chain. */
+  NO_CHANNEL_AVAILABLE: 'no_channel_available',
+  /** Write-ahead persist of the channel watermark failed; claim NOT issued. */
+  PERSIST_FAILED: 'persist_failed',
+  /** Balance-proof signing failed. */
+  SIGNING_FAILED: 'signing_failed',
+  /** The claim was issued but could not be encrypted to the sender (SDK). */
+  CLAIM_ENCRYPT_FAILED: 'claim_encrypt_failed',
+  /** Anything else the issuer threw. */
+  CLAIM_ISSUE_FAILED: 'claim_issue_failed',
+} as const;
+
+export type ClaimRefusalReason =
+  (typeof CLAIM_REFUSAL_REASONS)[keyof typeof CLAIM_REFUSAL_REASONS];
+
+export interface ClaimRefusal {
+  reason: ClaimRefusalReason;
+  /** ILP wire code returned to the client. */
+  code: string;
+  /** Semantic reason for the connector's `REJECT_CODE_MAP`. */
+  semantic: string;
+  /** Actionable prose, prefixed with `reason` so message-only surfaces work. */
+  message: string;
+  /** Extra machine-readable fields folded into the reject `data`. */
+  detail: Record<string, unknown>;
+  /** Severity for the maker's own log line. */
+  level: 'warn' | 'error';
+}
+
+interface RefusalShape {
+  code: string;
+  semantic: string;
+  level: 'warn' | 'error';
+  /** Prose after the `reason: ` prefix. */
+  describe: (detail: Record<string, unknown>) => string;
+}
+
+const SHAPES: Record<ClaimRefusalReason, RefusalShape> = {
+  [CLAIM_REFUSAL_REASONS.CHANNEL_UNREDEEMED]: {
+    code: 'T04',
+    semantic: 'insufficient_funds',
+    level: 'warn',
+    describe: (d) =>
+      `the maker's payment channel${d['channelId'] ? ` ${String(d['channelId'])}` : ''} on ${String(d['chain'] ?? 'the target chain')} still has ${String(d['unredeemed'] ?? '?')} unredeemed unit(s); redeem or settle the previous claim before swapping again`,
+  },
+  [CLAIM_REFUSAL_REASONS.NO_CHANNEL_AVAILABLE]: {
+    code: 'F99',
+    semantic: 'application_error',
+    level: 'warn',
+    describe: (d) =>
+      `the maker has no payment channel provisioned for this sender on ${String(d['chain'] ?? 'the target chain')}`,
+  },
+  [CLAIM_REFUSAL_REASONS.PERSIST_FAILED]: {
+    code: 'T00',
+    semantic: 'internal_error',
+    level: 'error',
+    describe: () =>
+      'the maker could not durably persist the channel watermark, so no claim was issued; retry shortly',
+  },
+  [CLAIM_REFUSAL_REASONS.SIGNING_FAILED]: {
+    code: 'T00',
+    semantic: 'internal_error',
+    level: 'error',
+    describe: (d) =>
+      `the maker could not sign the balance proof on ${String(d['chain'] ?? 'the target chain')}`,
+  },
+  [CLAIM_REFUSAL_REASONS.CLAIM_ENCRYPT_FAILED]: {
+    code: 'T00',
+    semantic: 'internal_error',
+    level: 'error',
+    describe: () =>
+      'the maker issued the claim but could not encrypt it to the sender key from the gift wrap',
+  },
+  [CLAIM_REFUSAL_REASONS.CLAIM_ISSUE_FAILED]: {
+    code: 'T00',
+    semantic: 'internal_error',
+    level: 'error',
+    describe: (d) =>
+      `claim issuance failed${d['err'] ? `: ${String(d['err'])}` : ''}`,
+  },
+};
+
+function buildRefusal(
+  reason: ClaimRefusalReason,
+  detail: Record<string, unknown>
+): ClaimRefusal {
+  const shape = SHAPES[reason];
+  return {
+    reason,
+    code: shape.code,
+    semantic: shape.semantic,
+    message: `${reason}: ${shape.describe(detail)}`,
+    detail,
+    level: shape.level,
+  };
+}
+
+/** Serialize bigints so a refusal survives `JSON.stringify` into reject `data`. */
+function jsonSafe(value: unknown): unknown {
+  if (typeof value === 'bigint') return value.toString();
+  if (Array.isArray(value)) return value.map(jsonSafe);
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = jsonSafe(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Classify whatever `MultiChainClaimIssuer.issueClaim()` threw.
+ *
+ * `INSUFFICIENT_INVENTORY` is deliberately NOT handled here: the SDK already
+ * maps it to `T04 Insufficient liquidity` and logs it at warn, so leaving it
+ * alone keeps that byte-identical contract for existing senders.
+ */
+export function classifyClaimIssuerError(err: unknown): ClaimRefusal {
+  const code = (err as { code?: string } | undefined)?.code;
+  const details = (err as { details?: Record<string, unknown> } | undefined)
+    ?.details;
+  const message = err instanceof Error ? err.message : String(err);
+
+  if (details?.['reason'] === CLAIM_REFUSAL_REASONS.CHANNEL_UNREDEEMED) {
+    const refusals = Array.isArray(details['refusals'])
+      ? (details['refusals'] as Record<string, unknown>[])
+      : [];
+    const first =
+      refusals.find((r) => r['reason'] === 'unredeemed') ?? refusals[0];
+    return buildRefusal(CLAIM_REFUSAL_REASONS.CHANNEL_UNREDEEMED, {
+      chain: details['chain'],
+      assetCode: details['assetCode'],
+      ...(first?.['channelId'] !== undefined && {
+        channelId: first['channelId'],
+      }),
+      ...(first?.['unredeemed'] !== undefined && {
+        unredeemed: String(first['unredeemed']),
+      }),
+      refusals: jsonSafe(refusals),
+    });
+  }
+  if (details?.['reason'] === CLAIM_REFUSAL_REASONS.NO_CHANNEL_AVAILABLE) {
+    return buildRefusal(CLAIM_REFUSAL_REASONS.NO_CHANNEL_AVAILABLE, {
+      chain: details['chain'],
+      assetCode: details['assetCode'],
+    });
+  }
+  if (code === 'PERSISTENCE_FAILED') {
+    return buildRefusal(CLAIM_REFUSAL_REASONS.PERSIST_FAILED, { err: message });
+  }
+  if (code === 'SIGNING_FAILED') {
+    return buildRefusal(CLAIM_REFUSAL_REASONS.SIGNING_FAILED, {
+      err: message,
+    });
+  }
+  return buildRefusal(CLAIM_REFUSAL_REASONS.CLAIM_ISSUE_FAILED, {
+    ...(code !== undefined && { code }),
+    err: message,
+  });
+}
+
+/** The SDK's generic swallow-everything reject, verbatim. */
+const SDK_GENERIC_REJECT_MESSAGE = 'Internal error';
+const SDK_GENERIC_REJECT_CODE = 'T00';
+
+/** Reject-response shape the connector's PaymentHandlerAdapter consumes. */
+export interface ClaimRefusalReject {
+  accept: false;
+  code: string;
+  message: string;
+  data: string;
+  rejectReason: { code: string; message: string };
+}
+
+/** Build the wire reject for a classified refusal. */
+export function buildClaimRefusalReject(
+  refusal: ClaimRefusal
+): ClaimRefusalReject {
+  return {
+    accept: false,
+    code: refusal.code,
+    message: refusal.message,
+    data: Buffer.from(
+      JSON.stringify({
+        reason: refusal.reason,
+        ...(jsonSafe(refusal.detail) as Record<string, unknown>),
+      }),
+      'utf8'
+    ).toString('base64'),
+    rejectReason: { code: refusal.semantic, message: refusal.message },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-packet capture + the two wrappers
+// ---------------------------------------------------------------------------
+
+interface CaptureSlot {
+  refusal?: ClaimRefusal;
+  issued: boolean;
+}
+
+/** Minimal structural view of the SDK's `ClaimIssuer` (avoids a value import). */
+export interface IssueClaimLike<P, R> {
+  issueClaim(params: P): Promise<R>;
+}
+
+export interface ClaimRefusalDiagnostics {
+  /**
+   * Wrap the claim issuer handed to `createSwapHandler`. Logs the classified
+   * refusal and records it for the in-flight packet, then rethrows unchanged
+   * so the SDK's own `INSUFFICIENT_INVENTORY` handling is untouched.
+   */
+  instrument<P, R>(issuer: IssueClaimLike<P, R>): IssueClaimLike<P, R>;
+  /**
+   * Wrap the SDK handler so its generic `T00 Internal error` is replaced by
+   * the refusal captured for that same packet.
+   */
+  wrap<C, T>(handler: (ctx: C) => Promise<T>): (ctx: C) => Promise<T>;
+}
+
+export function createClaimRefusalDiagnostics(options: {
+  logger?: SwapNodeLogger;
+}): ClaimRefusalDiagnostics {
+  const store = new AsyncLocalStorage<CaptureSlot>();
+  const logger = options.logger;
+
+  return {
+    instrument<P, R>(issuer: IssueClaimLike<P, R>): IssueClaimLike<P, R> {
+      return {
+        issueClaim: async (params: P): Promise<R> => {
+          try {
+            const result = await issuer.issueClaim(params);
+            const slot = store.getStore();
+            if (slot) slot.issued = true;
+            return result;
+          } catch (err) {
+            // Leave the SDK's own liquidity contract alone.
+            if (
+              (err as { code?: string } | undefined)?.code !==
+              'INSUFFICIENT_INVENTORY'
+            ) {
+              const refusal = classifyClaimIssuerError(err);
+              const slot = store.getStore();
+              if (slot) slot.refusal = refusal;
+              logger?.[refusal.level]?.('swap.claim.refused', {
+                reason: refusal.reason,
+                ilpCode: refusal.code,
+                clientMessage: refusal.message,
+                ...(jsonSafe(refusal.detail) as Record<string, unknown>),
+              });
+            }
+            throw err;
+          }
+        },
+      };
+    },
+
+    wrap<C, T>(handler: (ctx: C) => Promise<T>): (ctx: C) => Promise<T> {
+      return async (ctx: C): Promise<T> => {
+        const slot: CaptureSlot = { issued: false };
+        const result = await store.run(slot, () => handler(ctx));
+        const r = result as unknown as {
+          accept?: boolean;
+          code?: string;
+          message?: string;
+        };
+        if (
+          r?.accept !== false ||
+          r.code !== SDK_GENERIC_REJECT_CODE ||
+          r.message !== SDK_GENERIC_REJECT_MESSAGE
+        ) {
+          return result;
+        }
+        if (slot.refusal) {
+          return buildClaimRefusalReject(slot.refusal) as unknown as T;
+        }
+        if (slot.issued) {
+          // Nothing threw out of `issueClaim` and the claim was produced, so
+          // the SDK's only remaining `T00 Internal error` branch is
+          // `swap_handler.encrypt_failed` — whose error object the SDK
+          // discards, hence the inference. See this file's header.
+          const refusal = buildRefusal(
+            CLAIM_REFUSAL_REASONS.CLAIM_ENCRYPT_FAILED,
+            {}
+          );
+          logger?.error?.('swap.claim.refused', {
+            reason: refusal.reason,
+            ilpCode: refusal.code,
+            clientMessage: refusal.message,
+            note: 'inferred from the SDK handler response; the SDK discards the underlying encrypt error',
+          });
+          return buildClaimRefusalReject(refusal) as unknown as T;
+        }
+        return result;
+      };
+    },
+  };
+}

--- a/packages/swap/src/cli.ts
+++ b/packages/swap/src/cli.ts
@@ -14,6 +14,12 @@
  *   SWAP_SECRET_KEY_HEX    — 64-char hex-encoded 32-byte secret key
  *   SWAP_BLS_PORT          — numeric port for /health server
  *   SWAP_RELAYS            — comma-separated relay WebSocket URLs
+ *   SWAP_LOG_LEVEL         — swap#136: verbosity of the JSON-line console
+ *                            logger this CLI installs
+ *                            (debug|info|warn|error|silent, default info).
+ *                            OPTIONAL — an unset or unrecognised value
+ *                            degrades to the default; the maker never
+ *                            fails boot over it.
  *   SWAP_STATE_PATH        — durable state snapshot path (issue #46);
  *                            enables persistence of inventory, channel
  *                            watermarks, sticky bindings + replay
@@ -84,6 +90,7 @@ import { fromMnemonic, generateMnemonic } from '@toon-protocol/sdk';
 import { startSwapNode } from './swap-node.js';
 import type { SwapNodeConfig, SwapNodeInstance } from './swap-node.js';
 import { createHttpRateProvider } from './rate-provider.js';
+import { createConsoleLogger } from './logger.js';
 import { deriveSwapNodeKeys } from './wallet.js';
 
 interface CliRawConfig {
@@ -504,6 +511,28 @@ export class CliHelpRequested extends Error {
   }
 }
 
+/**
+ * swap#136 — install the process-level logger.
+ *
+ * `startSwapNode()` defaults `config.logger` to a NO-OP (correct for
+ * embedders: a library must not print uninvited), and this CLI — the
+ * entrypoint the published image runs, `ENTRYPOINT ["node", "dist/cli.js"]` —
+ * never replaced it. Result: a live maker refused every swap after the first
+ * and `docker logs` showed nothing at all, because both the swap node's own
+ * `logger.warn?.(...)` calls AND the logger forwarded into the SDK swap
+ * handler were the no-op.
+ *
+ * Verbosity comes from the optional `SWAP_LOG_LEVEL` env var, NOT a config
+ * key: `:release` auto-deploys on green main, so a newly *required* config
+ * key would crash-loop the live maker (swap#134).
+ *
+ * Exported so `cli.test.ts` can assert the wiring without booting a node.
+ */
+export function installDefaultLogger(config: SwapNodeConfig): SwapNodeConfig {
+  if (config.logger) return config;
+  return { ...config, logger: createConsoleLogger() };
+}
+
 export async function main(argv: string[]): Promise<SwapNodeInstance> {
   const { values } = parseArgs({
     args: argv,
@@ -527,7 +556,9 @@ export async function main(argv: string[]): Promise<SwapNodeInstance> {
   const raw = JSON.parse(rawText) as CliRawConfig;
   const parsed = parseRawConfig(raw);
   const overlaid = applyEnvOverlay(parsed);
-  const config = await resolveIdentityConfig(overlaid, raw);
+  const config = installDefaultLogger(
+    await resolveIdentityConfig(overlaid, raw)
+  );
 
   const instance = await startSwapNode(config);
 

--- a/packages/swap/src/errors.ts
+++ b/packages/swap/src/errors.ts
@@ -45,17 +45,41 @@ export class SwapInventoryError extends Error {
   }
 }
 
+/**
+ * Machine-readable payload attached to a {@link SwapWalletError}.
+ *
+ * swap#136: `code` alone is too coarse to refuse a swap actionably —
+ * `UNSUPPORTED_CHAIN` covers both "this swap node has no signer for that
+ * chain" (final) and "every provisioned channel still carries unredeemed
+ * value" (temporary, and the sender fixes it by redeeming). `details.reason`
+ * discriminates them, and the remaining fields carry the numbers an operator
+ * or a client needs — the channel id and its unredeemed delta — all the way
+ * out to the ILP reject `data`. See `claim-refusal.ts`.
+ */
+export interface SwapWalletErrorDetails {
+  /** Discriminator — see `CLAIM_REFUSAL_REASONS` in `claim-refusal.ts`. */
+  reason: string;
+  [key: string]: unknown;
+}
+
 export class SwapWalletError extends Error {
   public readonly code: SwapWalletErrorCode;
+
+  /**
+   * swap#136 — optional structured diagnosis. Absent on legacy throw sites;
+   * consumers MUST treat it as best-effort and fall back to `code`.
+   */
+  public readonly details?: SwapWalletErrorDetails;
 
   constructor(
     code: SwapWalletErrorCode,
     message: string,
-    options?: { cause?: unknown }
+    options?: { cause?: unknown; details?: SwapWalletErrorDetails }
   ) {
     super(message, options as ErrorOptions | undefined);
     this.name = 'SwapWalletError';
     this.code = code;
+    if (options?.details) this.details = options.details;
   }
 }
 

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -43,7 +43,10 @@ export type {
   ReleaseLogger,
   // Issue #113 — the `SwapChannelStateInit.onChainReader` seam.
   ChannelOnChainReader,
+  // swap#136 — structured rebind refusals (channelId + unredeemed delta).
+  ChannelRebindRefusal,
 } from './channel-state.js';
+export { describeChannelRebindRefusal } from './channel-state.js';
 
 // Claim issuer (Story 12.4)
 export { MultiChainClaimIssuer } from './claim-issuer.js';
@@ -74,7 +77,35 @@ export type {
 
 // Errors (Story 12.4)
 export { SwapInventoryError, SwapWalletError } from './errors.js';
-export type { SwapInventoryErrorCode, SwapWalletErrorCode } from './errors.js';
+export type {
+  SwapInventoryErrorCode,
+  SwapWalletErrorCode,
+  SwapWalletErrorDetails,
+} from './errors.js';
+
+// swap#136 — claim-refusal contract (the diagnosable replacement for the SDK
+// swap handler's blanket `T00 Internal error`).
+export {
+  CLAIM_REFUSAL_REASONS,
+  classifyClaimIssuerError,
+  buildClaimRefusalReject,
+  createClaimRefusalDiagnostics,
+} from './claim-refusal.js';
+export type {
+  ClaimRefusal,
+  ClaimRefusalReason,
+  ClaimRefusalReject,
+  ClaimRefusalDiagnostics,
+} from './claim-refusal.js';
+
+// swap#136 — the process-level structured logger the CLI installs.
+export {
+  createConsoleLogger,
+  resolveLogLevel,
+  DEFAULT_SWAP_LOG_LEVEL,
+  SWAP_LOG_LEVEL_ENV,
+} from './logger.js';
+export type { SwapLogLevel, ConsoleLoggerOptions } from './logger.js';
 
 // Runtime entrypoint (Story 12.7)
 export { startSwapNode } from './swap-node.js';

--- a/packages/swap/src/inventory.ts
+++ b/packages/swap/src/inventory.ts
@@ -248,8 +248,40 @@ export class SwapInventory {
   }
 
   /**
+   * swap#136 — exact inverse of {@link debit}: restore `amount` to
+   * `available` ONLY, leaving `total` untouched.
+   *
+   * This is the rollback of a failed legacy issuance, NOT an operator refill.
+   * {@link credit} adds NEW capital and therefore raises `total` as well; using
+   * it as the unwind ratcheted `total` upward on every failed swap (observed
+   * live: a configured 15 000 000 inventory advertising 15 001 000 after one
+   * failure, since `total` is what kind:10032 advertises — see
+   * `swap-node.ts`'s peer-info builder). A failed swap must be a no-op on
+   * BOTH buckets.
+   *
+   * Deliberately tolerant of a missing entry (a debit always creates/finds
+   * one, so this cannot legitimately happen — but a rollback must never
+   * throw over the error it is unwinding).
+   */
+  refundDebit(assetCode: string, chain: string, amount: bigint): void {
+    if (amount <= 0n) {
+      throw new SwapInventoryError(
+        'UNKNOWN_PAIR',
+        'Refund amount must be positive'
+      );
+    }
+    const entry = this.entries.get(key(assetCode, chain));
+    if (!entry) return;
+    entry.available += amount;
+    entry.updatedAt = this.clock();
+  }
+
+  /**
    * Credit `amount` to `(assetCode, chain).available` and `.total`.
    * Creates the entry if missing. Synchronous — atomic under concurrent use.
+   *
+   * Operator refill / new capital only. To unwind a failed issuance use
+   * {@link refundDebit} — `credit` would inflate `total` (swap#136).
    */
   credit(assetCode: string, chain: string, amount: bigint): void {
     if (amount <= 0n) {

--- a/packages/swap/src/logger.test.ts
+++ b/packages/swap/src/logger.test.ts
@@ -1,0 +1,185 @@
+/**
+ * swap#136 — the process-level logger, and the CLI wiring that installs it.
+ *
+ * The root cause of "the maker refused every swap and wrote NOTHING" was not
+ * a missing log statement: `swap-node.ts` and the SDK swap handler both had
+ * one. It was that `cli.ts` — the entrypoint `deploy/swap/Dockerfile` runs —
+ * never supplied `config.logger`, so `startSwapNode()` installed
+ * `noopLogger()` and every one of those statements was a no-op. These tests
+ * pin the entrypoint wiring so the regression cannot come back silently.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  createConsoleLogger,
+  resolveLogLevel,
+  buildLogRecord,
+  DEFAULT_SWAP_LOG_LEVEL,
+  type SwapLogLevel,
+} from './logger.js';
+import { installDefaultLogger } from './cli.js';
+import type { SwapNodeConfig } from './swap-node.js';
+
+function capture(level?: SwapLogLevel): {
+  logger: ReturnType<typeof createConsoleLogger>;
+  lines: string[];
+} {
+  const lines: string[] = [];
+  const logger = createConsoleLogger({
+    ...(level !== undefined && { level }),
+    write: (_at, line) => lines.push(line),
+    now: () => 1_700_000_000_000,
+  });
+  return { logger, lines };
+}
+
+/** Narrowing accessor — the gate forbids `!` (no-non-null-assertion). */
+function parseLine(lines: string[], index = 0): Record<string, unknown> {
+  const line = lines[index];
+  if (line === undefined) throw new Error(`no log line at index ${index}`);
+  return JSON.parse(line) as Record<string, unknown>;
+}
+
+function lineAt(lines: string[], index = 0): string {
+  const line = lines[index];
+  if (line === undefined) throw new Error(`no log line at index ${index}`);
+  return line;
+}
+
+describe('swap#136 — cli.ts installs a real logger (the no-op was the defect)', () => {
+  it('[P0] installDefaultLogger() gives a config with no logger a working one', () => {
+    const config = installDefaultLogger({} as SwapNodeConfig);
+    expect(config.logger).toBeDefined();
+    for (const method of ['debug', 'info', 'warn', 'error'] as const) {
+      expect(typeof config.logger?.[method]).toBe('function');
+    }
+  });
+
+  it('[P0] an operator-supplied logger is never overridden', () => {
+    const mine = {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    };
+    expect(
+      installDefaultLogger({ logger: mine } as SwapNodeConfig).logger
+    ).toBe(mine);
+  });
+
+  it('[P0] the installed logger actually emits — destructured methods included', () => {
+    const { logger, lines } = capture();
+    // swap-node.ts forwards `{ warn: logger.warn }` into the SDK handler and
+    // the rate guard; a `this`-bound method would break there.
+    const { warn } = logger;
+    warn('swap.claim.refused', { reason: 'channel_unredeemed' });
+    expect(lines).toHaveLength(1);
+    expect(parseLine(lines)).toMatchObject({
+      level: 'warn',
+      event: 'swap.claim.refused',
+      reason: 'channel_unredeemed',
+    });
+  });
+});
+
+describe('createConsoleLogger', () => {
+  it('[P0] accepts BOTH call shapes in play', () => {
+    const { logger, lines } = capture('debug');
+    // this repo's shape
+    logger.warn('swap.event', { a: 1 });
+    // the SDK's shape (`logger.error({ event, error })`)
+    logger.error({ event: 'swap_handler.issuer_failed', error: 'boom' });
+    expect(parseLine(lines)).toMatchObject({ event: 'swap.event', a: 1 });
+    expect(parseLine(lines, 1)).toMatchObject({
+      event: 'swap_handler.issuer_failed',
+      error: 'boom',
+    });
+  });
+
+  it('[P0] bigints serialize (raw JSON.stringify throws, and every swap number is a bigint)', () => {
+    const { logger, lines } = capture();
+    logger.warn('swap.claim.refused', {
+      unredeemed: 1_000n,
+      nested: { cumulative: 15_000_000n },
+    });
+    expect(parseLine(lines)).toMatchObject({
+      unredeemed: '1000',
+      nested: { cumulative: '15000000' },
+    });
+  });
+
+  it('[P1] Errors are reduced to { name, message } — no stacks (signer-material policy)', () => {
+    const { logger, lines } = capture();
+    logger.error('swap.boom', { err: new TypeError('nope') });
+    const record = parseLine(lines) as { err: Record<string, unknown> };
+    expect(record.err).toEqual({ name: 'TypeError', message: 'nope' });
+    expect(lineAt(lines)).not.toContain('at ');
+  });
+
+  it('[P1] byte arrays and cycles never take the process down', () => {
+    const { logger, lines } = capture();
+    const cyclic: Record<string, unknown> = { name: 'loop' };
+    cyclic['self'] = cyclic;
+    expect(() =>
+      logger.warn('swap.weird', { key: new Uint8Array(32), cyclic })
+    ).not.toThrow();
+    expect(lineAt(lines)).toContain('<bytes 32>');
+    expect(lineAt(lines)).toContain('[circular]');
+  });
+
+  it('[P1] a repeated sibling object is NOT reported as a cycle', () => {
+    const { logger, lines } = capture();
+    const shared = { id: 7 };
+    logger.warn('swap.shared', { a: shared, b: shared });
+    expect(parseLine(lines)).toMatchObject({ a: { id: 7 }, b: { id: 7 } });
+  });
+
+  it('[P1] a throwing sink is swallowed', () => {
+    const logger = createConsoleLogger({
+      write: () => {
+        throw new Error('EPIPE');
+      },
+    });
+    expect(() => logger.error('swap.boom', {})).not.toThrow();
+  });
+
+  it('[P0] level filtering: default drops debug, keeps warn/error', () => {
+    const { logger, lines } = capture(DEFAULT_SWAP_LOG_LEVEL);
+    logger.debug('swap.debug', {});
+    logger.info('swap.info', {});
+    logger.warn('swap.warn', {});
+    logger.error('swap.error', {});
+    expect(
+      lines.map((l) => (JSON.parse(l) as { event: string }).event)
+    ).toEqual(['swap.info', 'swap.warn', 'swap.error']);
+  });
+
+  it('[P1] `silent` emits nothing at all', () => {
+    const { logger, lines } = capture('silent');
+    logger.error('swap.error', {});
+    expect(lines).toEqual([]);
+  });
+
+  it('[P0] SWAP_LOG_LEVEL is optional and degrades safely — never a required key', () => {
+    expect(resolveLogLevel(undefined)).toBe(DEFAULT_SWAP_LOG_LEVEL);
+    expect(resolveLogLevel('')).toBe(DEFAULT_SWAP_LOG_LEVEL);
+    expect(resolveLogLevel('LOUD')).toBe(DEFAULT_SWAP_LOG_LEVEL);
+    expect(resolveLogLevel(' DEBUG ')).toBe('debug');
+    expect(resolveLogLevel('error')).toBe('error');
+  });
+
+  it('[P1] buildLogRecord stamps ts + level and keeps the first string as `event`', () => {
+    const record = buildLogRecord(
+      'warn',
+      ['swap.event', { a: 1 }, 'trailing'],
+      '2026-08-16T00:00:00.000Z'
+    );
+    expect(record).toMatchObject({
+      ts: '2026-08-16T00:00:00.000Z',
+      level: 'warn',
+      event: 'swap.event',
+      a: 1,
+      extra: ['trailing'],
+    });
+  });
+});

--- a/packages/swap/src/logger.ts
+++ b/packages/swap/src/logger.ts
@@ -1,0 +1,189 @@
+/**
+ * Console-backed structured logger for the swap-node entrypoint (swap#136).
+ *
+ * ## Why this exists
+ *
+ * `startSwapNode()` falls back to `noopLogger()` when `config.logger` is
+ * absent, and `cli.ts` — the entrypoint the published Docker image runs
+ * (`ENTRYPOINT ["node", "dist/cli.js"]`) — never supplied one. Every
+ * `logger.warn?.(...)` in the swap node AND the logger handed to the SDK's
+ * `createSwapHandler` therefore went into the void: a maker that refused
+ * every swap after the first wrote NOTHING to `docker logs`, and the whole
+ * diagnosis had to be reconstructed from the client's bare
+ * `T00 Internal error`. The no-op default is fine for embedders (a library
+ * must not print uninvited); the bug was that the *process* entrypoint never
+ * replaced it.
+ *
+ * ## Shape
+ *
+ * One JSON object per line, so `docker logs` output is greppable and
+ * machine-parseable. Both call conventions in play are accepted:
+ *
+ *   - this repo's:   `warn('swap.event.name', { field: 1 })`
+ *   - the SDK's:     `warn({ event: 'swap_handler.issuer_failed', error })`
+ *
+ * ## Level
+ *
+ * `SWAP_LOG_LEVEL` (`debug|info|warn|error|silent`, default `info`). An env
+ * knob, deliberately NOT a config key: `swap:release` auto-deploys on green
+ * main, and a newly *required* config key crash-looped the live maker once
+ * already (swap#134). Unknown/absent values degrade to the default.
+ *
+ * ## Safety
+ *
+ * Serialization never throws and never escapes a log call:
+ *   - `bigint` → decimal string (raw `JSON.stringify` throws on bigint, and
+ *     essentially every interesting swap field is a bigint);
+ *   - `Error` → `{ name, message }` only — same policy as `errSummary()` in
+ *     `swap-node.ts`: stacks can capture surrounding closure state including
+ *     signer-key-derived intermediates;
+ *   - `Uint8Array` → `<bytes n>` (claims and keys never get printed);
+ *   - cycles → `'[circular]'`;
+ *   - anything still failing → a minimal fallback record.
+ */
+
+import type { SwapNodeLogger } from './swap-node.js';
+
+export type SwapLogLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent';
+
+const LEVEL_RANK: Record<SwapLogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+  silent: 100,
+};
+
+/** Level used when `SWAP_LOG_LEVEL` is unset or unrecognised. */
+export const DEFAULT_SWAP_LOG_LEVEL: SwapLogLevel = 'info';
+
+/** Env var read by {@link createConsoleLogger}. Optional — never required. */
+export const SWAP_LOG_LEVEL_ENV = 'SWAP_LOG_LEVEL';
+
+/** Cap on one serialized record, so a fat payload cannot flood the log. */
+const MAX_LINE_CHARS = 4096;
+
+export function resolveLogLevel(raw: string | undefined): SwapLogLevel {
+  const candidate = (raw ?? '').trim().toLowerCase();
+  return candidate in LEVEL_RANK
+    ? (candidate as SwapLogLevel)
+    : DEFAULT_SWAP_LOG_LEVEL;
+}
+
+export interface ConsoleLoggerOptions {
+  /** Defaults to `resolveLogLevel(process.env.SWAP_LOG_LEVEL)`. */
+  level?: SwapLogLevel;
+  /** Sink seam (tests). Defaults to stdout for debug/info, stderr for warn/error. */
+  write?: (level: SwapLogLevel, line: string) => void;
+  /** Clock seam (tests). */
+  now?: () => number;
+}
+
+/** Log-safe replacement for one value. Recursive; cycle- and bigint-aware. */
+function sanitize(value: unknown, seen: WeakSet<object>): unknown {
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'function') return '[function]';
+  if (typeof value === 'symbol') return value.toString();
+  if (value === null || typeof value !== 'object') return value;
+
+  if (value instanceof Error) {
+    return { name: value.name, message: value.message };
+  }
+  if (value instanceof Uint8Array) return `<bytes ${value.length}>`;
+  if (seen.has(value)) return '[circular]';
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) return value.map((v) => sanitize(v, seen));
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = sanitize(v, seen);
+    }
+    return out;
+  } finally {
+    // Ancestors only — a value repeated in sibling positions is not a cycle.
+    seen.delete(value);
+  }
+}
+
+/** Fold a logger call's varargs into one flat record. */
+export function buildLogRecord(
+  level: SwapLogLevel,
+  args: readonly unknown[],
+  isoTimestamp: string
+): Record<string, unknown> {
+  const record: Record<string, unknown> = { ts: isoTimestamp, level };
+  const seen = new WeakSet<object>();
+  const extras: unknown[] = [];
+
+  for (const arg of args) {
+    if (typeof arg === 'string') {
+      // First string is the event name (this repo's convention); the SDK
+      // passes no bare strings at all.
+      if (record['event'] === undefined) record['event'] = arg;
+      else extras.push(arg);
+      continue;
+    }
+    const clean = sanitize(arg, seen);
+    if (clean !== null && typeof clean === 'object' && !Array.isArray(clean)) {
+      // An SDK-style `{ event: '…' }` fills the same `event` slot a bare
+      // string would have.
+      Object.assign(record, clean);
+      continue;
+    }
+    extras.push(clean);
+  }
+  if (extras.length > 0) record['extra'] = extras;
+  return record;
+}
+
+function defaultWrite(level: SwapLogLevel, line: string): void {
+  if (level === 'warn' || level === 'error') process.stderr.write(line + '\n');
+  else process.stdout.write(line + '\n');
+}
+
+/**
+ * Build a {@link SwapNodeLogger} that writes one JSON line per record.
+ *
+ * Accepts both the `(event, fields)` and the `({ event, … })` call shapes,
+ * and each returned method is a standalone arrow function so it survives the
+ * `{ warn: logger.warn }` destructuring the swap node does when it forwards
+ * the logger into the SDK handler and the rate guard.
+ */
+export function createConsoleLogger(
+  options: ConsoleLoggerOptions = {}
+): SwapNodeLogger {
+  const level =
+    options.level ?? resolveLogLevel(process.env[SWAP_LOG_LEVEL_ENV]);
+  const threshold = LEVEL_RANK[level];
+  const write = options.write ?? defaultWrite;
+  const now = options.now ?? Date.now;
+
+  const emit =
+    (at: SwapLogLevel) =>
+    (...args: unknown[]): void => {
+      if (LEVEL_RANK[at] < threshold) return;
+      let line: string;
+      try {
+        line = JSON.stringify(
+          buildLogRecord(at, args, new Date(now()).toISOString())
+        );
+        if (line.length > MAX_LINE_CHARS) {
+          line = line.slice(0, MAX_LINE_CHARS - 16) + '…","truncated":true}';
+        }
+      } catch {
+        line = JSON.stringify({ level: at, event: 'swap.log.unserializable' });
+      }
+      try {
+        write(at, line);
+      } catch {
+        // A logger must never take the node down.
+      }
+    };
+
+  return {
+    debug: emit('debug'),
+    info: emit('info'),
+    warn: emit('warn'),
+    error: emit('error'),
+  };
+}

--- a/packages/swap/src/rolling-engine.ts
+++ b/packages/swap/src/rolling-engine.ts
@@ -89,6 +89,7 @@ import type {
   MultiChainClaimIssuer,
   RollingIssueClaimResult,
 } from './claim-issuer.js';
+import { classifyClaimIssuerError } from './claim-refusal.js';
 import {
   buildStaleRateReject,
   StaleRateError,
@@ -917,20 +918,40 @@ export class RollingSwapEngine {
         reservationTtlMs: legBExpiryMs - now + this.#reservationGraceMs,
       });
     } catch (err) {
-      const code =
+      if (
         (err as { code?: string }).code === 'INSUFFICIENT_INVENTORY' ||
         /insufficient/i.test(err instanceof Error ? err.message : '')
-          ? 'T04'
-          : 'T00';
+      ) {
+        this.#logger.warn?.('swap.rolling.insufficient_liquidity', {
+          pair: pairKey(pair),
+          targetAmount: targetAmount.toString(),
+          err: err instanceof Error ? err.message : String(err),
+        });
+        return buildRollingReject({
+          code: 'T04',
+          semantic: 'insufficient_funds',
+          message: 'insufficient liquidity',
+          reason: ROLLING_REJECT_REASONS.INSUFFICIENT_LIQUIDITY,
+        });
+      }
+      // swap#136 — same defect the legacy path had: this collapsed every
+      // diagnosable issuance failure (notably "<channelId>: <n> unredeemed")
+      // into an unlogged, unactionable `T00 claim issuance failed`. Classify
+      // it, log it, and put the reason on the wire.
+      const refusal = classifyClaimIssuerError(err);
+      this.#logger[refusal.level]?.('swap.rolling.claim_refused', {
+        pair: pairKey(pair),
+        reason: refusal.reason,
+        ilpCode: refusal.code,
+        clientMessage: refusal.message,
+        ...refusal.detail,
+      });
       return buildRollingReject({
-        code,
-        semantic: code === 'T04' ? 'insufficient_funds' : 'internal_error',
-        message:
-          code === 'T04' ? 'insufficient liquidity' : 'claim issuance failed',
-        reason:
-          code === 'T04'
-            ? ROLLING_REJECT_REASONS.INSUFFICIENT_LIQUIDITY
-            : ROLLING_REJECT_REASONS.CLAIM_ISSUE_FAILED,
+        code: refusal.code,
+        semantic: refusal.semantic,
+        message: refusal.message,
+        reason: refusal.reason,
+        detail: refusal.detail,
       });
     }
 

--- a/packages/swap/src/swap-node.claim-refusal.test.ts
+++ b/packages/swap/src/swap-node.claim-refusal.test.ts
@@ -1,0 +1,300 @@
+/**
+ * swap#136 defect 1 — the rejection that logged absolutely nothing.
+ *
+ * Live repro (devnet, 2026-08-16): after ONE successful swap the maker
+ * refused every subsequent swap with `{"code":"T00","message":"Internal
+ * error"}` and wrote not a single line to `docker logs`. The real cause was
+ * mundane — `channel-state.ts`'s `reserve()` refuses to issue a claim against
+ * a channel whose previous claim is still unredeemed, and says so
+ * (`0x0124a370…: 1000 unredeemed`) — but the message died in the SDK swap
+ * handler's `catch`, which logs `swap_handler.issuer_failed` into a no-op
+ * logger and returns `ctx.reject('T00', 'Internal error')`.
+ *
+ * These tests therefore assert on the OBSERVABLE surface only — what an
+ * operator reads in the logs and what a client reads off the wire — driving
+ * real gift-wrapped packets through the connector-facing packet handler
+ * (`setPacketHandler`), which is exactly what the connector calls in
+ * production. A test that only asserted the internal throw would have passed
+ * throughout the outage; `swap-node.channel-rebind.test.ts` had one.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { createServer, type Server } from 'node:http';
+
+import { wrapSwapPacketToToon } from '@toon-protocol/sdk';
+
+import { startSwapNode } from './swap-node.js';
+import type { SwapNodeConfig, SwapNodeInstance } from './swap-node.js';
+import { CLAIM_REFUSAL_REASONS } from './claim-refusal.js';
+
+const VALID_MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const CHAIN = 'evm:8453';
+const CHANNEL_ID = '0x' + '01'.repeat(32);
+const CHAIN_RECIPIENT = '0x' + '11'.repeat(20);
+const DESTINATION = 'g.toon.swap.fixture';
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map((s) => new Promise<void>((resolve) => s.close(() => resolve())))
+  );
+});
+
+interface PacketRequest {
+  amount: string;
+  destination: string;
+  data: string;
+  executionCondition?: string;
+}
+interface PacketResponse {
+  accept: boolean;
+  code?: string;
+  message?: string;
+  data?: string;
+  rejectReason?: { code: string; message: string };
+}
+type PacketHandlerFn = (request: PacketRequest) => Promise<PacketResponse>;
+
+interface LogLine {
+  level: 'debug' | 'info' | 'warn' | 'error';
+  args: unknown[];
+}
+
+function capturingLogger(sink: LogLine[]): SwapNodeConfig['logger'] {
+  const at =
+    (level: LogLine['level']) =>
+    (...args: unknown[]): void => {
+      sink.push({ level, args });
+    };
+  return {
+    debug: at('debug'),
+    info: at('info'),
+    warn: at('warn'),
+    error: at('error'),
+  };
+}
+
+/** Flatten a captured log line to one searchable string. */
+function renderLine(line: LogLine): string {
+  return line.args
+    .map((a) =>
+      typeof a === 'string'
+        ? a
+        : JSON.stringify(a, (_k, v: unknown) =>
+            typeof v === 'bigint' ? v.toString() : v
+          )
+    )
+    .join(' ');
+}
+
+function word(hex: string): string {
+  return hex.toLowerCase().padStart(64, '0');
+}
+
+/** `eth_call`-only JSON-RPC whose `channels()` answer is `cumulativePaid`. */
+async function startFakeChainRpc(cumulativePaid: bigint): Promise<string> {
+  const server = createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk: Buffer) => {
+      body += chunk.toString();
+    });
+    req.on('end', () => {
+      const json = JSON.parse(body) as { id: number };
+      const result =
+        '0x' +
+        [
+          word('11'.repeat(20)),
+          word('22'.repeat(20)),
+          word(3n.toString(16)),
+          word(cumulativePaid.toString(16)),
+          word(1_000_000n.toString(16)),
+          word(0n.toString(16)),
+          word((1).toString(16)),
+        ].join('');
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ jsonrpc: '2.0', id: json.id, result }));
+    });
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('expected a bound TCP address');
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function bootNode(rpcUrl: string): Promise<{
+  instance: SwapNodeInstance;
+  handler: PacketHandlerFn;
+  logs: LogLine[];
+}> {
+  const logs: LogLine[] = [];
+  let captured: PacketHandlerFn | undefined;
+  const connector = {
+    sendPacket: async () => ({
+      type: 'reject' as const,
+      code: 'F02',
+      message: 'no route (fixture)',
+    }),
+    registerPeer: async () => undefined,
+    removePeer: async () => undefined,
+    setPacketHandler: (h: unknown) => {
+      captured = h as PacketHandlerFn;
+    },
+    close: async () => undefined,
+  } as unknown as SwapNodeConfig['connector'];
+
+  const instance = await startSwapNode({
+    mnemonic: VALID_MNEMONIC,
+    connector,
+    relayUrls: ['ws://localhost:0'],
+    blsPort: 0,
+    publisher: { publish: async () => undefined },
+    chains: ['evm'],
+    logger: capturingLogger(logs),
+    swapPairs: [
+      {
+        from: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+        to: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+        rate: '1.0',
+      },
+    ],
+    // ONE channel — the single-channel deployment the live maker runs.
+    channels: {
+      [CHAIN]: [
+        {
+          channelId: CHANNEL_ID,
+          cumulativeAmount: 0n,
+          nonce: 0n,
+          updatedAt: 0,
+        },
+      ],
+    },
+    inventory: { [CHAIN]: 15_000_000n },
+    chainProviders: [
+      {
+        chainType: 'evm',
+        chainId: CHAIN,
+        rpcUrl,
+        registryAddress: '0x' + '33'.repeat(20),
+        tokenAddress: '0x' + '44'.repeat(20),
+        tokenNetworkAddress: '0x' + '55'.repeat(20),
+        channelAddress: '0x' + 'aa'.repeat(20),
+      },
+    ],
+  });
+  if (!captured) throw new Error('setPacketHandler was never called');
+  return { instance, handler: captured, logs };
+}
+
+/** A real NIP-59 gift-wrapped swap request from a fresh ephemeral sender. */
+function swapPacket(
+  recipientPubkey: string,
+  senderByte: number,
+  amount: bigint
+): PacketRequest {
+  const { ilpPrepare } = wrapSwapPacketToToon({
+    rumor: {
+      pubkey: '',
+      created_at: Math.floor(Date.now() / 1000),
+      kind: 1,
+      content: '',
+      tags: [
+        ['swap-from', `USDC:${CHAIN}`],
+        ['swap-to', `USDC:${CHAIN}`],
+        ['chain-recipient', CHAIN_RECIPIENT],
+      ],
+    },
+    senderSecretKey: new Uint8Array(32).fill(senderByte),
+    recipientPubkey,
+    destination: DESTINATION,
+    amount,
+  });
+  return {
+    amount: ilpPrepare.amount,
+    destination: ilpPrepare.destination,
+    data: ilpPrepare.data,
+  };
+}
+
+describe('swap#136 — an unredeemed channel produces a LOGGED, actionable refusal', () => {
+  it('[P0] the live repro: swap #1 fulfils; swap #2 from a fresh sender is refused loudly', async () => {
+    // cumulativePaid = 0 on-chain → sender #1's claim is unredeemed, so the
+    // single provisioned channel cannot be rebound to sender #2.
+    const rpcUrl = await startFakeChainRpc(0n);
+    const { instance, handler, logs } = await bootNode(rpcUrl);
+    try {
+      const recipient = instance.identity.pubkey;
+
+      const first = await handler(swapPacket(recipient, 1, 1_000n));
+      expect(first.accept).toBe(true);
+
+      const inventoryBefore = { ...instance.health().inventory };
+      const availableBefore = { ...instance.health().inventoryAvailable };
+      logs.length = 0;
+
+      const second = await handler(swapPacket(recipient, 2, 1_000n));
+
+      // ---- (a) the maker LOGS the real reason ---------------------------
+      const refusalLogs = logs.filter(
+        (l) => l.level === 'warn' || l.level === 'error'
+      );
+      expect(refusalLogs.length).toBeGreaterThan(0);
+      const rendered = refusalLogs.map(renderLine).join('\n');
+      // names the channel …
+      expect(rendered).toContain(CHANNEL_ID);
+      // … and the unredeemed amount …
+      expect(rendered).toContain('1000');
+      // … under a greppable reason.
+      expect(rendered).toContain(CLAIM_REFUSAL_REASONS.CHANNEL_UNREDEEMED);
+
+      // ---- (b) the CLIENT gets something it can act on ------------------
+      expect(second.accept).toBe(false);
+      expect(second.code).not.toBe('T00');
+      expect(second.code).toBe('T04');
+      expect(second.message).not.toBe('Internal error');
+      expect(second.message).toContain(
+        CLAIM_REFUSAL_REASONS.CHANNEL_UNREDEEMED
+      );
+      expect(second.message).toContain(CHANNEL_ID);
+      expect(second.message?.toLowerCase()).toContain('redeem');
+      // Semantic reason survives the connector's REJECT_CODE_MAP as T04.
+      expect(second.rejectReason?.code).toBe('insufficient_funds');
+      // Machine-readable discriminator in the ILP reject `data`.
+      const data = JSON.parse(
+        Buffer.from(second.data ?? '', 'base64').toString('utf8')
+      ) as Record<string, unknown>;
+      expect(data['reason']).toBe(CLAIM_REFUSAL_REASONS.CHANNEL_UNREDEEMED);
+      expect(data['channelId']).toBe(CHANNEL_ID);
+      expect(data['unredeemed']).toBe('1000');
+      expect(data['chain']).toBe(CHAIN);
+
+      // ---- (c) defect 2: the failed swap moved no inventory -------------
+      expect(instance.health().inventory).toEqual(inventoryBefore);
+      expect(instance.health().inventoryAvailable).toEqual(availableBefore);
+    } finally {
+      await instance.stop();
+    }
+  }, 20_000);
+
+  it('[P0] once the first claim IS redeemed on-chain, the next sender swaps normally', async () => {
+    // Same topology, but the chain reports the claim settled → rebind is safe.
+    const rpcUrl = await startFakeChainRpc(1_000n);
+    const { instance, handler } = await bootNode(rpcUrl);
+    try {
+      const recipient = instance.identity.pubkey;
+      expect((await handler(swapPacket(recipient, 1, 1_000n))).accept).toBe(
+        true
+      );
+      expect((await handler(swapPacket(recipient, 2, 1_000n))).accept).toBe(
+        true
+      );
+    } finally {
+      await instance.stop();
+    }
+  }, 20_000);
+});

--- a/packages/swap/src/swap-node.ts
+++ b/packages/swap/src/swap-node.ts
@@ -71,6 +71,7 @@ import {
 } from './payment-channel-signer.js';
 import type { PaymentChannelSigner } from './payment-channel-signer.js';
 import { MultiChainClaimIssuer } from './claim-issuer.js';
+import { createClaimRefusalDiagnostics } from './claim-refusal.js';
 import { SwapNodeStartError } from './errors.js';
 import {
   JsonFileSwapStateStore,
@@ -664,6 +665,17 @@ export function buildSignerAddresses(
   return result;
 }
 
+/**
+ * Library default: silence. An embedded swap node must not print into its
+ * host's stdout uninvited.
+ *
+ * swap#136 — this is NOT the right default for a *process*, and the CLI
+ * (`cli.ts`, the entrypoint the published image runs) used to inherit it,
+ * which is why a maker that refused every swap for hours logged nothing at
+ * all. `cli.ts`'s `installDefaultLogger()` now replaces it with
+ * `createConsoleLogger()` (`logger.ts`). If you add another entrypoint, do
+ * the same there — do not make this function print.
+ */
 function noopLogger(): SwapNodeLogger {
   return {
     debug: () => undefined,
@@ -1421,10 +1433,18 @@ export async function startSwapNode(
       ? normalizeRateProvider(config.rateProvider)
       : undefined;
 
+  // swap#136 — reclaim the diagnosis the SDK handler throws away. `instrument`
+  // logs (and captures) whatever `issueClaim` threw; `wrap` (applied
+  // outermost, below) turns the SDK's blanket `T00 Internal error` into that
+  // captured refusal's code/message/data. See `claim-refusal.ts`.
+  const refusalDiagnostics = createClaimRefusalDiagnostics({ logger });
+
   const swapHandler = createSwapHandler({
     recipientSecretKey: identity.secretKey,
     swapPairs: [...config.swapPairs],
-    claimIssuer,
+    claimIssuer: refusalDiagnostics.instrument(
+      claimIssuer
+    ) as unknown as typeof claimIssuer,
     ...(sdkRateProvider && { rateProvider: sdkRateProvider }),
     // Issue #46 — prefer the operator's set (verbatim, SDK contract), else
     // the swap-node-owned persistent replay set when persistence is enabled,
@@ -1456,10 +1476,15 @@ export async function startSwapNode(
       })
     : swapHandler;
 
+  // swap#136 — outermost, so it sees the final response of whatever ran
+  // inside (the staleness gate never produces the SDK's generic T00, so
+  // decorating outside the gate is safe and covers every dispatch path).
+  const diagnosedSwapHandler = refusalDiagnostics.wrap(gatedSwapHandler);
+
   // 9/10. HandlerRegistry — register on kind:1059 (NIP-59 gift-wrap).
   const registry = new HandlerRegistry();
   try {
-    registry.on(1059, gatedSwapHandler);
+    registry.on(1059, diagnosedSwapHandler);
   } catch (err) {
     throw new SwapNodeStartError(
       'HANDLER_REGISTRATION_FAILED',


### PR DESCRIPTION
Fixes #136.

Two defects that together turned a mundane live condition — "the previous claim on this channel hasn't been redeemed yet" — into a multi-hour outage diagnosis on devnet 2026-08-16.

## Defect 1 — a rejection that logged absolutely nothing

**Where it was swallowed**

| # | file:line (pre-fix) | what it did |
|---|---|---|
| 1 | `packages/swap/src/claim-issuer.ts:340-343` | `catch (err) { hold.undo(); throw err; }` — unwound and rethrew in **total silence** |
| 2 | `@toon-protocol/sdk` `dist/chunk-KFYGI7VV.js:1183-1203` (`createSwapHandler`) | recognises only `INSUFFICIENT_INVENTORY`; everything else → `logger.error({event:'swap_handler.issuer_failed'})` + `ctx.reject('T00','Internal error')` |
| 3 | same file, `:1205-1213` | the `swap_handler.encrypt_failed` branch — a second `T00 Internal error`, error object **discarded entirely** |
| 4 | `packages/swap/src/rolling-engine.ts:918-932` | rolling path had the identical collapse: unlogged `T00 claim issuance failed` |

…and the logger those SDK statements wrote to was a **no-op**. Root cause: `packages/swap/src/cli.ts` — the entrypoint `deploy/swap/Dockerfile` runs (`ENTRYPOINT ["node", "dist/cli.js"]`) — never supplied `config.logger`, so `startSwapNode()` installed `noopLogger()` (`swap-node.ts:1021`) and every `logger.warn?.(…)` in the swap node **and** the logger it forwards into the SDK handler went into the void. The message was there the whole time (`channel-state.ts:360`, `0x0124a370…: 1000 unredeemed`) — nobody was listening.

**Fixes**

- `logger.ts` — a JSON-line console logger, installed by `cli.ts`'s new `installDefaultLogger()`. Accepts both call shapes in play (`warn('event', {fields})` and the SDK's `warn({event, error})`), serializes bigints (raw `JSON.stringify` throws on them, and every interesting swap number is one), reduces `Error`s to `{name, message}` per the existing `errSummary` no-stacks policy, and never throws. `noopLogger()` stays the *library* default with a comment saying why, since an embedded node must not print uninvited.
- `claim-refusal.ts` — classifies whatever the claim issuer threw, logs it at warn/error before the SDK ever sees it, and replaces the SDK's blanket `T00` on the wire using the refusal captured *for that packet* (an `AsyncLocalStorage` slot — concurrent `handlePacket` calls can't cross-contaminate; there's a test).
- `channel-state.ts` throws **structured** refusals (`{channelId, reason, unredeemed}`) instead of only a prose string, so the numbers reach the log line and the reject `data`. The human message is byte-identical to before (swap#113's test still passes).
- The rolling coupled-leg path gets the same classification, and `INSUFFICIENT_INVENTORY` keeps its existing T04 "Insufficient liquidity" contract untouched on both paths.

**What the client sees now instead of `T00 Internal error`**

```
code:    T04                                    (was T00)
message: channel_unredeemed: the maker's payment channel 0x0124a370… on evm:8453
         still has 1000 unredeemed unit(s); redeem or settle the previous claim
         before swapping again
rejectReason.code: insufficient_funds           → connector REJECT_CODE_MAP → wire T04
data (base64 JSON): {"reason":"channel_unredeemed","chain":"evm:8453",
                     "assetCode":"USDC","channelId":"0x0124a370…",
                     "unredeemed":"1000","refusals":[…]}
```

Full mapping, chosen to match how refusals are already coded here (`INSUFFICIENT_INVENTORY`→T04/`insufficient_funds` in the SDK, `stale_rate`→T99/`stale_rate` in `rate-staleness.ts`, F-class for "don't retry" in `rolling-engine.ts`) and to use only semantic reasons the connector's `REJECT_CODE_MAP` actually knows:

| reason | wire | semantic | why |
|---|---|---|---|
| `channel_unredeemed` | **T04** | `insufficient_funds` | maker's channel capital is locked in an unredeemed claim; the sender fixes it by redeeming → T-class, retryable |
| `no_channel_available` | **F99** | `application_error` | no channel provisioned for this sender at all; retrying now cannot help |
| `persist_failed` / `signing_failed` / `claim_encrypt_failed` | T00 | `internal_error` | genuinely internal — but they now say which one |

And in `docker logs`: `{"ts":…,"level":"warn","event":"swap.claim.refused","reason":"channel_unredeemed","ilpCode":"T04","channelId":"0x0124a370…","unredeemed":"1000",…}`.

**Still owed by the SDK.** `swap_handler.encrypt_failed` discards its error object before any caller-supplied seam, so no wrapper on this side can recover the message. What we do is *identify* it — a blanket `T00 Internal error` after a claim was issued successfully can only be that branch — log it at error and name it on the wire. The real fix (surface the error, reject with something better than `T00 Internal error`) belongs in `packages/sdk/src/swap-handler.ts` upstream.

## Defect 2 — a failed swap leaked inventory

`packages/swap/src/claim-issuer.ts:239-240` used `SwapInventory.credit()` — the **operator refill** primitive (`available += n` *and* `total += n`) — to unwind a `debit()` (`available -= n`). So `total` ratcheted upward on every failure, and `total` is what the maker advertises in kind:10032 (`swap-node.ts:1976`) and reports as `inventory` on `/health`. Observed live: `15 001 000` against a configured `15 000 000`.

New `SwapInventory.refundDebit()` is the exact inverse of `debit` — restores `available` only. `credit` is left alone as the refill primitive (with a doc note pointing at `refundDebit`).

## Tests

- **`swap-node.claim-refusal.test.ts`** (new) — the regression test for defect 1, asserting only the *observable* surface. Boots a real node against a fake chain RPC reporting `cumulativePaid = 0`, sends two real NIP-59 gift-wrapped swaps from different ephemeral senders through the connector-facing `setPacketHandler` callback, and asserts: (a) a warn/error log line naming the channel **and** the unredeemed amount **and** a greppable reason, (b) a reject whose code/message/`rejectReason`/`data` a client can act on, (c) inventory byte-identical across the failure. Plus the inverse: once the chain reports the claim redeemed, the next sender swaps fine. Verified to FAIL against the pre-fix code.
- **`claim-issuer.inventory-rollback.test.ts`** (new) — defect 2, across every failure mode the issuer has (signer, channel reservation, write-ahead persist), including a repeated-failure case for the cumulative live symptom. 4 of 5 fail against the pre-fix code.
- **`claim-refusal.test.ts`** (new) — per-condition classification, `INSUFFICIENT_INVENTORY` pass-through, the encrypt-path inference, and concurrent-packet isolation.
- **`logger.test.ts`** (new) — the entrypoint wiring (`installDefaultLogger`), both call shapes, bigint/Error/cycle/byte-array safety, level filtering, and that `SWAP_LOG_LEVEL` degrades safely.

`pnpm run gate:correctness` PASS (0 errors / 352 warnings, at the frozen baseline), `pnpm test` 409 passed / 2 skipped.

## Constraints honoured

- **No new required config key.** The only new knob is the optional `SWAP_LOG_LEVEL` env var; unset or unrecognised degrades to `info` and the maker never fails boot over it — `:release` auto-deploys, and #134's required key already crash-looped the live maker once.
- No devnet box was touched.
- Rebased onto `main` after #135 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
