### PR TITLE
Install the fleet no-op merge guard shim — a PR must not merge green and change nothing

### DIFF
--- a/.github/workflows/empty-pr-guard-shim.yml
+++ b/.github/workflows/empty-pr-guard-shim.yml
@@ -1,0 +1,43 @@
+# empty-pr-guard shim — puts this repo's PRs under the fleet's no-op merge
+# guard in toon-meta (connector#1008: a PR merged green, closed its ticket,
+# and changed zero files).
+#
+# CANONICAL COPY. This file is fanned out VERBATIM to every factory repo as
+# .github/workflows/empty-pr-guard-shim.yml (toon-meta itself needs no shim —
+# its empty-pr-guard.yml carries the same trigger directly). When onboarding a
+# new factory repo, copy this file unchanged; when changing it, change it here
+# first and re-fan-out. Verify it actually landed in every repo before relying
+# on it — the #329 lesson (a shim that only exists as a canonical copy was
+# never installed).
+#
+# Same fleet convention as pr-housekeeping-shim.yml / auto-merge-shim.yml
+# (thin per-repo shim → toon-meta reusable workflow via workflow_call), kept as
+# a SIBLING file so a problem in one forwarder cannot take down another.
+#
+# TWO THINGS THIS SHIM DOES NOT NEED, both unusual for a shim here:
+#   * no `secrets: inherit` — the guard reads nothing but the PR's own merge
+#     ref via the default GITHUB_TOKEN's checkout, and makes no API call and no
+#     write of any kind. Handing it FACTORY_OPS_TOKEN would widen a monitored
+#     credential (#271) for nothing.
+#   * no branch filter — this is not factory plumbing that only matters on
+#     `sandcastle/` and `agent/` branches. A human's duplicate PR is exactly
+#     what merged empty in connector#1008, so every PR is checked.
+#
+# `synchronize` is not optional: a PR that had a real diff can BECOME a no-op
+# when its branch is updated onto a base that has since acquired the same
+# content. That is the #1008 shape, and under strict branch protection (#272)
+# a stale PR must be updated before it can merge — so this trigger is what
+# re-asks the question at the last moment before the merge button lights up.
+
+name: empty-pr-guard-shim
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  empty-pr-guard:
+    uses: toon-protocol/toon-meta/.github/workflows/empty-pr-guard.yml@main


### PR DESCRIPTION
Installs this repo's copy of the fleet no-op merge guard, landed in [toon-meta#405](https://github.com/toon-protocol/toon-meta/pull/405).

**What it guards.** `connector#1008` merged as `610c6860` and `git show 610c6860 --numstat` returns **zero files** — a second PR opened from the same branch 17 minutes after `connector#1000` had already merged that branch's content, so its squash landed an empty commit while its title and ticket history claimed the work was done. Green checks, a closed ticket, a merge commit, and no change. Nothing noticed; a human caught it by diffing the file.

Nothing could have caught it from the PR page either: GitHub's Files-changed tab is the **three-dot** diff and #1008's was not empty. What was empty was the **merge result**.

**What this file does.** Forwards this repo's `pull_request` events to `toon-protocol/toon-meta/.github/workflows/empty-pr-guard.yml@main`, which checks out `refs/pull/N/merge` — the merge of the head branch into the base tip, which a `pull_request` run already checks out — and diffs it against its base parent. That diff **is** what the squash commit would carry. Empty diff, empty merge, red check with a message naming the shape and the recovery.

Verbatim copy of the canonical shim at `toon-meta/scripts/factory/empty-pr-guard-shim.yml`, diffed against it before this PR was opened.

**No credential, no branch filter.** No `secrets: inherit` — the guard makes no API call and no write, so handing it `FACTORY_OPS_TOKEN` would widen a monitored credential for nothing. No `sandcastle/`/`agent/` filter — a human's duplicate PR is exactly what merged empty.

**How it blocks.** `checksVerdict` counts any non-plumbing red check as `failing`, so from this merge on, an empty PR here is ineligible for the fleet auto-merge pass — no branch-protection change needed. Making it hard-block a *human* merge is a separate, per-repo choice: add the job to this repo's aggregate required check.

**Behaviour on a legitimate no-op:** there isn't one. Checked across all eleven factory repos before building this — nothing here merges an empty PR on purpose, and no release, tag or deploy flow rides an empty commit (moving tags move by `docker buildx imagetools create`). A conflicted PR, which has no merge ref, warns and passes.

Part of the guard's fleet fan-out. Full rationale: `toon-meta/FACTORY.md` → "Empty-PR guard (no-op merges)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
