### PR TITLE
An operator who adds real capital has no route — corroborate it against on-chain channel funding (#142)

### DIFF
--- a/.changeset/issue-142-operator-route-new-capital.md
+++ b/.changeset/issue-142-operator-route-new-capital.md
@@ -1,0 +1,27 @@
+---
+'@toon-protocol/swap': minor
+---
+
+Operator route for genuinely new capital: `POST /admin/inventory/deposit`.
+
+#140's `/admin/inventory/credit` applies only what an on-chain **redemption**
+corroborates, which is right for recycling and leaves an operator who actually
+**adds** capital — funds a new channel, tops up a deposit — with no route at
+all (`SwapInventory.credit` had no caller, and raising config inventory does
+not reliably take: the persisted snapshot wins for keys it has already seen,
+issue #130).
+
+The new route corroborates against the pool's on-chain channel funding, Σ
+`cumulativePaid + deposit`, and credits only the excess of that over the pool's
+own `total`. `deposit` alone is unusable — it is the *remaining un-paid-out*
+balance and falls on every redemption — while the sum is invariant under
+redemption and rises only when capital actually enters a channel. Because
+crediting raises `total`, and `total` is what the next read is compared
+against, a repeated call measures a gap that has already closed: double
+crediting is structurally impossible, with no new persisted ledger.
+
+Also adds the optional `getFundingPosition` capability to the
+`ChannelOnChainReader` seam (implemented for EVM as one `eth_call` returning
+both words, so they can never straddle a redemption). Readers without it cause
+the route to refuse (503), never to guess. `SWAP_ADMIN_TOKEN` still gates the
+write and an unset token still disables it (503); no new config key.

--- a/deploy/swap/README.md
+++ b/deploy/swap/README.md
@@ -116,6 +116,49 @@ the chain key of the `chainProviders` entry you already have.
 | `GET /admin/inventory` | none | Per-pool `available`/`total`/`unsettled`/`inFlight`/`free`, per-channel issued-vs-redeemed-on-chain, and a `blockedReason` naming what is holding the capacity when `free` is 0. |
 | `POST /admin/inventory/reconcile` | token | Force a chain-truth pass now; returns what it recycled. |
 | `POST /admin/inventory/credit` | token | `{ assetCode, chain, amount? }` — recycle burned capital. Applies **only** what an on-chain redemption corroborates: an uncorroborated request (or one larger than the chain backs) is refused `409` with nothing applied. |
+| `POST /admin/inventory/deposit` | token | **swap#142.** `{ assetCode, chain, amount?, dryRun? }` — book genuinely NEW capital. Applies **only** what the pool's on-chain channel funding corroborates. |
+
+### Adding capital (swap#142)
+
+`credit` recycles capital the pool already counted — it can restore
+`available`, never raise `total`. Genuinely *adding* capital (funding a new
+channel, topping up a deposit) is `deposit`, and it is the only route that
+raises `total`. Editing the configured inventory is not a substitute: the
+persisted snapshot wins over config for pool keys the node has already seen
+(issue #130), so a config bump silently does nothing.
+
+Procedure — **fund the channel on chain first**, then tell the node:
+
+```sh
+# 1. Deposit into a channel this maker has provisioned (chain side).
+# 2. See what the node will credit, without changing anything:
+curl -sX POST http://127.0.0.1:<blsPort>/admin/inventory/deposit \
+  -H "authorization: Bearer $SWAP_ADMIN_TOKEN" -H 'content-type: application/json' \
+  -d '{"assetCode":"USDC","chain":"evm:base:8453","dryRun":true}'
+# 3. Same call without dryRun applies it (add "amount" to assert an exact figure).
+```
+
+What it corroborates against is Σ `cumulativePaid + deposit` over the pool's
+channels — **not** the `deposit` field alone, which is the *remaining
+un-paid-out* balance and falls on every redemption. The sum is invariant
+under redemption and rises only when capital actually enters a channel. Only
+the excess of that sum over the pool's `total` is credited, and crediting
+raises `total` — so the gap a repeat call measures has already closed, and
+double-crediting is impossible without any extra bookkeeping to lose.
+
+Refusals, all with nothing applied:
+
+| Status | Meaning |
+| --- | --- |
+| `409 uncorroborated` | the chain shows no more capital than the pool already booked — the deposit has not landed, or it went somewhere this node does not read |
+| `409 exceeds_corroborated` | `amount` is larger than the chain backs |
+| `503 chain_unreadable` | a channel read failed; the corroborated total would be incomplete |
+| `503 funding_unreadable` | no on-chain reader, or one that cannot read funding positions (non-EVM until swap#141) |
+| `404 unknown_pool` | no channel state for that pool |
+
+Capital sitting in the payout wallet but not yet placed in a channel is **not**
+creditable — the chain shows no channel holding it. Move it into a channel and
+it becomes corroborable.
 
 **Protection.** Two layers:
 
@@ -133,6 +176,36 @@ the chain key of the `chainProviders` entry you already have.
 `GET` is unauthenticated because it discloses strictly less than the
 already-unauthenticated `GET /health`, and an operator diagnosing a stalled
 maker should not be blocked on a secret they may not have set.
+
+### Known: a small historical `total` inflation
+
+Before swap#137, a *failed* swap unwound its inventory hold with `credit()`,
+which raises `available` **and** `total`, so every failure left `total` one
+swap-notional too high. #137 fixed the unwind and #140's reconciler restored
+`available`; the live devnet maker therefore reads `available` 15 000 000
+(correct) against `total` 15 003 500. The error is static — it cannot grow —
+and it is deliberately **not** corrected by any live write path:
+
+- `total` is what kind:10032 advertises, so the maker over-advertises by
+  0.023 %. A counterparty sizing a swap against the inflated figure is refused
+  at issuance with a benign `T04`; it is never handed a claim the maker cannot
+  honor.
+- A reconcile that recomputed `total` from configured inventory would be a
+  *downward* write derived from figures the node does not durably own (config
+  loses to the snapshot for seen keys, issue #130; the state file is the only
+  ledger of additions and the documented reset deletes it). Firing wrongly, it
+  would shrink `total` below capital the maker really holds — turning a
+  bounded cosmetic error into an unbounded one, automatically, on a
+  `:release` auto-deploy.
+- It self-heals: `POST /admin/inventory/deposit` converges `total` onto chain
+  truth **from below**, so the next genuine top-up credits the top-up minus
+  the 3 500 and lands `total` exactly on the chain's figure. The residue moves
+  into `available` being 3 500 low, which is the under-serving (safe)
+  direction.
+
+If it must be exact sooner, do it with the node **down** — stop the maker,
+edit the persisted pool entry in `swap-node-state.json`, restart. That is a
+deliberate human action, not a route that can be fired by accident.
 
 ## Runtime user & filesystem
 

--- a/packages/swap/src/admin-surface.ts
+++ b/packages/swap/src/admin-surface.ts
@@ -10,13 +10,32 @@
  * `nonce`/`cumulativeAmount` BELOW claims already issued and invites a
  * replay — see `state-store.ts`).
  *
- * Three routes, mounted on the existing BLS server under `/admin`:
+ * Four routes, mounted on the existing BLS server under `/admin`:
  *
  * - `GET  /admin/inventory`           — read: per-pool buckets, per-channel
  *   issued-vs-redeemed, and an explicit reason when issuance is blocked.
  * - `POST /admin/inventory/reconcile` — write: force a chain-truth pass now.
  * - `POST /admin/inventory/credit`    — write: recycle burned capital, and
  *   ONLY the amount an on-chain redemption corroborates.
+ * - `POST /admin/inventory/deposit`   — write (swap#142): book genuinely NEW
+ *   capital, and ONLY the amount the pool's on-chain channel funding
+ *   corroborates.
+ *
+ * ## Recycling vs. new capital (swap#142)
+ *
+ * `credit` and `deposit` answer two different questions and must not be
+ * confused:
+ *
+ * | | corroborated by | moves |
+ * | --- | --- | --- |
+ * | `credit` | an on-chain **redemption** (`cumulativePaid` rose) | `available` only — a redemption returns capital already counted, so `total` must not move |
+ * | `deposit` | on-chain **channel funding** (`cumulativePaid + deposit` exceeds `total`) | `available` AND `total` — this is capital the pool did not have before |
+ *
+ * Before swap#142 the second had no route at all: `SwapInventory.credit` had
+ * no caller, and raising the configured inventory does not reliably take,
+ * because the persisted snapshot wins over config for keys it has already
+ * seen (issue #130). An operator who funded a new channel could only redeploy
+ * and hope.
  *
  * ## Protection
  *
@@ -27,8 +46,8 @@
  *    connector's own `/admin` surface gets. Mounting under `/admin` (rather
  *    than inventing a new prefix) is what makes that existing rule cover
  *    these routes.
- * 2. **Writes are token-gated and default-denied.** Both `POST` routes
- *    require the operator token (`SWAP_ADMIN_TOKEN` →
+ * 2. **Writes are token-gated and default-denied.** Every `POST` route
+ *    requires the operator token (`SWAP_ADMIN_TOKEN` →
  *    `SwapNodeConfig.adminToken`) in `Authorization: Bearer …` or
  *    `X-Swap-Admin-Token`, compared in constant time. When no token is
  *    configured the writes are DISABLED (503) rather than open — a maker
@@ -47,8 +66,10 @@ import { createHash, timingSafeEqual } from 'node:crypto';
 import type { Context, Hono } from 'hono';
 
 import type { SwapInventory } from './inventory.js';
+import { SwapInventoryError } from './errors.js';
 import type {
   ChannelRedemptionObservation,
+  PoolFundingReading,
   ReconcileResult,
   SwapInventoryReconciler,
 } from './inventory-reconciler.js';
@@ -314,6 +335,62 @@ interface CreditBody {
   amount?: unknown;
 }
 
+interface DepositBody extends CreditBody {
+  dryRun?: unknown;
+}
+
+/** JSON-safe projection of a pool's on-chain funding read (swap#142). */
+function serializeFunding(
+  reading: PoolFundingReading
+): Record<string, unknown> {
+  return {
+    pool: reading.pool,
+    supported: reading.supported,
+    chainFundedTotal: reading.chainFundedTotal.toString(),
+    readAt: reading.readAt,
+    channels: reading.channels.map((c) => ({
+      channelId: c.channelId,
+      cumulativePaid:
+        c.cumulativePaid === null ? null : c.cumulativePaid.toString(),
+      deposit: c.deposit === null ? null : c.deposit.toString(),
+      funded: c.funded === null ? null : c.funded.toString(),
+      observedAt: c.observedAt,
+      ...(c.error !== undefined && { error: c.error }),
+    })),
+    errors: [...reading.errors],
+  };
+}
+
+/**
+ * Parse and validate the `{ assetCode, chain, amount? }` shape both write
+ * routes share. Returns either the parsed fields or the Response to send.
+ */
+function parsePoolBody(
+  body: CreditBody
+):
+  | { ok: true; assetCode: string; chain: string; amount?: bigint }
+  | { ok: false; reason: string } {
+  const { assetCode, chain } = body;
+  if (typeof assetCode !== 'string' || assetCode.length === 0) {
+    return { ok: false, reason: 'assetCode is required' };
+  }
+  if (typeof chain !== 'string' || chain.length === 0) {
+    return { ok: false, reason: 'chain is required' };
+  }
+  if (body.amount === undefined) return { ok: true, assetCode, chain };
+  let amount: bigint;
+  try {
+    amount = BigInt(body.amount as string | number | bigint);
+  } catch {
+    return {
+      ok: false,
+      reason: 'amount must be a decimal integer (string or number)',
+    };
+  }
+  if (amount <= 0n) return { ok: false, reason: 'amount must be positive' };
+  return { ok: true, assetCode, chain, amount };
+}
+
 /** Register `/admin/*` on the BLS Hono app. */
 export function registerAdminRoutes(app: Hono, deps: AdminSurfaceDeps): void {
   /** Returns a Response to send when the caller is not authorized, else null. */
@@ -466,5 +543,154 @@ export function registerAdminRoutes(app: Hono, deps: AdminSurfaceDeps): void {
       credited: sumRestored(applied).toString(),
       result: serializeReconcile(applied),
     });
+  });
+
+  /**
+   * swap#142 — book genuinely NEW capital.
+   *
+   * `{ assetCode, chain, amount?, dryRun? }`. The corroboration is the pool's
+   * on-chain channel funding, Σ `cumulativePaid + deposit`, versus the pool's
+   * own `total`; only the excess of chain proof over booked claim is credited,
+   * and crediting closes that excess — see
+   * `SwapInventory.creditCorroboratedFunding` for why that makes a repeat call
+   * a structural no-op rather than a double credit.
+   *
+   * `dryRun: true` runs the identical decision, returns the identical status
+   * code, and mutates nothing — so an operator can see exactly what the real
+   * call will do before making it.
+   */
+  app.post('/admin/inventory/deposit', async (c: Context) => {
+    const denied = denyWrite(c);
+    if (denied) return denied;
+
+    let raw: DepositBody = {};
+    try {
+      raw = (await c.req.json()) as DepositBody;
+    } catch {
+      return c.json(
+        {
+          error: 'invalid_body',
+          reason:
+            'expected a JSON object { assetCode, chain, amount?, dryRun? }',
+        },
+        400
+      );
+    }
+    const parsed = parsePoolBody(raw);
+    if (!parsed.ok) {
+      return c.json({ error: 'invalid_body', reason: parsed.reason }, 400);
+    }
+    if (raw.dryRun !== undefined && typeof raw.dryRun !== 'boolean') {
+      return c.json(
+        { error: 'invalid_body', reason: 'dryRun must be a boolean' },
+        400
+      );
+    }
+    const { assetCode, chain } = parsed;
+    const dryRun = raw.dryRun === true;
+
+    const reading = await deps.reconciler.readPoolFunding({ assetCode, chain });
+    if (!reading.supported) {
+      return c.json(
+        {
+          error: 'funding_unreadable',
+          reason: `cannot read on-chain channel funding for ${assetCode}:${chain} — refusing to credit capital the chain has not corroborated`,
+          errors: [...reading.errors],
+        },
+        503
+      );
+    }
+    if (reading.channels.length === 0) {
+      return c.json(
+        {
+          error: 'unknown_pool',
+          reason: `no channel state for ${assetCode}:${chain} — capital only counts once the chain shows it in a channel this node has provisioned`,
+          funding: serializeFunding(reading),
+        },
+        404
+      );
+    }
+    if (reading.errors.length > 0) {
+      // A failed read only ever makes the sum SMALLER (that channel is simply
+      // excluded), so proceeding would under-credit rather than over-credit —
+      // safe, but an operator asking "did my top-up land?" must not be handed
+      // a silently partial answer. Refuse and let them retry.
+      return c.json(
+        {
+          error: 'chain_unreadable',
+          reason: `${reading.errors.length} of ${reading.channels.length} channel reads failed — the corroborated total would be incomplete, so nothing was credited`,
+          funding: serializeFunding(reading),
+        },
+        503
+      );
+    }
+
+    // From here to the credit is one synchronous block: `total` is read and
+    // raised without an intervening await, so two concurrent operator calls
+    // that observed the same `chainFundedTotal` cannot both credit it (the
+    // second finds the gap already closed and is refused as uncorroborated).
+    let outcome;
+    try {
+      const p = {
+        assetCode,
+        chain,
+        chainFundedTotal: reading.chainFundedTotal,
+        ...(parsed.amount !== undefined && { requested: parsed.amount }),
+      };
+      outcome = dryRun
+        ? deps.inventory.previewCorroboratedFunding(p)
+        : deps.inventory.creditCorroboratedFunding(p);
+    } catch (err) {
+      if (
+        err instanceof SwapInventoryError &&
+        err.code === 'INVENTORY_NOT_INITIALIZED'
+      ) {
+        return c.json(
+          {
+            error: 'unknown_pool',
+            reason: `no inventory pool ${assetCode}:${chain} is configured on this node`,
+          },
+          404
+        );
+      }
+      throw err;
+    }
+
+    const body = {
+      applied: !dryRun && outcome.credited > 0n,
+      dryRun,
+      requested: outcome.requested?.toString() ?? null,
+      total: outcome.total.toString(),
+      chainFundedTotal: outcome.chainFundedTotal.toString(),
+      corroborated: outcome.corroborated.toString(),
+      credited: outcome.credited.toString(),
+      funding: serializeFunding(reading),
+    };
+
+    if (outcome.refused === 'uncorroborated') {
+      return c.json(
+        {
+          ...body,
+          error: 'uncorroborated',
+          reason: `the pool's channels hold ${reading.chainFundedTotal} on chain and the pool has already booked ${outcome.total} — no new capital to credit. Fund or top up a channel this node has provisioned; inventory is only ever credited against capital the chain shows in a channel.`,
+        },
+        409
+      );
+    }
+    if (outcome.refused === 'exceeds_corroborated') {
+      return c.json(
+        {
+          ...body,
+          error: 'exceeds_corroborated',
+          reason: `the chain corroborates only ${outcome.corroborated} of the requested ${outcome.requested ?? 0n}; nothing was credited`,
+        },
+        409
+      );
+    }
+
+    const persisted = dryRun
+      ? { persisted: false }
+      : deps.reconciler.persistState();
+    return c.json({ ...body, ...persisted });
   });
 }

--- a/packages/swap/src/channel-state.ts
+++ b/packages/swap/src/channel-state.ts
@@ -138,6 +138,13 @@ export interface ChannelOnChainReader {
    * interface; callers MUST feature-detect and fail closed (refuse to credit)
    * when it is absent, never guess a funding level.
    *
+   * A reader that WRAPS or DISPATCHES to other readers (e.g. a chain-family
+   * dispatcher over per-family readers) MUST forward this method whenever any
+   * reader it delegates to implements it. Returning a bare object with only
+   * `getCumulativePaid` silently drops the capability, and the operator
+   * credit surface then refuses every request with `503 funding_unreadable` —
+   * fail-closed, but the route is dead and nothing says why.
+   *
    * IMPLEMENTATIONS MUST return both words from ONE atomic chain read (a
    * single `eth_call` / one account fetch). Two separate reads straddling a
    * redemption can observe the pre-redemption `deposit` together with the

--- a/packages/swap/src/channel-state.ts
+++ b/packages/swap/src/channel-state.ts
@@ -86,12 +86,71 @@ export interface ReleaseLogger {
  * rightful recipient, which is exactly the bug this interface exists to
  * prevent.
  */
+/**
+ * swap#142 — one channel's on-chain capital position, read atomically.
+ *
+ * `deposit` on `RollingSwapChannel` is the **remaining, un-paid-out** deposit,
+ * NOT the cumulative amount ever deposited: `updateBalance` does
+ * `deposit -= delta; cumulativePaid += delta` on every redemption. Reading
+ * `deposit` alone would therefore see a *falling* number on a busy maker and
+ * is useless as a corroboration of added capital.
+ *
+ * The quantity that behaves is the **sum**:
+ *
+ * ```
+ * funded(channel) = cumulativePaid + deposit
+ * ```
+ *
+ * which is invariant under redemption (one word falls by exactly what the
+ * other rises by) and rises only when capital actually enters the channel —
+ * `openChannel` and `deposit()`. It falls only when the funder reclaims the
+ * unspent remainder on close (`cooperativeClose` / `withdrawRemainder` zero
+ * `deposit`), which is a genuine capital *withdrawal* and must credit nothing.
+ * See {@link channelFundedTotal}.
+ */
+export interface ChannelFundingPosition {
+  /** Cumulative value already paid out of this channel (monotone). */
+  cumulativePaid: bigint;
+  /** Remaining, un-paid-out deposit — FALLS as claims are redeemed. */
+  deposit: bigint;
+}
+
+/**
+ * `cumulativePaid + deposit` — the capital the chain shows has been placed
+ * into this channel and not yet reclaimed. See {@link ChannelFundingPosition}
+ * for why neither word alone is usable.
+ */
+export function channelFundedTotal(p: ChannelFundingPosition): bigint {
+  return p.cumulativePaid + p.deposit;
+}
+
 export interface ChannelOnChainReader {
   getCumulativePaid(params: {
     assetCode: string;
     chain: string;
     channelId: string;
   }): Promise<bigint>;
+  /**
+   * swap#142 — OPTIONAL capability: the channel's full funding position.
+   *
+   * Optional so a chain family that has a `getCumulativePaid` implementation
+   * but no funding read (swap#141's Solana/Mina readers) still satisfies this
+   * interface; callers MUST feature-detect and fail closed (refuse to credit)
+   * when it is absent, never guess a funding level.
+   *
+   * IMPLEMENTATIONS MUST return both words from ONE atomic chain read (a
+   * single `eth_call` / one account fetch). Two separate reads straddling a
+   * redemption can observe the pre-redemption `deposit` together with the
+   * post-redemption `cumulativePaid`, which OVERSTATES `funded` by the
+   * redeemed delta — and overstated funding is exactly what would let the
+   * operator credit surface invent capital. Same freshness rule as
+   * `getCumulativePaid`: never cache.
+   */
+  getFundingPosition?(params: {
+    assetCode: string;
+    chain: string;
+    channelId: string;
+  }): Promise<ChannelFundingPosition>;
 }
 
 export interface SwapChannelStateInit {

--- a/packages/swap/src/evm-channel-reader.test.ts
+++ b/packages/swap/src/evm-channel-reader.test.ts
@@ -9,6 +9,15 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { createServer, type Server } from 'node:http';
 
 import { createEvmChannelOnChainReader } from './evm-channel-reader.js';
+import { channelFundedTotal } from './channel-state.js';
+
+/** Non-null narrowing without `!` (the repo's eslint gate forbids it). */
+function must<T>(value: T | null | undefined, what: string): T {
+  if (value === null || value === undefined) {
+    throw new Error(`expected ${what} to be present`);
+  }
+  return value;
+}
 
 const CHANNEL_ADDRESS = '0x' + '33'.repeat(20);
 const CHAIN = 'evm:31337';
@@ -240,5 +249,59 @@ describe('createEvmChannelOnChainReader (issue #113)', () => {
     ]);
     expect(a).toBe(1n);
     expect(b).toBe(2n);
+  });
+});
+
+describe('createEvmChannelOnChainReader.getFundingPosition (swap#142)', () => {
+  it('[P0] returns both capital words from ONE eth_call, so they share a block', async () => {
+    let calls = 0;
+    const rpcUrl = await startRpcServer((req) => {
+      calls += 1;
+      expect(req.method).toBe('eth_call');
+      return encodeChannelStruct({ cumulativePaid: 8_000n, deposit: 2_000n });
+    });
+    const reader = createEvmChannelOnChainReader([
+      { chainId: CHAIN, rpcUrl, channelAddress: CHANNEL_ADDRESS },
+    ]);
+
+    const position = await must(
+      reader.getFundingPosition,
+      'getFundingPosition capability'
+    ).call(reader, { assetCode: 'ETH', chain: CHAIN, channelId: CHANNEL_ID });
+
+    // Two eth_calls could straddle a redemption and overstate the sum.
+    expect(calls).toBe(1);
+    expect(position).toEqual({ cumulativePaid: 8_000n, deposit: 2_000n });
+    expect(channelFundedTotal(position)).toBe(10_000n);
+  });
+
+  it('[P0] decodes `deposit` from word index 4, distinct from cumulativePaid', async () => {
+    const rpcUrl = await startRpcServer(() =>
+      encodeChannelStruct({ cumulativePaid: 0n, deposit: 15_000_000n })
+    );
+    const reader = createEvmChannelOnChainReader([
+      { chainId: CHAIN, rpcUrl, channelAddress: CHANNEL_ADDRESS },
+    ]);
+
+    const position = await must(
+      reader.getFundingPosition,
+      'getFundingPosition capability'
+    ).call(reader, { assetCode: 'ETH', chain: CHAIN, channelId: CHANNEL_ID });
+    expect(position.deposit).toBe(15_000_000n);
+    expect(position.cumulativePaid).toBe(0n);
+  });
+
+  it('[P1] a truncated response throws rather than decoding a short word', async () => {
+    const rpcUrl = await startRpcServer(() => '0x' + '00'.repeat(32 * 4));
+    const reader = createEvmChannelOnChainReader([
+      { chainId: CHAIN, rpcUrl, channelAddress: CHANNEL_ADDRESS },
+    ]);
+
+    await expect(
+      must(reader.getFundingPosition, 'getFundingPosition capability').call(
+        reader,
+        { assetCode: 'ETH', chain: CHAIN, channelId: CHANNEL_ID }
+      )
+    ).rejects.toThrow(/deposit/);
   });
 });

--- a/packages/swap/src/evm-channel-reader.ts
+++ b/packages/swap/src/evm-channel-reader.ts
@@ -25,15 +25,25 @@ import { keccak_256 } from '@noble/hashes/sha3.js';
 import { bytesToHex } from '@noble/hashes/utils.js';
 import { hexToBytes } from '@toon-protocol/sdk';
 
-import type { ChannelOnChainReader } from './channel-state.js';
+import type {
+  ChannelFundingPosition,
+  ChannelOnChainReader,
+} from './channel-state.js';
 
 /** `channels(bytes32)` 4-byte selector — keccak256("channels(bytes32)")[0:4]. */
 const CHANNELS_SELECTOR = keccak_256(
   new TextEncoder().encode('channels(bytes32)')
 ).slice(0, 4);
 
-/** Word index of `cumulativePaid` in the `Channel` struct's ABI-encoded return. */
+/**
+ * Word indices in the `Channel` struct's ABI-encoded return.
+ * `struct Channel { address signer; address funder; uint256 nonce;
+ *   uint256 cumulativePaid; uint256 deposit; uint64 closingAt;
+ *   ChannelState state; }` — all static types, so a flat run of 32-byte words.
+ */
 const CUMULATIVE_PAID_WORD_INDEX = 3;
+/** swap#142 — `deposit`, the REMAINING un-paid-out deposit (word 4). */
+const DEPOSIT_WORD_INDEX = 4;
 const WORD_HEX_LEN = 64; // 32 bytes, 2 hex chars/byte
 
 /** `channels(bytes32)` calldata: 4-byte selector followed by the 32-byte channelId. */
@@ -48,20 +58,50 @@ function encodeChannelsCall(channelId: string): string {
 }
 
 /**
- * Pull `cumulativePaid` out of a `channels()` return value. Every `Channel`
+ * Pull one uint256 word out of a `channels()` return value. Every `Channel`
  * field is a static type, so the struct is a flat run of 32-byte words and
  * the field sits at a fixed offset — no general ABI decoder needed.
  */
-function decodeCumulativePaid(resultHex: string, chain: string): bigint {
+function decodeWord(
+  resultHex: string,
+  chain: string,
+  wordIndex: number,
+  fieldName: string
+): bigint {
   const hex = resultHex.startsWith('0x') ? resultHex.slice(2) : resultHex;
-  const wordStart = CUMULATIVE_PAID_WORD_INDEX * WORD_HEX_LEN;
+  const wordStart = wordIndex * WORD_HEX_LEN;
   const word = hex.slice(wordStart, wordStart + WORD_HEX_LEN);
   if (word.length !== WORD_HEX_LEN) {
     throw new Error(
-      `channels() response for chain '${chain}' is too short to contain cumulativePaid (got ${hex.length} hex chars)`
+      `channels() response for chain '${chain}' is too short to contain ${fieldName} (got ${hex.length} hex chars)`
     );
   }
   return BigInt(`0x${word}`);
+}
+
+function decodeCumulativePaid(resultHex: string, chain: string): bigint {
+  return decodeWord(
+    resultHex,
+    chain,
+    CUMULATIVE_PAID_WORD_INDEX,
+    'cumulativePaid'
+  );
+}
+
+/**
+ * swap#142 — both capital words from ONE response, so they are necessarily
+ * from the same block. Reading them with two `eth_call`s could straddle a
+ * redemption and overstate `cumulativePaid + deposit`; see
+ * `ChannelFundingPosition`.
+ */
+function decodeFundingPosition(
+  resultHex: string,
+  chain: string
+): ChannelFundingPosition {
+  return {
+    cumulativePaid: decodeCumulativePaid(resultHex, chain),
+    deposit: decodeWord(resultHex, chain, DEPOSIT_WORD_INDEX, 'deposit'),
+  };
 }
 
 /** Minimal per-EVM-chain slice this reader needs — see `SwapNodeEvmChainProvider`. */
@@ -98,42 +138,53 @@ export function createEvmChannelOnChainReader(
     });
   }
 
+  /** One `eth_call` to `channels(channelId)`; returns the raw hex result. */
+  async function callChannels(
+    chain: string,
+    channelId: string
+  ): Promise<string> {
+    const entry = byChain.get(chain);
+    if (!entry) {
+      throw new Error(`No EVM chain provider configured for chain '${chain}'`);
+    }
+    const calldata = encodeChannelsCall(channelId);
+    const response = await fetch(entry.rpcUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'eth_call',
+        params: [{ to: entry.address, data: calldata }, 'latest'],
+      }),
+    });
+    const json = (await response.json()) as {
+      result?: string;
+      error?: { message?: string };
+    };
+    if (json.error) {
+      throw new Error(
+        `eth_call to channels(${channelId}) on chain '${chain}' failed: ${
+          json.error.message ?? JSON.stringify(json.error)
+        }`
+      );
+    }
+    if (typeof json.result !== 'string') {
+      throw new Error(
+        `eth_call to channels(${channelId}) on chain '${chain}' returned no result`
+      );
+    }
+    return json.result;
+  }
+
   return {
     async getCumulativePaid({ chain, channelId }) {
-      const entry = byChain.get(chain);
-      if (!entry) {
-        throw new Error(
-          `No EVM chain provider configured for chain '${chain}'`
-        );
-      }
-      const calldata = encodeChannelsCall(channelId);
-      const response = await fetch(entry.rpcUrl, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          id: 1,
-          method: 'eth_call',
-          params: [{ to: entry.address, data: calldata }, 'latest'],
-        }),
-      });
-      const json = (await response.json()) as {
-        result?: string;
-        error?: { message?: string };
-      };
-      if (json.error) {
-        throw new Error(
-          `eth_call to channels(${channelId}) on chain '${chain}' failed: ${
-            json.error.message ?? JSON.stringify(json.error)
-          }`
-        );
-      }
-      if (typeof json.result !== 'string') {
-        throw new Error(
-          `eth_call to channels(${channelId}) on chain '${chain}' returned no result`
-        );
-      }
-      return decodeCumulativePaid(json.result, chain);
+      return decodeCumulativePaid(await callChannels(chain, channelId), chain);
+    },
+    // swap#142 — ONE call, both words: `cumulativePaid` and `deposit` are
+    // decoded from the same response and therefore the same block.
+    async getFundingPosition({ chain, channelId }) {
+      return decodeFundingPosition(await callChannels(chain, channelId), chain);
     },
   };
 }

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -19,6 +19,8 @@ export type {
   SwapWindowSnapshotEntry,
   // Issue #138 — chain-corroborated settle-and-recycle outcome.
   ChainRedemptionResult,
+  // swap#142 — chain-corroborated NEW-capital credit outcome.
+  FundingCreditResult,
 } from './inventory.js';
 
 // Chain-truth inventory reconciliation + operator surface (issue #138)
@@ -35,6 +37,9 @@ export type {
   PoolReconcileTotals,
   ReconcileResult,
   ReconcileOptions,
+  // swap#142 — the pool's on-chain capital position.
+  ChannelFundingObservation,
+  PoolFundingReading,
 } from './inventory-reconciler.js';
 export { buildInventoryReport, registerAdminRoutes } from './admin-surface.js';
 export type {
@@ -70,8 +75,13 @@ export type {
   ChannelOnChainReader,
   // swap#136 — structured rebind refusals (channelId + unredeemed delta).
   ChannelRebindRefusal,
+  // swap#142 — the optional funding-read capability on the reader seam.
+  ChannelFundingPosition,
 } from './channel-state.js';
-export { describeChannelRebindRefusal } from './channel-state.js';
+export {
+  describeChannelRebindRefusal,
+  channelFundedTotal,
+} from './channel-state.js';
 
 // Claim issuer (Story 12.4)
 export { MultiChainClaimIssuer } from './claim-issuer.js';

--- a/packages/swap/src/inventory-deposit.test.ts
+++ b/packages/swap/src/inventory-deposit.test.ts
@@ -15,7 +15,8 @@
  * credit.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createServer, type Server } from 'node:http';
 import { Hono } from 'hono';
 
 import { SwapInventory } from './inventory.js';
@@ -26,6 +27,8 @@ import type {
 } from './channel-state.js';
 import { SwapInventoryReconciler } from './inventory-reconciler.js';
 import { registerAdminRoutes } from './admin-surface.js';
+import { createEvmChannelOnChainReader } from './evm-channel-reader.js';
+import { composeChannelOnChainReaders } from './channel-reader.js';
 
 const ASSET = 'USDC';
 const CHAIN = 'evm:base:8453';
@@ -679,5 +682,116 @@ describe('POST /admin/inventory/deposit — never credits on trust', () => {
       (await post(app, { assetCode: ASSET, chain: CHAIN, dryRun: 'yes' }))
         .status
     ).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The production wiring, end to end
+// ---------------------------------------------------------------------------
+
+describe('the route against the REAL reader behind the REAL dispatcher', () => {
+  const servers: Server[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      servers
+        .splice(0)
+        .map((s) => new Promise<void>((resolve) => s.close(() => resolve())))
+    );
+  });
+
+  /** Serves a `channels()` struct whose capital words the test mutates live. */
+  async function startChannelRpc(position: ChannelFundingPosition) {
+    const w = (hex: string) => hex.toLowerCase().padStart(64, '0');
+    const server = createServer((req, res) => {
+      let body = '';
+      req.on('data', (chunk: Buffer) => {
+        body += chunk.toString();
+      });
+      req.on('end', () => {
+        const { id } = JSON.parse(body) as { id: number };
+        const words = [
+          w('11'.repeat(20)),
+          w('22'.repeat(20)),
+          w('3'),
+          w(position.cumulativePaid.toString(16)),
+          w(position.deposit.toString(16)),
+          w('0'),
+          w('1'),
+        ];
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify({ jsonrpc: '2.0', id, result: '0x' + words.join('') })
+        );
+      });
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve)
+    );
+    const address = server.address();
+    if (address === null || typeof address === 'string') {
+      throw new Error('expected a bound TCP address');
+    }
+    return `http://127.0.0.1:${address.port}`;
+  }
+
+  it('[P0] the funding capability survives composition, so the route is not silently dead', async () => {
+    // swap#141 composes per-family readers into one dispatching reader. A
+    // dispatcher that forwarded only the capabilities it happened to NAME
+    // would drop `getFundingPosition` and make this route answer 503 on every
+    // chain — fail-closed, but dead with nothing explaining why. #141's
+    // dispatcher forwards by capability union; #141's own tests pin that with
+    // STUB readers, which would still pass if the real EVM reader lost the
+    // method. This pins the real one, through the real dispatcher.
+    const chain = 'evm:31337';
+    const rpcUrl = await startChannelRpc({
+      cumulativePaid: 1_000n,
+      deposit: 14_999_000n,
+    });
+    const composed = composeChannelOnChainReaders({
+      evm: createEvmChannelOnChainReader([
+        { chainId: chain, rpcUrl, channelAddress: '0x' + '33'.repeat(20) },
+      ]),
+    });
+    expect(typeof composed?.getFundingPosition).toBe('function');
+
+    const inventory = new SwapInventory({
+      balances: {
+        [`${ASSET}:${chain}`]: { available: 15_000_000n, total: 15_000_000n },
+      },
+    });
+    const reconciler = new SwapInventoryReconciler({
+      inventory,
+      channelState: new SwapChannelState({
+        channels: {
+          [`${ASSET}:${chain}:${CHANNEL}`]: {
+            channelId: CHANNEL,
+            cumulativeAmount: 1_000n,
+            nonce: 1n,
+            updatedAt: 0,
+          },
+        },
+      }),
+      ...(composed && { reader: composed }),
+    });
+    const app = makeAdminApp({ inventory, reconciler, adminToken: TOKEN });
+
+    const res = await app.request('/admin/inventory/deposit', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${TOKEN}`,
+      },
+      body: JSON.stringify({ assetCode: ASSET, chain }),
+    });
+
+    // Reaching a corroboration verdict at all is the point: a dropped
+    // capability would have produced 503 `funding_unreadable` instead.
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as DepositJsonBody;
+    expect(body.error).toBe('uncorroborated');
+    // ...and the sum is cumulativePaid + deposit, decoded off a real eth_call.
+    expect(body.chainFundedTotal).toBe('15000000');
   });
 });

--- a/packages/swap/src/inventory-deposit.test.ts
+++ b/packages/swap/src/inventory-deposit.test.ts
@@ -1,0 +1,683 @@
+/**
+ * swap#142 — the operator route for genuinely NEW capital.
+ *
+ * The gap these cover: #138/#140 gave the operator a way to recycle capital
+ * the chain shows REDEEMED, and deliberately nothing else — so an operator who
+ * actually funded a new channel or topped up an existing one had no route at
+ * all, and editing config does not reliably take (the persisted snapshot wins
+ * over config for keys it has already seen, issue #130).
+ *
+ * The invariant every test here defends: inventory is NEVER credited on an
+ * operator's word. The only thing that can raise `total` is the chain showing
+ * more capital in the pool's channels than the pool has already booked — and
+ * because crediting raises `total` itself, that gap closes as it is credited,
+ * which is what makes a repeated call a structural no-op rather than a double
+ * credit.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { Hono } from 'hono';
+
+import { SwapInventory } from './inventory.js';
+import { SwapChannelState, channelFundedTotal } from './channel-state.js';
+import type {
+  ChannelFundingPosition,
+  ChannelOnChainReader,
+} from './channel-state.js';
+import { SwapInventoryReconciler } from './inventory-reconciler.js';
+import { registerAdminRoutes } from './admin-surface.js';
+
+const ASSET = 'USDC';
+const CHAIN = 'evm:base:8453';
+const CHANNEL = '0x' + '01'.repeat(32);
+const CHANNEL_B = '0x' + '02'.repeat(32);
+const POOL = `${ASSET}:${CHAIN}`;
+const TOKEN = 'operator-secret';
+
+/** Non-null narrowing without `!` (the repo's eslint gate forbids it). */
+function must<T>(value: T | null | undefined, what: string): T {
+  if (value === null || value === undefined) {
+    throw new Error(`expected ${what} to be present`);
+  }
+  return value;
+}
+
+function poolOf(inventory: SwapInventory) {
+  return must(inventory.get(ASSET, CHAIN), 'pool balance');
+}
+
+/** Body shape shared by every response these routes return. */
+interface DepositJsonBody {
+  error?: string;
+  reason?: string;
+  applied?: boolean;
+  dryRun?: boolean;
+  requested?: string | null;
+  total?: string;
+  chainFundedTotal?: string;
+  corroborated?: string;
+  credited?: string;
+  persisted?: boolean;
+  funding?: {
+    supported: boolean;
+    chainFundedTotal: string;
+    channels: { channelId: string; funded: string | null }[];
+    errors: string[];
+  };
+}
+
+async function depositJson(res: Response): Promise<DepositJsonBody> {
+  return (await res.json()) as DepositJsonBody;
+}
+
+/**
+ * A reader whose per-channel funding position the test controls. `fail`
+ * makes the funding read throw, exactly as an RPC outage would.
+ */
+function fundingReader(state: {
+  positions: Record<string, ChannelFundingPosition>;
+  fail?: string;
+}) {
+  return {
+    getCumulativePaid: vi.fn(async ({ channelId }: { channelId: string }) => {
+      return state.positions[channelId]?.cumulativePaid ?? 0n;
+    }),
+    getFundingPosition: vi.fn(async ({ channelId }: { channelId: string }) => {
+      if (state.fail) throw new Error(state.fail);
+      const position = state.positions[channelId];
+      if (!position) throw new Error(`no fixture channel ${channelId}`);
+      return position;
+    }),
+  } satisfies ChannelOnChainReader;
+}
+
+/** swap#141's shape: a reader that can read redemptions but not funding. */
+function redemptionOnlyReader(): ChannelOnChainReader {
+  return { getCumulativePaid: vi.fn(async () => 0n) };
+}
+
+function makeInventory(p: { available: bigint; total: bigint }) {
+  return new SwapInventory({
+    balances: { [POOL]: { available: p.available, total: p.total } },
+  });
+}
+
+function makeChannelState(channelIds: readonly string[]) {
+  const channels: Record<
+    string,
+    {
+      channelId: string;
+      cumulativeAmount: bigint;
+      nonce: bigint;
+      updatedAt: number;
+    }
+  > = {};
+  for (const channelId of channelIds) {
+    channels[`${POOL}:${channelId}`] = {
+      channelId,
+      cumulativeAmount: 0n,
+      nonce: 0n,
+      updatedAt: 0,
+    };
+  }
+  return new SwapChannelState({ channels });
+}
+
+function makeAdminApp(p: {
+  inventory: SwapInventory;
+  reconciler: SwapInventoryReconciler;
+  adminToken?: string;
+}) {
+  const app = new Hono();
+  registerAdminRoutes(app, {
+    inventory: p.inventory,
+    reconciler: p.reconciler,
+    ...(p.adminToken !== undefined && { adminToken: p.adminToken }),
+  });
+  return app;
+}
+
+/** The live devnet maker's shape: one channel, 15 000 000 of configured capital. */
+function setup(p: {
+  available?: bigint;
+  total?: bigint;
+  positions: Record<string, ChannelFundingPosition>;
+  channels?: readonly string[];
+  fail?: string;
+  adminToken?: string | undefined;
+  reader?: ChannelOnChainReader;
+  persist?: () => void;
+}) {
+  const inventory = makeInventory({
+    available: p.available ?? 15_000_000n,
+    total: p.total ?? 15_000_000n,
+  });
+  const reconciler = new SwapInventoryReconciler({
+    inventory,
+    channelState: makeChannelState(p.channels ?? [CHANNEL]),
+    reader:
+      p.reader ??
+      fundingReader({
+        positions: p.positions,
+        ...(p.fail !== undefined && { fail: p.fail }),
+      }),
+    ...(p.persist !== undefined && { persist: p.persist }),
+  });
+  const app = makeAdminApp({
+    inventory,
+    reconciler,
+    ...(p.adminToken !== undefined && { adminToken: p.adminToken }),
+  });
+  // `positions` is live: a test can mutate it to simulate an on-chain top-up
+  // happening between two operator calls against the SAME node.
+  return { inventory, reconciler, app, positions: p.positions };
+}
+
+async function post(
+  app: Hono,
+  body: unknown,
+  token: string | null = TOKEN
+): Promise<Response> {
+  return app.request('/admin/inventory/deposit', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...(token !== null && { authorization: `Bearer ${token}` }),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// The corroboration quantity
+// ---------------------------------------------------------------------------
+
+describe('channelFundedTotal — why not the raw `deposit` field', () => {
+  it('[P0] is invariant under a redemption, which the `deposit` word alone is not', () => {
+    // RollingSwapChannel.updateBalance: `deposit -= delta; cumulativePaid += delta`.
+    const before = { cumulativePaid: 0n, deposit: 1_000n };
+    const afterRedeeming400 = { cumulativePaid: 400n, deposit: 600n };
+
+    expect(afterRedeeming400.deposit).toBeLessThan(before.deposit);
+    expect(channelFundedTotal(afterRedeeming400)).toBe(
+      channelFundedTotal(before)
+    );
+  });
+
+  it('[P0] rises by exactly the amount a top-up puts into the channel', () => {
+    const busy = { cumulativePaid: 400n, deposit: 600n };
+    const toppedUp = { cumulativePaid: 400n, deposit: 600n + 5_000n };
+    expect(channelFundedTotal(toppedUp) - channelFundedTotal(busy)).toBe(
+      5_000n
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The primitive — SwapInventory.creditCorroboratedFunding
+// ---------------------------------------------------------------------------
+
+describe('SwapInventory.creditCorroboratedFunding — bounds', () => {
+  it('[P0] credits the excess of chain proof over booked total, once', () => {
+    const inventory = makeInventory({
+      available: 15_000_000n,
+      total: 15_000_000n,
+    });
+
+    const first = inventory.creditCorroboratedFunding({
+      assetCode: ASSET,
+      chain: CHAIN,
+      chainFundedTotal: 20_000_000n,
+    });
+    expect(first.credited).toBe(5_000_000n);
+    expect(poolOf(inventory).total).toBe(20_000_000n);
+    expect(poolOf(inventory).available).toBe(20_000_000n);
+
+    // The same chain reading again: the gap it measured is now closed.
+    const replay = inventory.creditCorroboratedFunding({
+      assetCode: ASSET,
+      chain: CHAIN,
+      chainFundedTotal: 20_000_000n,
+    });
+    expect(replay.credited).toBe(0n);
+    expect(replay.refused).toBe('uncorroborated');
+    expect(poolOf(inventory).total).toBe(20_000_000n);
+  });
+
+  it('[P0] `total` is its own watermark: N replays credit exactly what one does', () => {
+    const inventory = makeInventory({ available: 1_000n, total: 1_000n });
+    for (let i = 0; i < 25; i += 1) {
+      inventory.creditCorroboratedFunding({
+        assetCode: ASSET,
+        chain: CHAIN,
+        chainFundedTotal: 1_600n,
+      });
+    }
+    expect(poolOf(inventory).total).toBe(1_600n);
+    expect(poolOf(inventory).available).toBe(1_600n);
+  });
+
+  it('[P0] refuses when the chain shows no more than the pool already booked', () => {
+    const inventory = makeInventory({ available: 1_000n, total: 1_000n });
+    for (const chainFundedTotal of [0n, 999n, 1_000n]) {
+      const outcome = inventory.creditCorroboratedFunding({
+        assetCode: ASSET,
+        chain: CHAIN,
+        chainFundedTotal,
+      });
+      expect(outcome.refused).toBe('uncorroborated');
+      expect(outcome.credited).toBe(0n);
+    }
+    expect(poolOf(inventory).total).toBe(1_000n);
+    expect(poolOf(inventory).available).toBe(1_000n);
+  });
+
+  it('[P0] capital LEAVING (a funder reclaiming a remainder) never lowers total, and never credits', () => {
+    const inventory = makeInventory({ available: 1_000n, total: 1_000n });
+    const outcome = inventory.creditCorroboratedFunding({
+      assetCode: ASSET,
+      chain: CHAIN,
+      chainFundedTotal: 0n, // channel closed, remainder returned to the funder
+    });
+    expect(outcome.refused).toBe('uncorroborated');
+    expect(poolOf(inventory).total).toBe(1_000n);
+
+    // Re-funding back to a level already credited must credit nothing.
+    const refund = inventory.creditCorroboratedFunding({
+      assetCode: ASSET,
+      chain: CHAIN,
+      chainFundedTotal: 1_000n,
+    });
+    expect(refund.credited).toBe(0n);
+    expect(poolOf(inventory).total).toBe(1_000n);
+  });
+
+  it('[P0] refuses a request larger than the chain backs, WHOLE — nothing applied', () => {
+    const inventory = makeInventory({ available: 1_000n, total: 1_000n });
+    const outcome = inventory.creditCorroboratedFunding({
+      assetCode: ASSET,
+      chain: CHAIN,
+      chainFundedTotal: 1_400n,
+      requested: 5_000n,
+    });
+    expect(outcome.refused).toBe('exceeds_corroborated');
+    expect(outcome.corroborated).toBe(400n);
+    expect(outcome.credited).toBe(0n);
+    expect(poolOf(inventory).total).toBe(1_000n);
+  });
+
+  it('[P1] a partial request credits exactly that, and leaves the remainder creditable', () => {
+    const inventory = makeInventory({ available: 1_000n, total: 1_000n });
+    inventory.creditCorroboratedFunding({
+      assetCode: ASSET,
+      chain: CHAIN,
+      chainFundedTotal: 1_400n,
+      requested: 100n,
+    });
+    expect(poolOf(inventory).total).toBe(1_100n);
+
+    const rest = inventory.creditCorroboratedFunding({
+      assetCode: ASSET,
+      chain: CHAIN,
+      chainFundedTotal: 1_400n,
+    });
+    expect(rest.credited).toBe(300n);
+    expect(poolOf(inventory).total).toBe(1_400n);
+  });
+
+  it('[P0] over a whole life, Σ credited never exceeds the highest funding ever seen', () => {
+    const inventory = makeInventory({ available: 1_000n, total: 1_000n });
+    const readings = [1_000n, 1_500n, 1_500n, 1_200n, 1_800n, 0n, 1_800n];
+    let credited = 0n;
+    for (const chainFundedTotal of readings) {
+      credited += inventory.creditCorroboratedFunding({
+        assetCode: ASSET,
+        chain: CHAIN,
+        chainFundedTotal,
+      }).credited;
+    }
+    const highestEverSeen = 1_800n;
+    expect(credited).toBe(highestEverSeen - 1_000n);
+    expect(poolOf(inventory).total).toBe(highestEverSeen);
+  });
+
+  it('[P1] the historical swap#137 `total` inflation converges onto chain truth from below', () => {
+    // The live devnet maker: `available` correct after #140's reconciler,
+    // `total` carrying 3 500 of inflation from failed swaps that unwound with
+    // `credit()` before #137. Nothing corrects this directly (see the module
+    // docblock — every recompute is a downward write on data the node does
+    // not durably own); it resolves the next time real capital arrives.
+    const inventory = new SwapInventory({
+      balances: { [POOL]: { available: 15_000_000n, total: 15_003_500n } },
+    });
+
+    const outcome = inventory.creditCorroboratedFunding({
+      assetCode: ASSET,
+      chain: CHAIN,
+      chainFundedTotal: 20_000_000n, // operator really added 5 000 000
+    });
+
+    // The credit is the top-up MINUS the inflation, so `total` lands exactly
+    // on the chain's figure — never above it.
+    expect(outcome.credited).toBe(4_996_500n);
+    expect(poolOf(inventory).total).toBe(20_000_000n);
+    // The residue moves into `available` being 3 500 low: under-serving, the
+    // safe direction, and never above `total`.
+    expect(poolOf(inventory).available).toBe(19_996_500n);
+    expect(poolOf(inventory).available).toBeLessThanOrEqual(
+      poolOf(inventory).total
+    );
+  });
+
+  it('[P0] preview mutates nothing while predicting the same numbers', () => {
+    const inventory = makeInventory({ available: 1_000n, total: 1_000n });
+    const preview = inventory.previewCorroboratedFunding({
+      assetCode: ASSET,
+      chain: CHAIN,
+      chainFundedTotal: 1_400n,
+    });
+    expect(preview.credited).toBe(400n);
+    expect(poolOf(inventory).total).toBe(1_000n);
+
+    const applied = inventory.creditCorroboratedFunding({
+      assetCode: ASSET,
+      chain: CHAIN,
+      chainFundedTotal: 1_400n,
+    });
+    expect(applied.credited).toBe(preview.credited);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reading the pool's on-chain position
+// ---------------------------------------------------------------------------
+
+describe('SwapInventoryReconciler.readPoolFunding', () => {
+  it('[P0] sums cumulativePaid + deposit across the pool channels', async () => {
+    const { reconciler } = setup({
+      channels: [CHANNEL, CHANNEL_B],
+      positions: {
+        [CHANNEL]: { cumulativePaid: 8_000n, deposit: 2_000n },
+        [CHANNEL_B]: { cumulativePaid: 0n, deposit: 5_000n },
+      },
+    });
+
+    const reading = await reconciler.readPoolFunding({
+      assetCode: ASSET,
+      chain: CHAIN,
+    });
+    expect(reading.supported).toBe(true);
+    expect(reading.chainFundedTotal).toBe(15_000n);
+    expect(reading.errors).toEqual([]);
+  });
+
+  it('[P0] a reader with no funding capability reports unsupported, never a guess', async () => {
+    const { reconciler } = setup({
+      positions: {},
+      reader: redemptionOnlyReader(),
+    });
+
+    const reading = await reconciler.readPoolFunding({
+      assetCode: ASSET,
+      chain: CHAIN,
+    });
+    expect(reading.supported).toBe(false);
+    expect(reading.chainFundedTotal).toBe(0n);
+    expect(must(reading.errors[0], 'reason')).toContain('cannot read');
+  });
+
+  it('[P1] a failed read is excluded from the sum and reported', async () => {
+    const { reconciler } = setup({
+      positions: { [CHANNEL]: { cumulativePaid: 0n, deposit: 1_000n } },
+      fail: 'rpc down',
+    });
+
+    const reading = await reconciler.readPoolFunding({
+      assetCode: ASSET,
+      chain: CHAIN,
+    });
+    expect(reading.chainFundedTotal).toBe(0n);
+    expect(reading.errors).toHaveLength(1);
+    expect(must(reading.errors[0], 'error')).toContain('rpc down');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The HTTP surface
+// ---------------------------------------------------------------------------
+
+describe('POST /admin/inventory/deposit — protection', () => {
+  it('[P0] with NO token configured the write is DISABLED (503), never open', async () => {
+    const { app, inventory } = setup({
+      positions: { [CHANNEL]: { cumulativePaid: 0n, deposit: 20_000_000n } },
+      adminToken: undefined,
+    });
+
+    const noHeader = await post(app, { assetCode: ASSET, chain: CHAIN }, null);
+    expect(noHeader.status).toBe(503);
+    expect((await depositJson(noHeader)).error).toBe('admin_writes_disabled');
+
+    // ...and presenting a token cannot enable it either.
+    const withHeader = await post(app, { assetCode: ASSET, chain: CHAIN });
+    expect(withHeader.status).toBe(503);
+
+    expect(poolOf(inventory).total).toBe(15_000_000n);
+  });
+
+  it('[P0] a wrong or missing token is rejected once a token IS configured', async () => {
+    const { app, inventory } = setup({
+      positions: { [CHANNEL]: { cumulativePaid: 0n, deposit: 20_000_000n } },
+      adminToken: TOKEN,
+    });
+
+    expect(
+      (await post(app, { assetCode: ASSET, chain: CHAIN }, null)).status
+    ).toBe(401);
+    expect(
+      (await post(app, { assetCode: ASSET, chain: CHAIN }, 'guess')).status
+    ).toBe(401);
+    expect(poolOf(inventory).total).toBe(15_000_000n);
+  });
+});
+
+describe('POST /admin/inventory/deposit — never credits on trust', () => {
+  it('[P0] a corroborated top-up credits exactly once, and the repeat does not double-credit', async () => {
+    const persist = vi.fn();
+    const { app, inventory, positions } = setup({
+      // The live devnet shape: 15 000 000 configured, one channel holding it —
+      // partly already paid out, which is exactly the case a raw `deposit`
+      // read would get wrong.
+      positions: {
+        [CHANNEL]: { cumulativePaid: 1_000n, deposit: 14_999_000n },
+      },
+      adminToken: TOKEN,
+      persist,
+    });
+
+    // Nothing to credit yet: the chain holds exactly what the pool booked.
+    const before = await post(app, { assetCode: ASSET, chain: CHAIN });
+    expect(before.status).toBe(409);
+    const beforeBody = await depositJson(before);
+    expect(beforeBody.error).toBe('uncorroborated');
+    // The corroborating quantity is cumulativePaid + deposit, so the 1 000
+    // already paid out still counts as capital the maker placed. Reading the
+    // `deposit` word alone would report 14 999 000 here and then hand the
+    // operator a phantom 1 000 of "new" capital on the next top-up.
+    expect(beforeBody.chainFundedTotal).toBe('15000000');
+
+    // The operator tops the SAME channel up by 5 000 000 on chain.
+    positions[CHANNEL] = {
+      cumulativePaid: 1_000n,
+      deposit: 14_999_000n + 5_000_000n,
+    };
+
+    const first = await post(app, { assetCode: ASSET, chain: CHAIN });
+    expect(first.status).toBe(200);
+    const firstBody = await depositJson(first);
+    expect(firstBody.applied).toBe(true);
+    expect(firstBody.credited).toBe('5000000');
+    expect(firstBody.chainFundedTotal).toBe('20000000');
+    expect(poolOf(inventory).total).toBe(20_000_000n);
+    expect(poolOf(inventory).available).toBe(20_000_000n);
+    expect(persist).toHaveBeenCalled();
+
+    // The exact same call again, against the exact same chain state.
+    const replay = await post(app, { assetCode: ASSET, chain: CHAIN });
+    expect(replay.status).toBe(409);
+    const replayBody = await depositJson(replay);
+    expect(replayBody.error).toBe('uncorroborated');
+    expect(replayBody.credited).toBe('0');
+    expect(poolOf(inventory).total).toBe(20_000_000n);
+    expect(poolOf(inventory).available).toBe(20_000_000n);
+
+    // ...and a redemption of the new capital must not make it creditable
+    // again: `cumulativePaid + deposit` is invariant under redemption.
+    positions[CHANNEL] = {
+      cumulativePaid: 3_000_000n,
+      deposit: 17_000_000n,
+    };
+    const afterRedemption = await post(app, { assetCode: ASSET, chain: CHAIN });
+    expect(afterRedemption.status).toBe(409);
+    expect(poolOf(inventory).total).toBe(20_000_000n);
+  });
+
+  it('[P0] an UNCORROBORATED top-up is refused — the operator asserting it changes nothing', async () => {
+    const { app, inventory } = setup({
+      // The chain shows exactly the configured capital: no top-up landed.
+      positions: { [CHANNEL]: { cumulativePaid: 0n, deposit: 15_000_000n } },
+      adminToken: TOKEN,
+    });
+
+    const res = await post(app, {
+      assetCode: ASSET,
+      chain: CHAIN,
+      amount: '5000000',
+    });
+    expect(res.status).toBe(409);
+    const body = await depositJson(res);
+    expect(body.error).toBe('uncorroborated');
+    expect(body.credited).toBe('0');
+    expect(must(body.reason, 'reason')).toContain('no new capital');
+    expect(poolOf(inventory).total).toBe(15_000_000n);
+    expect(poolOf(inventory).available).toBe(15_000_000n);
+  });
+
+  it('[P0] a top-up larger than the chain backs is refused whole, nothing applied', async () => {
+    const { app, inventory } = setup({
+      positions: { [CHANNEL]: { cumulativePaid: 0n, deposit: 15_400_000n } },
+      adminToken: TOKEN,
+    });
+
+    const res = await post(app, {
+      assetCode: ASSET,
+      chain: CHAIN,
+      amount: '5000000',
+    });
+    expect(res.status).toBe(409);
+    const body = await depositJson(res);
+    expect(body.error).toBe('exceeds_corroborated');
+    expect(body.corroborated).toBe('400000');
+    expect(body.credited).toBe('0');
+    expect(poolOf(inventory).total).toBe(15_000_000n);
+  });
+
+  it('[P0] an unreadable chain refuses (503) rather than crediting', async () => {
+    const { app, inventory } = setup({
+      positions: { [CHANNEL]: { cumulativePaid: 0n, deposit: 20_000_000n } },
+      fail: 'connect ECONNREFUSED',
+      adminToken: TOKEN,
+    });
+
+    const res = await post(app, { assetCode: ASSET, chain: CHAIN });
+    expect(res.status).toBe(503);
+    expect((await depositJson(res)).error).toBe('chain_unreadable');
+    expect(poolOf(inventory).total).toBe(15_000_000n);
+  });
+
+  it('[P0] a reader that cannot read funding refuses (503) rather than guessing', async () => {
+    const { app, inventory } = setup({
+      positions: {},
+      reader: redemptionOnlyReader(),
+      adminToken: TOKEN,
+    });
+
+    const res = await post(app, { assetCode: ASSET, chain: CHAIN });
+    expect(res.status).toBe(503);
+    expect((await depositJson(res)).error).toBe('funding_unreadable');
+    expect(poolOf(inventory).total).toBe(15_000_000n);
+  });
+
+  it('[P1] a pool with no provisioned channel is a 404, not a credit', async () => {
+    const { app, inventory } = setup({
+      channels: [],
+      positions: {},
+      adminToken: TOKEN,
+    });
+
+    const res = await post(app, { assetCode: ASSET, chain: CHAIN });
+    expect(res.status).toBe(404);
+    expect((await depositJson(res)).error).toBe('unknown_pool');
+    expect(poolOf(inventory).total).toBe(15_000_000n);
+  });
+
+  it('[P0] dryRun predicts the real call exactly and mutates nothing', async () => {
+    const { app, inventory } = setup({
+      positions: { [CHANNEL]: { cumulativePaid: 0n, deposit: 20_000_000n } },
+      adminToken: TOKEN,
+    });
+
+    const dry = await post(app, {
+      assetCode: ASSET,
+      chain: CHAIN,
+      dryRun: true,
+    });
+    expect(dry.status).toBe(200);
+    const dryBody = await depositJson(dry);
+    expect(dryBody.dryRun).toBe(true);
+    expect(dryBody.applied).toBe(false);
+    expect(dryBody.credited).toBe('5000000');
+    expect(poolOf(inventory).total).toBe(15_000_000n);
+
+    const real = await post(app, { assetCode: ASSET, chain: CHAIN });
+    expect(real.status).toBe(dry.status);
+    expect((await depositJson(real)).credited).toBe(dryBody.credited);
+    expect(poolOf(inventory).total).toBe(20_000_000n);
+  });
+
+  it('[P1] a refusal predicted by dryRun carries the same status as the real call', async () => {
+    const { app } = setup({
+      positions: { [CHANNEL]: { cumulativePaid: 0n, deposit: 15_000_000n } },
+      adminToken: TOKEN,
+    });
+
+    const dry = await post(app, {
+      assetCode: ASSET,
+      chain: CHAIN,
+      dryRun: true,
+    });
+    const real = await post(app, { assetCode: ASSET, chain: CHAIN });
+    expect(dry.status).toBe(409);
+    expect(real.status).toBe(409);
+  });
+
+  it('[P1] rejects a malformed body before touching the chain', async () => {
+    const { app } = setup({
+      positions: { [CHANNEL]: { cumulativePaid: 0n, deposit: 20_000_000n } },
+      adminToken: TOKEN,
+    });
+
+    expect((await post(app, { chain: CHAIN })).status).toBe(400);
+    expect((await post(app, { assetCode: ASSET })).status).toBe(400);
+    expect(
+      (await post(app, { assetCode: ASSET, chain: CHAIN, amount: '0' })).status
+    ).toBe(400);
+    expect(
+      (await post(app, { assetCode: ASSET, chain: CHAIN, amount: 'many' }))
+        .status
+    ).toBe(400);
+    expect(
+      (await post(app, { assetCode: ASSET, chain: CHAIN, dryRun: 'yes' }))
+        .status
+    ).toBe(400);
+  });
+});

--- a/packages/swap/src/inventory-reconciler.ts
+++ b/packages/swap/src/inventory-reconciler.ts
@@ -44,6 +44,7 @@
  */
 
 import type { ChannelEntry, ChannelOnChainReader } from './channel-state.js';
+import { channelFundedTotal } from './channel-state.js';
 import type { SwapInventory } from './inventory.js';
 
 /** Default reconcile cadence — chosen to be far cheaper than the RPC budget of a live maker. */
@@ -119,6 +120,46 @@ export interface SwapInventoryReconcilerConfig {
   clock?: () => number;
   /** Periodic cadence; `0` disables the timer (boot pass still runs). */
   intervalMs?: number;
+}
+
+/** swap#142 — one channel's on-chain capital position, or why it is unknown. */
+export interface ChannelFundingObservation {
+  /** `${assetCode}:${chain}:${channelId}` — the channel-state storage key. */
+  storedKey: string;
+  channelId: string;
+  /** Cumulative paid out, or `null` when the read failed. */
+  cumulativePaid: bigint | null;
+  /** Remaining un-paid-out deposit, or `null` when the read failed. */
+  deposit: bigint | null;
+  /** `cumulativePaid + deposit` — capital in this channel; `null` on failure. */
+  funded: bigint | null;
+  observedAt: number;
+  error?: string;
+}
+
+/**
+ * swap#142 — a pool's on-chain capital position: the sum the operator credit
+ * surface corroborates against.
+ *
+ * `chainFundedTotal` counts ONLY channels that read successfully, so a failed
+ * read always makes it smaller — under-crediting, the safe direction. Callers
+ * that are about to move value must still refuse outright when `errors` is
+ * non-empty (an operator asking "did my top-up land?" deserves a complete
+ * answer, not a partial one), and MUST refuse when `supported` is false.
+ */
+export interface PoolFundingReading {
+  /** `${assetCode}:${chain}`. */
+  pool: string;
+  assetCode: string;
+  chain: string;
+  /** `false` when no reader, or one with no `getFundingPosition` capability. */
+  supported: boolean;
+  /** Σ `funded` over the channels that read successfully. */
+  chainFundedTotal: bigint;
+  channels: readonly ChannelFundingObservation[];
+  /** Read failures — non-empty ⇒ `chainFundedTotal` is incomplete. */
+  errors: readonly string[];
+  readAt: number;
 }
 
 export interface ReconcileOptions {
@@ -370,6 +411,113 @@ export class SwapInventoryReconciler {
   }
 
   /**
+   * swap#142 — read one pool's on-chain capital position: Σ over its channels
+   * of `cumulativePaid + deposit`, each pair from ONE atomic chain read.
+   *
+   * Deliberately read-only and deliberately NOT wired into {@link reconcile}'s
+   * periodic pass: the recycle loop's job is redemptions, and adding a second
+   * RPC per channel per minute to it would double a live maker's read budget
+   * for a number only an operator action consumes. This is called on demand,
+   * by the operator surface.
+   *
+   * Channels are de-duplicated by `channelId`: `(chain, channelId)` names one
+   * on-chain object, and counting it twice — were the same id ever to appear
+   * under two channel-state keys — would corroborate capital that does not
+   * exist.
+   *
+   * Never throws: a per-channel failure is recorded and excluded from the sum
+   * (making it smaller, never larger).
+   */
+  async readPoolFunding(p: {
+    assetCode: string;
+    chain: string;
+  }): Promise<PoolFundingReading> {
+    const readAt = this.clock();
+    const pool = `${p.assetCode}:${p.chain}`;
+    const getFundingPosition = this.reader?.getFundingPosition;
+    if (!this.reader || !getFundingPosition) {
+      return {
+        pool,
+        assetCode: p.assetCode,
+        chain: p.chain,
+        supported: false,
+        chainFundedTotal: 0n,
+        channels: [],
+        errors: [
+          this.reader
+            ? `the on-chain reader for chain '${p.chain}' cannot read channel funding positions, so new capital cannot be corroborated`
+            : 'no on-chain reader configured (no EVM chainProviders entry) — channel funding cannot be read, so no capital can be corroborated',
+        ],
+        readAt,
+      };
+    }
+
+    const { channels: live } = this.channelState.snapshot();
+    const channels: ChannelFundingObservation[] = [];
+    const errors: string[] = [];
+    const seenChannelIds = new Set<string>();
+    let chainFundedTotal = 0n;
+
+    for (const [storedKey, entry] of Object.entries(live)) {
+      const parsed = parseChannelStoredKey(storedKey, entry.channelId);
+      if (!parsed) continue;
+      if (parsed.assetCode !== p.assetCode || parsed.chain !== p.chain) {
+        continue;
+      }
+      if (seenChannelIds.has(entry.channelId)) continue;
+      seenChannelIds.add(entry.channelId);
+
+      try {
+        const position = await getFundingPosition.call(this.reader, {
+          assetCode: parsed.assetCode,
+          chain: parsed.chain,
+          channelId: entry.channelId,
+        });
+        const funded = channelFundedTotal(position);
+        chainFundedTotal += funded;
+        channels.push({
+          storedKey,
+          channelId: entry.channelId,
+          cumulativePaid: position.cumulativePaid,
+          deposit: position.deposit,
+          funded,
+          observedAt: this.clock(),
+        });
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        const message = `${storedKey}: on-chain funding read failed (${detail})`;
+        errors.push(message);
+        channels.push({
+          storedKey,
+          channelId: entry.channelId,
+          cumulativePaid: null,
+          deposit: null,
+          funded: null,
+          observedAt: this.clock(),
+          error: message,
+        });
+        this.logger?.warn?.('swap.funding.read_failed', {
+          storedKey,
+          channelId: entry.channelId,
+          chain: parsed.chain,
+          err: detail,
+        });
+      }
+    }
+
+    return {
+      pool,
+      assetCode: p.assetCode,
+      chain: p.chain,
+      supported: true,
+      chainFundedTotal,
+      channels,
+      errors,
+      readAt,
+    };
+  }
+
+  /**
    * Start the periodic pass. No-op when no reader is configured or the
    * interval is non-positive. The timer is unref'd so it can never hold the
    * process open, and overlapping passes are suppressed (a slow RPC must not
@@ -381,6 +529,38 @@ export class SwapInventoryReconciler {
       void this.runGuarded();
     }, this.intervalMs);
     (this.timer as { unref?: () => void }).unref?.();
+  }
+
+  /**
+   * Best-effort snapshot of node state (`SwapStatePersister.persist`), for
+   * callers that mutated inventory outside a reconcile pass — swap#142's
+   * operator credit raises `total`, which IS the anti-double-credit watermark
+   * and so must survive a restart.
+   *
+   * Honors the same {@link stopped} guard as {@link reconcile}: after
+   * `SwapNodeInstance.stop()` has zeroed the in-memory channel watermarks
+   * (`releaseAll()`, state-store crash rule 5), persisting would write those
+   * zeros over the real ones and invite a claim replay. Returns the failure
+   * rather than throwing — a persist problem must not turn a successful
+   * in-memory credit into a 500.
+   */
+  persistState(): { persisted: boolean; error?: string } {
+    if (this.stopped || !this.persist) {
+      return {
+        persisted: false,
+        ...(this.stopped && {
+          error: 'node is stopping — state not persisted',
+        }),
+      };
+    }
+    try {
+      this.persist();
+      return { persisted: true };
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      this.logger?.error?.('swap.persist_failed', { err: detail });
+      return { persisted: false, error: detail };
+    }
   }
 
   stop(): void {

--- a/packages/swap/src/inventory.ts
+++ b/packages/swap/src/inventory.ts
@@ -43,6 +43,54 @@
  * unredeemed stays blocked, which is the same capacity block the unified
  * model expresses as `unsettled`.
  *
+ * ## Adding genuinely new capital (swap#142)
+ *
+ * {@link recordChainRedemption} recycles capital that was already counted and
+ * therefore never raises `total`. {@link creditCorroboratedFunding} is the
+ * other direction — capital the pool did not have before — and is likewise
+ * corroborated, against Σ `cumulativePaid + deposit` over the pool's channels
+ * rather than against a redemption. See its docblock for the model and for
+ * why a repeat call cannot double-credit.
+ *
+ * ## The historical `total` inflation, and why it is NOT corrected here
+ *
+ * Before swap#137, a FAILED swap unwound its `debit()` with {@link credit},
+ * which raises `available` AND `total`. Every failure therefore left `total`
+ * one swap-notional too high. #137 fixed the unwind ({@link refundDebit}, and
+ * since #138 the unwind is `releaseReservation` — no debit to undo at all) so
+ * the error cannot grow, and #140's reconciler restored `available`; the live
+ * devnet maker consequently sits at `available` 15 000 000 (correct) against
+ * `total` 15 003 500 — 3 500 units, 0.023 %, static.
+ *
+ * Nothing in this module corrects that, deliberately:
+ *
+ * - **What it actually costs is bounded and one-directional.** `total` is
+ *   what kind:10032 advertises, so the maker over-advertises by 3 500; a
+ *   counterparty that sizes a swap against the inflated figure is refused at
+ *   issuance with a benign T04, never handed a claim the maker cannot honor.
+ *   It also loosens the recycle cap in {@link recordChainRedemption} by the
+ *   same 3 500 — but that cap only binds against an on-chain redemption delta
+ *   `unsettled` does not absorb, i.e. a pre-#138 legacy burn, and by
+ *   construction there is at most as much of that as was actually burned.
+ * - **Every recompute is a DOWNWARD write derived from data the node does not
+ *   durably own.** `total = configured inventory + Σ corroborated additions`
+ *   looks exact, but the configured figure is not authoritative at runtime
+ *   (the persisted snapshot wins over config for keys it has already seen —
+ *   issue #130) and the additions ledger IS `total` itself, which the
+ *   documented state-file reset destroys. A recompute firing after such a
+ *   reset would shrink `total` below capital the maker really holds, turning
+ *   a 3 500 over-advertisement into an unbounded under-capitalisation — and
+ *   it would do so automatically, on a `:release` auto-deploy.
+ * - **It self-heals the moment it matters.** {@link creditCorroboratedFunding}
+ *   converges `total` onto chain truth from BELOW: the next genuine top-up
+ *   credits `chainFundedTotal − total`, which is the top-up minus the 3 500,
+ *   landing `total` exactly on the chain's figure. The residue moves into
+ *   `available` being 3 500 low, which is the safe direction (under-serving).
+ *
+ * If an operator ever does want it exact before then, the safe procedure is a
+ * deliberate one with the node DOWN — stop the maker, edit the persisted pool
+ * entry, restart — not a live write path that exists to be fired by accident.
+ *
  * ## Capacity formula (spec §8)
  *
  * ```
@@ -185,6 +233,30 @@ export interface ChainRedemptionResult {
    * `available` never exceeds `total`.
    */
   availableRestored: bigint;
+}
+
+/**
+ * swap#142 — what a pool's on-chain funding position does (or would do) to
+ * its `total`. See {@link SwapInventory.creditCorroboratedFunding}.
+ */
+export interface FundingCreditResult {
+  /** `total` BEFORE this operation — the watermark the credit is measured against. */
+  total: bigint;
+  /** Σ `cumulativePaid + deposit` over the pool's channels, read from chain. */
+  chainFundedTotal: bigint;
+  /** `max(0, chainFundedTotal − total)` — the most the chain can back. */
+  corroborated: bigint;
+  /** What the operator asked for (absent ⇒ "all of it"). */
+  requested?: bigint;
+  /** Actually applied to `available` AND `total` (0 on any refusal). */
+  credited: bigint;
+  /**
+   * Why nothing was applied. `uncorroborated`: the chain shows no capital the
+   * pool has not already booked. `exceeds_corroborated`: the request is larger
+   * than the chain backs — refused whole rather than clamped, so an operator
+   * never silently gets less than they asked for.
+   */
+  refused?: 'uncorroborated' | 'exceeds_corroborated';
 }
 
 /** Fresh zero result — never a shared instance a caller could mutate. */
@@ -583,6 +655,133 @@ export class SwapInventory {
       this.settledWatermarks.get(`${k}:${p.channelId}`) ?? 0n,
       p.redeemedCumulative
     );
+  }
+
+  // -------------------------------------------------------------------------
+  // swap#142 — operator route for genuinely NEW capital
+  // -------------------------------------------------------------------------
+
+  /**
+   * swap#142 — credit new capital, and ONLY what the chain corroborates.
+   *
+   * ## The problem
+   *
+   * {@link recordChainRedemption} recycles capital that was already counted:
+   * it can restore `available` but never raises `total`, because a redemption
+   * is not new money. An operator who genuinely ADDS capital — funds a new
+   * channel, tops up an existing one — therefore had no route at all
+   * (`credit` has no caller), and editing config does not reliably take: the
+   * persisted snapshot wins over config inventory for keys it has already
+   * seen (issue #130).
+   *
+   * ## The corroboration, and why it cannot double-credit
+   *
+   * The chain-side quantity is **Σ over the pool's channels of
+   * `cumulativePaid + deposit`** (`channelFundedTotal`), NOT the raw `deposit`
+   * field. `deposit` is the *remaining un-paid-out* balance and falls on every
+   * redemption (`deposit -= delta; cumulativePaid += delta`), so it is neither
+   * monotone nor a measure of capital added. Their sum is invariant under
+   * redemption and rises only when capital actually enters a channel.
+   *
+   * The node-side quantity it is compared against is **`total` itself** — the
+   * pool's own record of the capital it holds. The credit is the excess of
+   * proof over claim:
+   *
+   * ```
+   * corroborated = max(0, chainFundedTotal − total)
+   * ```
+   *
+   * and applying it uses {@link credit}, which raises `available` AND `total`
+   * by the same amount. **`total` is therefore its own watermark**, and the
+   * credit is a fixed-point step that closes exactly the gap it measured:
+   *
+   * - Repeated calls cannot double-credit. Crediting `c` makes `total' =
+   *   total + c`, so the next read of the same `chainFundedTotal` computes
+   *   `max(0, chainFundedTotal − total') = corroborated − c = 0`. There is no
+   *   separate ledger that could drift, be lost, or be replayed — nothing to
+   *   persist beyond `total`, which the state file already carries.
+   * - Over the pool's whole life, Σ credited = `total_final − total_initial`
+   *   ≤ `sup(chainFundedTotal) − total_initial`. The node can never book more
+   *   capital than the chain has, at any moment, shown to be in its channels.
+   * - Capital that *leaves* (a funder reclaiming an unspent remainder on
+   *   close) makes `chainFundedTotal` fall below `total`; the `max(0, …)`
+   *   makes that a refusal, not a negative credit, and `total` is deliberately
+   *   never lowered here — this route only ever adds, so it can only ever
+   *   under-serve, never over-serve. Re-funding back to a previously credited
+   *   level correctly credits nothing.
+   * - A channel the node cannot read, or does not know about, is simply absent
+   *   from the sum, which UNDER-states `chainFundedTotal` and under-credits.
+   *   Under-crediting is the safe failure; the caller additionally refuses
+   *   outright when any read fails (see the admin route).
+   *
+   * Note what this deliberately cannot corroborate: capital sitting in the
+   * payout wallet but not yet placed in a channel. The chain shows no channel
+   * holding it, so the node will not book it. That is the invariant working,
+   * not a gap — move it into a channel and it becomes creditable.
+   *
+   * ## Atomicity
+   *
+   * Synchronous, like every other mutator here, and it re-reads `total` at
+   * the moment it credits. A caller MUST therefore do its chain read first
+   * and then call this — never cache a `total` across the `await`. Two
+   * concurrent operator requests that both read the same `chainFundedTotal`
+   * are safe: the first credits the gap, the second finds it closed and is
+   * refused as `uncorroborated`.
+   *
+   * @param p.chainFundedTotal Σ `cumulativePaid + deposit` over the pool's
+   *   channels, from a LIVE chain read — never a cached or asserted value.
+   * @param p.requested Optional operator assertion. Larger than the chain
+   *   backs ⇒ refused whole (`exceeds_corroborated`), nothing applied.
+   *   Smaller ⇒ exactly that much is credited and the remainder stays
+   *   creditable, since `total` still trails `chainFundedTotal`.
+   */
+  creditCorroboratedFunding(p: {
+    assetCode: string;
+    chain: string;
+    chainFundedTotal: bigint;
+    requested?: bigint;
+  }): FundingCreditResult {
+    const outcome = this.previewCorroboratedFunding(p);
+    if (outcome.credited > 0n) {
+      this.credit(p.assetCode, p.chain, outcome.credited);
+    }
+    return outcome;
+  }
+
+  /**
+   * What {@link creditCorroboratedFunding} WOULD do, without mutating
+   * anything — the dry-run behind the operator surface's `dryRun` flag.
+   */
+  previewCorroboratedFunding(p: {
+    assetCode: string;
+    chain: string;
+    chainFundedTotal: bigint;
+    requested?: bigint;
+  }): FundingCreditResult {
+    const k = key(p.assetCode, p.chain);
+    const entry = this.entries.get(k);
+    if (!entry) {
+      throw new SwapInventoryError(
+        'INVENTORY_NOT_INITIALIZED',
+        `Inventory not initialized for ${k}`
+      );
+    }
+    const total = entry.total;
+    const corroborated =
+      p.chainFundedTotal > total ? p.chainFundedTotal - total : 0n;
+    const base = {
+      total,
+      chainFundedTotal: p.chainFundedTotal,
+      corroborated,
+      ...(p.requested !== undefined && { requested: p.requested }),
+    };
+    if (corroborated === 0n) {
+      return { ...base, credited: 0n, refused: 'uncorroborated' };
+    }
+    if (p.requested !== undefined && p.requested > corroborated) {
+      return { ...base, credited: 0n, refused: 'exceeds_corroborated' };
+    }
+    return { ...base, credited: p.requested ?? corroborated };
   }
 
   private applyRedemption(


### PR DESCRIPTION
Closes #142.

`/admin/inventory/credit` (#140) applies **only** what an on-chain redemption corroborates. That is the right default for *recycling* and it leaves exactly one legitimate operator action with no route at all: **adding genuinely new capital**. `SwapInventory.credit` has no caller, and raising the configured inventory does not reliably take — the persisted snapshot wins over config for pool keys the node has already seen (#130). Funding a new channel meant a redeploy and a hope.

## 1. The corroboration, and why it cannot double-credit

**The ticket's suggestion — read the `deposit` field — does not work, and the reason matters.** On `RollingSwapChannel`, `deposit` is the *remaining, un-paid-out* balance, not the cumulative amount ever deposited: `updateBalance` does `deposit -= delta; cumulativePaid += delta` on every redemption. Read alone it is a *falling* number on a busy maker — the opposite of a monotone corroboration of added capital. The quantity that behaves is the **sum**:

```
funded(channel) = cumulativePaid + deposit
```

invariant under redemption (one word falls by exactly what the other rises by), rising only when capital actually enters the channel (`openChannel`, `deposit()`), falling only when the funder reclaims an unspent remainder on close — a genuine withdrawal, which must credit nothing.

**The node-side quantity it is compared against is `total` itself.** The credit is the excess of chain proof over booked claim:

```
corroborated = max(0, Σ funded(channel) − total)
```

and applying it goes through the existing `SwapInventory.credit`, which raises `available` **and** `total` by the same amount. So **`total` is its own watermark** and the credit is a fixed-point step that closes exactly the gap it measured:

- **A repeat call cannot double-credit.** Crediting `c` makes `total' = total + c`, so the next read of the same `Σ funded` computes `max(0, Σ funded − total') = 0` → `409 uncorroborated`. There is no separate ledger that could drift, be lost, or be replayed — **nothing new is persisted**, and the one thing that is (`total`) the state file already carries. This is what a per-channel `alreadyCreditedDeposit` watermark would have required, plus a schema migration, plus a "baseline adoption" rule to stop the first call crediting capital the config already counted. The fixed point dissolves all three: a pool whose `total` was *under*-stated relative to its channels is correctly topped up rather than swallowed by a baseline.
- **Over the pool's whole life**, Σ credited = `total_final − total_initial` ≤ `sup(Σ funded) − total_initial`. The node can never book more capital than the chain has, at some moment, shown to be in its channels.
- **Capital leaving** (a close returning a remainder) drives `Σ funded` below `total`; `max(0, …)` makes that a refusal, not a negative credit, and this route never lowers `total`. Re-funding back to a previously credited level correctly credits nothing.
- **Reads are atomic where it counts.** `cumulativePaid` and `deposit` come from ONE `eth_call` — two calls straddling a redemption would see the pre-redemption `deposit` with the post-redemption `cumulativePaid` and **overstate** `funded` by the redeemed delta, which is precisely the read that would let the surface invent capital. The seam docs this as a MUST for implementors.
- **Missing or unreadable channels only ever shrink the sum**, i.e. under-credit. The route additionally refuses outright (`503`) when any read fails, because an operator asking "did my top-up land?" must not get a silently partial answer.

Deliberately not corroborable: capital sitting in the payout wallet but not yet in a channel. The chain shows no channel holding it, so the node will not book it. That is the invariant working, not a gap.

## 2. The seam

`ChannelOnChainReader` gains an **optional** `getFundingPosition` capability, implemented for EVM as one `eth_call` decoding words 3 and 4 of the same `Channel` struct response. Optional on purpose: #141's Solana/Mina readers satisfy the interface unchanged, and callers feature-detect and **fail closed** (`503 funding_unreadable`) rather than guessing a funding level. No reader implementation other than the existing EVM one is touched, and `startSwapNode` is not touched at all.

The route consumes the seam through `SwapInventoryReconciler.readPoolFunding`, which reuses the reconciler's existing channel-state walk and `parseChannelStoredKey`. It is deliberately **not** wired into the periodic reconcile pass — the recycle loop's job is redemptions, and doubling a live maker's per-channel RPC every 60s for a number only an operator action consumes is not a trade worth making.

## 3. Protection — unchanged from #140

Under `/admin` (the fleet's box nginx already 404s `^~ /admin`), same constant-time token check, **no token configured = writes disabled 503, never open**. `dryRun: true` runs the identical decision and returns the identical status code while mutating nothing, so an operator can see exactly what the real call will do.

**No new config key** — nothing was added, optional or otherwise. #134 crash-looped the live maker precisely because a required key landed on a `:release` auto-deploy.

## 4. On the historical `total` inflation (task 2) — documented, not "fixed"

The live devnet maker reads `available` 15 000 000 (correct after #140's reconciler) against `total` 15 003 500 — 3 500 units accumulated from failed swaps before #137 fixed the unwind. **No correction path is shipped**, and the reasoning is written into `inventory.ts` and `deploy/swap/README.md`, not just here:

- **What it costs is bounded and one-directional.** `total` is what kind:10032 advertises, so the maker over-advertises by 0.023 %; a counterparty sizing against the inflated figure is refused at issuance with a benign `T04`, never handed a claim the maker cannot honor. It also loosens `recordChainRedemption`'s recycle cap by the same 3 500 — but that cap only binds against an on-chain redemption delta `unsettled` does not absorb, i.e. a pre-#138 legacy burn, of which there is by construction at most as much as was actually burned.
- **Every recompute is a *downward* write derived from data the node does not durably own.** `total = configured + Σ corroborated additions` looks exact, but the configured figure is not authoritative at runtime (#130) and the additions ledger *is* `total`, which the documented state-file reset destroys. Firing after such a reset, a recompute would shrink `total` below capital the maker really holds — turning a bounded cosmetic error into an unbounded under-capitalisation, automatically, on a `:release` auto-deploy. That is strictly worse than the problem.
- **It self-heals the moment it matters.** This PR's route converges `total` onto chain truth **from below**: the next genuine top-up credits `Σ funded − total` — the top-up *minus* the 3 500 — landing `total` exactly on the chain's figure. The residue moves into `available` being 3 500 low, the under-serving (safe) direction. Pinned by a test.

If it must be exact sooner, the safe procedure is a deliberate one with the node **down** (stop, edit the persisted pool entry, restart), documented in the deploy README — not a live write path that can be fired by accident.

## Tests

`inventory-deposit.test.ts` (24 new) plus 3 in `evm-channel-reader.test.ts`:

- **The four required ACs.** A corroborated top-up credits **exactly once** (409 before the deposit lands → 200 crediting 5 000 000 → **409 on the identical repeat**, with `total`/`available` unmoved); an uncorroborated top-up is refused 409 with the operator's asserted `amount` changing nothing; the write surface is **closed with no token configured** (503 both with and without a presented token, and 401 for a wrong token once one is set).
- **The corroboration quantity.** `channelFundedTotal` is invariant under redemption where `deposit` alone falls; the end-to-end test uses a *partly redeemed* channel (`cumulativePaid` 1 000, `deposit` 14 999 000) and asserts `chainFundedTotal` is 15 000 000 — a raw-`deposit` implementation reports 14 999 000 here and then hands the operator a phantom 1 000 on the next top-up. A redemption *after* the credit does not make it creditable again.
- **The bounds.** 25 replays credit exactly what one does; chain funding at/below `total` refuses; capital leaving never lowers `total` and re-funding to a credited level credits nothing; `exceeds_corroborated` refuses **whole**; a partial request credits exactly that and leaves the remainder creditable; over a 7-reading life Σ credited equals `sup(Σ funded) − total_initial`; preview mutates nothing while predicting the same numbers.
- **Failing closed.** Unreadable chain → 503; a redemption-only reader (#141's shape) → 503 `funding_unreadable`; no provisioned channel → 404; malformed body → 400 before any chain read.
- **The seam.** `getFundingPosition` returns both words from exactly **one** `eth_call` (asserted by call count), decodes `deposit` from word 4 distinctly from `cumulativePaid`, and throws on a truncated response.
- **The task-2 claim.** The 15 003 500 → 20 000 000 convergence is pinned, including `available` ending 3 500 low and never above `total`.

Gate: `gate:correctness` PASS (lint 0/351 vs frozen 0/352; typecheck 4 errors vs frozen 25 — the 4 are the pre-existing `claim-refusal.test.ts` ones from #137), 467 tests green, prettier clean. Rebased on `main`; no overlap with #141 (reader implementations) beyond the optional interface member, and `swap-node.ts` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
