### PR TITLE
A rolling fill cannot be delivered — leg B has no route to a direct-dialled sender

### DIFF
--- a/.changeset/leg-b-return-path.md
+++ b/.changeset/leg-b-return-path.md
@@ -1,0 +1,37 @@
+---
+---
+
+**A rolling fill can now actually be delivered: leg B goes back over the BTP session its RFQ arrived on.**
+
+A live devnet swap negotiated a rolling session end to end for the first time — and then delivered nothing. The maker quoted, opened the session, and F02'd its own leg-B PREPARE:
+
+```
+maker:  REJECT destination=g.toon.client errorCode=F02 "no route found"
+maker:  swap.rolling.fill_unwound streamNonce=1007de73… seq=1 cause=F02
+client: F99 "leg B failed; fill not executed"  packetsAccepted 0, valueReceived 0
+```
+
+The address was right. The maker simply had no way to reach it, and — because auto-probe is the default and this maker now answers the RFQ — **every** default swap against it failed. Only an explicit `rolling: "off"` still worked.
+
+**Two layers, both maker-side, neither of which any existing test could see** (every rolling test injects `rollingLegBSender` or drives a fake connector, so leg B never touched a routing table):
+
+1. **No route.** A client that direct-dials the maker's BTP server is an inbound *session*, bound in `BTPServer.peers` under the `peerId` it declared on the auth greeting — never a routing-table entry. `ConnectorNode.sendPacket` resolves a destination only through `RoutingTable.getNextHop()`, so leg B was rejected before it left the maker. Requiring an operator to hand-configure a route for each client would make the direct-dial model (swap#105, `docker-compose.relay.swap.yml`) unusable.
+
+2. **No settlement channel.** Even routed, `PacketHandler` demands a per-packet claim on every value-bearing forward to a non-`child` next hop, and a maker holds no payment channel toward the client it is *paying* — so a routed leg B answers `T00 "No payment channel available for peer"` instead. `'child'` is the ILP-correct relation, not a workaround: the connector's own comment for that skip is *"a parent settles DOWN to a child by letting the child accrue a balance owed up"*, which is exactly the rolling swap's netting (the sender pays on leg A; leg B's value is the signed chain-B claim inside the packet, never an ILP settlement over the link).
+
+New `leg-b-return-path.ts` resolves the return path at RFQ intake, from the session the RFQ actually arrived on (`LocalDeliveryRequest.sourcePeer`) — so a **stock client works against a stock maker with no operator routing configuration**. It adds no config key.
+
+Guards, because an RFQ payload is attacker-controlled:
+
+- the route is only ever `prefix: X → nextHop: X` for the string the peer **authenticated under** — a stock client's `senderIlpAddress` is by construction the same expression as its BTP greeting `peerId`, and requiring the match stops an RFQ claiming `senderIlpAddress: "g.proxy"` from shadowing the maker's upstream route;
+- a prefix that would shadow the maker's own `ilpAddress` is refused;
+- an operator/static route for the same prefix always wins;
+- bindings are capped and LRU-evicted, and withdrawn on `stop()`.
+
+**When the maker cannot deliver, it now refuses at leg 0** (`F02` / `reason: "no_return_path"`) instead of minting a session every fill will fail. That is the only moment failing is free — nothing quoted, no inventory reserved, no leg A revealed — and a sender's existing RFQ-failure fallback quietly takes the legacy path, which works. No retry-after-failure was added: re-running a fill as legacy after a rolling attempt is exactly the shape that risks double-delivery, and the withhold property (spec R5/R8) is what made the original failure free.
+
+Also: the standalone connector branch now sets `settlement: { connectorFeePercentage: 0 }`, mirroring the embedded-with-parent branch. Without it the default fee shaved the ILP `amount` of the one thing a standalone maker ever forwards — its own leg-B PREPARE — so the packet understated the claim it carried (3000 → 2997).
+
+Withhold behaviour is unchanged, and is now also asserted on the real wire: a sender that answers leg B with a REJECT leaves leg A rejected with no preimage learned.
+
+New tests boot a REAL `startSwapNode()` with a REAL `ConnectorNode` and drive it from a REAL `BtpRuntimeClient` over a socket — the same `onMessage` seam a stock client installs its leg-B router on. That is what caught defect 2; a unit test of address derivation would have caught neither.

--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toon-protocol/swap",
   "version": "2.1.0",
-  "description": "TOON Protocol swap node — multi-chain payment-channel claim issuer (EVM/Solana/Mina)",
+  "description": "TOON Protocol swap node \u2014 multi-chain payment-channel claim issuer (EVM/Solana/Mina)",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -75,6 +75,7 @@
   },
   "devDependencies": {
     "@toon-protocol/client": "^0.29.8",
+    "@toon-protocol/shared": "^1.3.0",
     "@types/node": "^20.0.0",
     "@types/ws": "^8.18.1",
     "tsup": "^8.0.0",

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -239,6 +239,19 @@ export type {
   RfqQuote,
 } from './rolling-rfq.js';
 
+// Leg-B return path — how a maker addresses a direct-dialled sender's daemon
+export {
+  createLegBReturnRouteBinder,
+  DEFAULT_MAX_RETURN_ROUTE_BINDINGS,
+  DEFAULT_RETURN_ROUTE_PRIORITY,
+} from './leg-b-return-path.js';
+export type {
+  LegBReturnPath,
+  LegBReturnRouteBinder,
+  LegBReturnRouteBinderOptions,
+  ReturnRouteConnectorLike,
+} from './leg-b-return-path.js';
+
 // HTTP rate provider — CLI `rateProvider` wiring (issue #47 AC-3)
 export {
   createHttpRateProvider,

--- a/packages/swap/src/leg-b-return-path.test.ts
+++ b/packages/swap/src/leg-b-return-path.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Unit cover for the leg-B return-route binder's decision table.
+ *
+ * The DELIVERY proof lives in `swap-node.leg-b-wire.test.ts`, which drives a
+ * real BTP session against a real `ConnectorNode`. What is checked here is the
+ * part a wire test cannot enumerate cheaply: the guards that stop this from
+ * becoming a routing-table hijack, and the bookkeeping that stops it from
+ * growing without bound.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { createLegBReturnRouteBinder } from './leg-b-return-path.js';
+
+const MAKER_ILP = 'g.toon.swap.fixture';
+
+interface Route {
+  prefix: string;
+  nextHop: string;
+  priority?: number;
+}
+
+function fakeConnector(seed: Route[] = []) {
+  const routes: Route[] = [...seed];
+  const relations = new Map<string, string>();
+  return {
+    routes,
+    relations,
+    addRoute(route: Route) {
+      const at = routes.findIndex((r) => r.prefix === route.prefix);
+      if (at >= 0) routes.splice(at, 1);
+      routes.push(route);
+    },
+    removeRoute(prefix: string) {
+      const at = routes.findIndex((r) => r.prefix === prefix);
+      if (at < 0) throw new Error(`Route not found: ${prefix}`);
+      routes.splice(at, 1);
+    },
+    listRoutes(): Route[] {
+      return routes.map((r) => ({ ...r }));
+    },
+    _packetHandler: {
+      setPeerRelation(peerId: string, relation: string) {
+        relations.set(peerId, relation);
+      },
+      getPeerRelation(peerId: string) {
+        return relations.get(peerId);
+      },
+    },
+  };
+}
+
+describe('leg-B return-route binder', () => {
+  it('[P0] binds the arrival session and marks it a child so a paid leg B is not claim-gated', () => {
+    const connector = fakeConnector();
+    const binder = createLegBReturnRouteBinder(connector, {
+      ilpAddress: MAKER_ILP,
+    });
+
+    const result = binder.bind({
+      senderIlpAddress: 'g.toon.client.a',
+      sourcePeer: 'g.toon.client.a',
+    });
+
+    expect(result).toEqual({ status: 'bound', nextHop: 'g.toon.client.a' });
+    expect(connector.listRoutes()).toContainEqual(
+      expect.objectContaining({
+        prefix: 'g.toon.client.a',
+        nextHop: 'g.toon.client.a',
+      })
+    );
+    // Without this the forward is gated on a settlement claim the maker can
+    // never produce toward its own customer (T00, not F02).
+    expect(connector.relations.get('g.toon.client.a')).toBe('child');
+  });
+
+  it('[P0] refuses to bind an address the arrival session did not authenticate under', () => {
+    const connector = fakeConnector();
+    const binder = createLegBReturnRouteBinder(connector, {
+      ilpAddress: MAKER_ILP,
+    });
+
+    // The hijack this guard exists for: claim someone else's prefix in the
+    // RFQ payload and the maker would install a route shadowing it.
+    const result = binder.bind({
+      senderIlpAddress: 'g.proxy',
+      sourcePeer: 'g.toon.client.a',
+    });
+
+    expect(result.status).toBe('unreachable');
+    expect(connector.listRoutes()).toHaveLength(0);
+    expect(connector.relations.size).toBe(0);
+  });
+
+  it('[P0] never shadows the maker own ilpAddress (no self-delivery hijack)', () => {
+    const connector = fakeConnector([
+      { prefix: MAKER_ILP, nextHop: 'toon-swap-fixture', priority: 100 },
+    ]);
+    const binder = createLegBReturnRouteBinder(connector, {
+      ilpAddress: MAKER_ILP,
+    });
+
+    // A peer that authenticated as an ANCESTOR of our own address. Binding it
+    // would divert the maker's own local delivery out over that session.
+    const result = binder.bind({
+      senderIlpAddress: 'g.toon.swap',
+      sourcePeer: 'g.toon.swap',
+    });
+
+    expect(result.status).not.toBe('bound');
+    expect(connector.listRoutes()).toEqual([
+      { prefix: MAKER_ILP, nextHop: 'toon-swap-fixture', priority: 100 },
+    ]);
+  });
+
+  it('[P0] an operator route for the same prefix wins and is left untouched', () => {
+    const connector = fakeConnector([
+      { prefix: 'g.toon.client.a', nextHop: 'apex', priority: 10 },
+    ]);
+    const binder = createLegBReturnRouteBinder(connector, {
+      ilpAddress: MAKER_ILP,
+    });
+
+    const result = binder.bind({
+      senderIlpAddress: 'g.toon.client.a',
+      sourcePeer: 'g.toon.client.a',
+    });
+
+    expect(result).toEqual({ status: 'routed', nextHop: 'apex' });
+    expect(connector.listRoutes()).toEqual([
+      { prefix: 'g.toon.client.a', nextHop: 'apex', priority: 10 },
+    ]);
+  });
+
+  it('[P0] adopts a return route replayed from the registry after a restart', () => {
+    // Runtime routes are persisted and replayed on boot; the peer RELATION is
+    // not. Deferring to the replayed route would leave every leg B gated on a
+    // settlement claim (T00) until the process was restarted again.
+    const connector = fakeConnector([
+      { prefix: 'g.toon.client.a', nextHop: 'g.toon.client.a', priority: 50 },
+    ]);
+    const binder = createLegBReturnRouteBinder(connector, {
+      ilpAddress: MAKER_ILP,
+    });
+
+    const result = binder.bind({
+      senderIlpAddress: 'g.toon.client.a',
+      sourcePeer: 'g.toon.client.a',
+    });
+
+    expect(result).toEqual({ status: 'bound', nextHop: 'g.toon.client.a' });
+    expect(connector.relations.get('g.toon.client.a')).toBe('child');
+    expect(connector.listRoutes()).toHaveLength(1);
+  });
+
+  it('an apex-forwarded RFQ needs no ephemeral route — the default-up route already reaches the sender', () => {
+    const connector = fakeConnector([
+      { prefix: MAKER_ILP, nextHop: 'toon-swap-fixture', priority: 100 },
+      { prefix: 'g', nextHop: 'apex', priority: 0 },
+    ]);
+    const binder = createLegBReturnRouteBinder(connector, {
+      ilpAddress: MAKER_ILP,
+    });
+
+    const result = binder.bind({
+      senderIlpAddress: 'g.toon.client.a',
+      sourcePeer: 'apex',
+    });
+
+    expect(result).toEqual({ status: 'routed', nextHop: 'apex' });
+    expect(binder.boundPrefixes()).toEqual([]);
+  });
+
+  it('an ILP-over-HTTP arrival has no session to reply on and no route: unreachable', () => {
+    const connector = fakeConnector([
+      { prefix: MAKER_ILP, nextHop: 'toon-swap-fixture', priority: 100 },
+    ]);
+    const binder = createLegBReturnRouteBinder(connector, {
+      ilpAddress: MAKER_ILP,
+    });
+
+    expect(
+      binder.bind({
+        senderIlpAddress: 'g.toon.client.a',
+        sourcePeer: 'http:anon',
+      }).status
+    ).toBe('unreachable');
+  });
+
+  it('a connector with no routing introspection degrades to the pre-fix behaviour', () => {
+    const binder = createLegBReturnRouteBinder(
+      { sendPacket: async () => ({ type: 'reject' }) },
+      { ilpAddress: MAKER_ILP }
+    );
+
+    // `unavailable`, NOT `unreachable`: an embedder's own connector must keep
+    // minting sessions exactly as it did before this module existed.
+    expect(
+      binder.bind({
+        senderIlpAddress: 'g.toon.client.a',
+        sourcePeer: 'g.toon.client.a',
+      })
+    ).toEqual({ status: 'unavailable' });
+  });
+
+  it('re-binding the same session is idempotent', () => {
+    const connector = fakeConnector();
+    const binder = createLegBReturnRouteBinder(connector, {
+      ilpAddress: MAKER_ILP,
+    });
+    const args = {
+      senderIlpAddress: 'g.toon.client.a',
+      sourcePeer: 'g.toon.client.a',
+    };
+
+    binder.bind(args);
+    binder.bind(args);
+
+    expect(connector.listRoutes()).toHaveLength(1);
+    expect(binder.boundPrefixes()).toEqual(['g.toon.client.a']);
+  });
+
+  it('bindings are bounded — the least recent is withdrawn, never accumulated', () => {
+    const connector = fakeConnector();
+    const binder = createLegBReturnRouteBinder(connector, {
+      ilpAddress: MAKER_ILP,
+      maxBindings: 2,
+    });
+
+    for (const id of ['a', 'b', 'c']) {
+      binder.bind({
+        senderIlpAddress: `g.toon.client.${id}`,
+        sourcePeer: `g.toon.client.${id}`,
+      });
+    }
+
+    expect(binder.boundPrefixes()).toEqual([
+      'g.toon.client.b',
+      'g.toon.client.c',
+    ]);
+    expect(connector.listRoutes().map((r) => r.prefix)).toEqual([
+      'g.toon.client.b',
+      'g.toon.client.c',
+    ]);
+  });
+
+  it('release() hands a caller-owned connector back its original routing table', () => {
+    const connector = fakeConnector([
+      { prefix: MAKER_ILP, nextHop: 'toon-swap-fixture', priority: 100 },
+    ]);
+    const binder = createLegBReturnRouteBinder(connector, {
+      ilpAddress: MAKER_ILP,
+    });
+
+    binder.bind({
+      senderIlpAddress: 'g.toon.client.a',
+      sourcePeer: 'g.toon.client.a',
+    });
+    binder.release();
+    binder.release(); // idempotent
+
+    expect(connector.listRoutes()).toEqual([
+      { prefix: MAKER_ILP, nextHop: 'toon-swap-fixture', priority: 100 },
+    ]);
+    expect(binder.boundPrefixes()).toEqual([]);
+  });
+});

--- a/packages/swap/src/leg-b-return-path.ts
+++ b/packages/swap/src/leg-b-return-path.ts
@@ -1,0 +1,378 @@
+/**
+ * Leg-B return path (rolling-swap spec §3) — how a maker addresses the
+ * sender's daemon.
+ *
+ * ## The defect this module exists to fix
+ *
+ * A rolling session negotiates over leg 0 (the RFQ) and then every fill's
+ * leg B is an ILP PREPARE the maker ORIGINATES back to the sender's
+ * `senderIlpAddress`. The maker originates it through the connector's public
+ * `sendPacket`, which resolves the destination the only way a connector can:
+ * `RoutingTable.getNextHop()`, a longest-prefix match over the routing table
+ * (connector `core/packet-handler.ts` `handlePreparePacket`).
+ *
+ * A client that DIRECT-DIALS the maker's BTP server is in nobody's routing
+ * table. It is an *inbound BTP session*, bound in the connector's
+ * `BTPServer.peers` map under the `peerId` it declared on the BTP auth
+ * greeting, verbatim (connector `btp/btp-server.ts` `authenticatePeer` —
+ * `this.peers.set(peerId, peerConn)`). Nothing in `ConnectorNode` ever turns
+ * that session into a route. So leg B was rejected
+ * `F02 no route found` before it left the maker, every single fill, and the
+ * rolling protocol was undeliverable against a stock client:
+ *
+ * ```
+ * maker: REJECT destination=g.toon.client errorCode=F02 "no route found"
+ * maker: swap.rolling.fill_unwound streamNonce=… seq=1 cause=F02
+ * ```
+ *
+ * The connector already knows how to send over an inbound session — its
+ * `forwardToNextHop` prefers an outbound client, then falls back to
+ * `btpServer.sendPacketToPeer(nextHop, …)` when `btpServer.hasPeer(nextHop)`.
+ * The ONLY missing ingredient is a routing-table entry whose `nextHop` names
+ * that session. This module adds exactly that entry, for the lifetime of the
+ * maker process, keyed off the session the RFQ actually arrived on — so a
+ * stock client works against a stock maker with **no operator routing
+ * configuration** (the direct-dial model swap#105 proved and
+ * `docker-compose.relay.swap.yml` documents).
+ *
+ * ## Why the binding requires `senderIlpAddress === sourcePeer`
+ *
+ * The route this module adds is always `prefix: X → nextHop: X`, where `X` is
+ * the string the peer **authenticated under** on this connector's BTP server
+ * (`LocalDeliveryRequest.sourcePeer`, which the connector sets to
+ * `peerConn.peerId`). It is never a name the RFQ payload alone can choose.
+ *
+ * That is not a limitation for a stock client: `ToonClient.getOwnIlpAddress()`
+ * — the default `senderIlpAddress` an RFQ carries — is literally the same
+ * expression the client uses for its BTP greeting `peerId`
+ * (`config.btpPeerId ?? config.ilpInfo.ilpAddress`), so the two match by
+ * construction. But it closes a hijack: without it, any peer could publish an
+ * RFQ claiming `senderIlpAddress: 'g.proxy'` and install a routing-table entry
+ * that shadows the maker's own upstream route for every packet under that
+ * prefix. Requiring the address to equal the authenticated session id means an
+ * ephemeral route can only ever capture traffic addressed to that peer's own
+ * name — which the peer already owns on this connector.
+ *
+ * Two further guards, for the same reason:
+ *
+ *  - never bind a prefix that would shadow the maker's own `ilpAddress`
+ *    (that would divert the maker's local delivery to a peer);
+ *  - never overwrite a route this module did not add (operator/static config
+ *    always wins — see {@link LegBReturnRouteBinder.bind}'s `'routed'`).
+ *
+ * ## Why the peer is also marked a `child`
+ *
+ * A route alone is still not enough. `PacketHandler` requires a per-packet
+ * settlement claim on **every value-bearing forward to a non-`child` next
+ * hop** (`requiresSettlementClaim` — `peerRelations.get(peerId) !== 'child'`),
+ * and a maker has no payment channel toward a client it is *paying*. So a
+ * routed leg B answers `T00 "No payment channel available for peer"` instead
+ * of `F02 "no route found"` — the same undeliverable fill, one layer down.
+ *
+ * `'child'` is the ILP-correct relation here, not a workaround. The connector's
+ * own comment for the skip says it: *"a parent settles DOWN to a child by
+ * letting the child accrue a balance owed up (the child settles via its own
+ * up-claims)"*. That is precisely the rolling swap's netting — the sender pays
+ * the maker on leg A, and leg B's value is the signed chain-B claim carried in
+ * the packet's `data`, never an ILP settlement the maker owes back over the
+ * link.
+ *
+ * The connector exposes `setPeerRelation` only to its admin HTTP server
+ * (`core/connector-node.ts` wires it into `AdminServer`), and a swap node runs
+ * with `adminApi: { enabled: false }`, so this reaches the `PacketHandler`
+ * directly. It is guarded and best-effort: a connector that does not expose it
+ * still gets the route, and a leg B that then trips the claim gate fails
+ * loudly and benignly (T00, nothing revealed) rather than silently.
+ *
+ * Ordering is load-bearing: the route is added FIRST. `ConnectorNode.addRoute`
+ * validates relation↔route admission, and a `'child'` peer may only hold
+ * routes *under the connector's own address* — which a sender's address never
+ * is. Adding the route while the peer is still an ordinary `'peer'` and
+ * marking it a child afterwards satisfies both rules.
+ *
+ * ## When there is no return path
+ *
+ * `bind()` reports `'unreachable'` when it can positively determine that the
+ * maker can neither reply on the arrival session nor route to the address.
+ * The RFQ intake turns that into a leg-0 REJECT, which is the ONLY safe
+ * moment to fail: nothing has been quoted, no inventory reserved, no leg A
+ * revealed — and a sender's existing RFQ-failure fallback (toon-client#591)
+ * quietly takes the legacy swap path, which works. Establishing a session the
+ * maker knows it cannot deliver on is what turned a working default swap into
+ * `F99 leg B failed; fill not executed`.
+ */
+
+/**
+ * The slice of `ConnectorNode`'s public API this module drives. All optional:
+ * a test double or an HTTP-mode connector that exposes none of it degrades to
+ * `'unavailable'`, i.e. exactly the pre-fix behaviour.
+ */
+export interface ReturnRouteConnectorLike {
+  addRoute?(route: {
+    prefix: string;
+    nextHop: string;
+    priority?: number;
+  }): void;
+  removeRoute?(prefix: string): void;
+  listRoutes?(): readonly { prefix: string; nextHop: string }[];
+  /**
+   * `ConnectorNode`'s internal forwarding seam. Only the admin HTTP server is
+   * handed a public `setPeerRelation`, and a swap node runs without one — see
+   * the module doc. Structurally typed and fully optional.
+   */
+  _packetHandler?: {
+    setPeerRelation?: (peerId: string, relation: string) => void;
+    getPeerRelation?: (peerId: string) => string | undefined;
+  };
+}
+
+/** Outcome of resolving a session's leg-B return path. */
+export type LegBReturnPath =
+  /** An ephemeral route now points `senderIlpAddress` at the arrival session. */
+  | { status: 'bound'; nextHop: string }
+  /** The routing table already resolves the address (operator/parent route). */
+  | { status: 'routed'; nextHop: string }
+  /** The connector exposes no routing introspection — behave as before. */
+  | { status: 'unavailable' }
+  /** No arrival session to reply on and no route: leg B cannot be delivered. */
+  | { status: 'unreachable'; reason: string };
+
+export interface LegBReturnRouteBinderOptions {
+  /**
+   * The maker's own ILP address. A sender may never bind a prefix that
+   * equals it or is one of its ancestors.
+   */
+  ilpAddress?: string;
+  /** Cap on simultaneously bound ephemeral routes; oldest is evicted. */
+  maxBindings?: number;
+  /**
+   * Priority of the ephemeral route. Longest-prefix match decides first, so
+   * this only breaks ties against another route with the SAME prefix — which
+   * the `'routed'` guard already refuses to create.
+   */
+  priority?: number;
+  logger?: {
+    debug?: (msg: string, meta?: Record<string, unknown>) => void;
+    warn?: (msg: string, meta?: Record<string, unknown>) => void;
+  };
+}
+
+export const DEFAULT_MAX_RETURN_ROUTE_BINDINGS = 256;
+export const DEFAULT_RETURN_ROUTE_PRIORITY = 50;
+
+/**
+ * `sourcePeer` values that can never name a duplex session to reply on.
+ *
+ * `http:*` is the connector's namespace for an ILP-over-HTTP arrival
+ * (`http/ilp-http-adapter.ts` — `http:anon` / `http:<claim-signer>`): a
+ * request/response hop with no socket the maker can originate a PREPARE on.
+ * `unknown` is `PacketHandler`'s placeholder for an unattributed packet.
+ */
+function isReplyableSessionId(sourcePeer: string | undefined): boolean {
+  if (typeof sourcePeer !== 'string' || sourcePeer.length === 0) return false;
+  if (sourcePeer === 'unknown' || sourcePeer === 'local') return false;
+  if (sourcePeer.startsWith('http:')) return false;
+  return true;
+}
+
+/** ILP longest-prefix semantics: `p` covers `addr` on label boundaries only. */
+function covers(prefix: string, addr: string): boolean {
+  return addr === prefix || addr.startsWith(`${prefix}.`);
+}
+
+export interface LegBReturnRouteBinder {
+  /**
+   * Resolve (and if possible install) the leg-B return path for a session.
+   * Idempotent: re-binding the same address to the same session is a no-op
+   * that only refreshes its eviction recency.
+   */
+  bind(args: { senderIlpAddress: string; sourcePeer?: string }): LegBReturnPath;
+  /** Prefixes this binder currently owns — introspection for tests/diagnostics. */
+  boundPrefixes(): string[];
+  /** Withdraw every ephemeral route this binder added. Safe to call twice. */
+  release(): void;
+}
+
+/**
+ * Build the leg-B return-route binder over a connector's public routing API.
+ *
+ * Adds **no configuration key**: everything it needs is either already on the
+ * connector or arrives on the wire with the RFQ.
+ */
+export function createLegBReturnRouteBinder(
+  connector: unknown,
+  options: LegBReturnRouteBinderOptions = {}
+): LegBReturnRouteBinder {
+  const c = (connector ?? {}) as ReturnRouteConnectorLike;
+  const addRoute =
+    typeof c.addRoute === 'function' ? c.addRoute.bind(c) : undefined;
+  const removeRoute =
+    typeof c.removeRoute === 'function' ? c.removeRoute.bind(c) : undefined;
+  const listRoutes =
+    typeof c.listRoutes === 'function' ? c.listRoutes.bind(c) : undefined;
+  const logger = options.logger;
+  const maxBindings = options.maxBindings ?? DEFAULT_MAX_RETURN_ROUTE_BINDINGS;
+  const priority = options.priority ?? DEFAULT_RETURN_ROUTE_PRIORITY;
+  const ilpAddress = options.ilpAddress;
+
+  /** prefix → nextHop, insertion-ordered so the head is the least recent. */
+  const owned = new Map<string, string>();
+
+  /**
+   * Mark the return peer a `child` so leg B — value-bearing, and paid in the
+   * chain-B claim it CARRIES — is not gated on a settlement channel the maker
+   * could never hold toward its own customer. See the module doc.
+   */
+  const markReturnPeerAsChild = (peerId: string): void => {
+    const setRelation = c._packetHandler?.setPeerRelation;
+    if (typeof setRelation !== 'function') {
+      logger?.warn?.('swap.rolling.return_peer_relation_unavailable', {
+        peerId,
+        reason:
+          'connector exposes no setPeerRelation; a value-bearing leg B to this ' +
+          'peer will be gated on a per-packet settlement claim (T00)',
+      });
+      return;
+    }
+    try {
+      setRelation.call(c._packetHandler, peerId, 'child');
+      logger?.debug?.('swap.rolling.return_peer_marked_child', { peerId });
+    } catch (err) {
+      logger?.warn?.('swap.rolling.return_peer_relation_failed', {
+        peerId,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  const resolveExistingRoute = (
+    addr: string
+  ): { prefix: string; nextHop: string } | undefined => {
+    if (!listRoutes) return undefined;
+    let best: { prefix: string; nextHop: string } | undefined;
+    for (const route of listRoutes()) {
+      if (typeof route?.prefix !== 'string') continue;
+      if (!covers(route.prefix, addr)) continue;
+      if (!best || route.prefix.length > best.prefix.length) {
+        best = { prefix: route.prefix, nextHop: route.nextHop };
+      }
+    }
+    return best;
+  };
+
+  const evictIfFull = (): void => {
+    while (owned.size >= maxBindings) {
+      const oldest = owned.keys().next();
+      if (oldest.done) return;
+      const prefix = oldest.value;
+      owned.delete(prefix);
+      try {
+        removeRoute?.(prefix);
+      } catch (err) {
+        logger?.warn?.('swap.rolling.return_route_evict_failed', {
+          prefix,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  };
+
+  return {
+    bind({ senderIlpAddress, sourcePeer }): LegBReturnPath {
+      if (!addRoute || !listRoutes) {
+        // No routing introspection at all (test double / HTTP-mode connector):
+        // leave the RFQ exactly as it behaved before this module existed.
+        return { status: 'unavailable' };
+      }
+
+      const existing = resolveExistingRoute(senderIlpAddress);
+      const alreadyOwned = owned.get(senderIlpAddress);
+
+      const canReply =
+        isReplyableSessionId(sourcePeer) && sourcePeer === senderIlpAddress;
+
+      if (canReply) {
+        // Never divert the maker's own local delivery.
+        if (ilpAddress && covers(senderIlpAddress, ilpAddress)) {
+          logger?.warn?.('swap.rolling.return_route_refused', {
+            senderIlpAddress,
+            reason: 'would shadow the maker ilpAddress',
+          });
+        } else if (
+          existing &&
+          existing.prefix === senderIlpAddress &&
+          existing.nextHop !== senderIlpAddress &&
+          alreadyOwned === undefined
+        ) {
+          // A static/operator route owns this exact prefix and points it
+          // somewhere ELSE — it wins. (An existing entry that already points
+          // the address at itself IS a return route — most likely one this
+          // maker persisted before a restart — so it is adopted below rather
+          // than deferred to: the peer relation does NOT survive a restart,
+          // and deferring would leave leg B claim-gated forever.)
+          return { status: 'routed', nextHop: existing.nextHop };
+        } else if (alreadyOwned === senderIlpAddress) {
+          // Refresh eviction recency without touching the routing table.
+          owned.delete(senderIlpAddress);
+          owned.set(senderIlpAddress, senderIlpAddress);
+          markReturnPeerAsChild(senderIlpAddress);
+          return { status: 'bound', nextHop: senderIlpAddress };
+        } else {
+          owned.delete(senderIlpAddress);
+          evictIfFull();
+          try {
+            addRoute({
+              prefix: senderIlpAddress,
+              nextHop: senderIlpAddress,
+              priority,
+            });
+            owned.set(senderIlpAddress, senderIlpAddress);
+            // AFTER the route: `addRoute` refuses a child-held prefix that is
+            // not under the connector's own address (see the module doc).
+            markReturnPeerAsChild(senderIlpAddress);
+            logger?.debug?.('swap.rolling.return_route_bound', {
+              prefix: senderIlpAddress,
+              nextHop: senderIlpAddress,
+            });
+            return { status: 'bound', nextHop: senderIlpAddress };
+          } catch (err) {
+            logger?.warn?.('swap.rolling.return_route_bind_failed', {
+              senderIlpAddress,
+              err: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+      }
+
+      // Could not reply on the arrival session — is the address routable
+      // anyway (an operator route, or the default-up-to-parent route on a
+      // child maker, which is how an apex-forwarded sender is reached)?
+      if (existing) return { status: 'routed', nextHop: existing.nextHop };
+
+      return {
+        status: 'unreachable',
+        reason: isReplyableSessionId(sourcePeer)
+          ? `the RFQ arrived on BTP session "${String(sourcePeer)}" but advertised ` +
+            `senderIlpAddress "${senderIlpAddress}"; leg B can only be returned ` +
+            `to the address the session authenticated under`
+          : `no BTP session to return leg B on (arrival peer ` +
+            `"${String(sourcePeer ?? 'unknown')}") and no route to "${senderIlpAddress}"`,
+      };
+    },
+
+    boundPrefixes(): string[] {
+      return [...owned.keys()];
+    },
+
+    release(): void {
+      for (const prefix of [...owned.keys()]) {
+        try {
+          removeRoute?.(prefix);
+        } catch {
+          // Best effort: the connector may already be stopped.
+        }
+      }
+      owned.clear();
+    },
+  };
+}

--- a/packages/swap/src/rolling-rfq.ts
+++ b/packages/swap/src/rolling-rfq.ts
@@ -48,6 +48,7 @@ import {
   buildRollingReject,
   type RollingSession,
 } from './rolling-engine.js';
+import type { LegBReturnPath } from './leg-b-return-path.js';
 
 /** Inner rumor kind of an RFQ request (spec §2.2). */
 export const ROLLING_RFQ_REQUEST_KIND = 20033;
@@ -70,6 +71,14 @@ export const ROLLING_RFQ_REJECT_REASONS = {
   RATE_UNAVAILABLE: 'rate_unavailable',
   /** Session store full, or the nonce collided with a live session. */
   SESSION_REJECTED: 'session_rejected',
+  /**
+   * The maker has no way to deliver leg B back to the sender: the RFQ did not
+   * arrive on a BTP session it can reply on (or advertised a different
+   * address than the one that session authenticated under) and the routing
+   * table has no route to `senderIlpAddress`. Refusing here is what keeps the
+   * failure free — see `leg-b-return-path.ts`.
+   */
+  NO_RETURN_PATH: 'no_return_path',
 } as const;
 
 /**
@@ -267,6 +276,18 @@ export interface RollingRfqIntakeConfig {
   quote: (pair: SwapPair) => Promise<RfqQuote | null> | RfqQuote | null;
   /** Commits the session. Throwing → `session_rejected` (store full, etc.). */
   registerSession: (session: RollingSession) => void;
+  /**
+   * Resolve — and where possible install — the leg-B return path for the
+   * session about to be minted (`leg-b-return-path.ts`). Called BEFORE
+   * {@link registerSession}, so an `'unreachable'` verdict refuses the RFQ
+   * without ever creating a session that could not be filled.
+   *
+   * Absent (or `'unavailable'`) leaves the pre-fix behaviour untouched.
+   */
+  bindReturnPath?: (args: {
+    senderIlpAddress: string;
+    sourcePeer?: string;
+  }) => LegBReturnPath;
   /** Maker's Nostr secret key: unwraps the request, seals the response. */
   secretKey: Uint8Array;
   /** Per-chain on-chain signer addresses, keyed as `pair.to.chain`. */
@@ -304,7 +325,10 @@ export type RollingRfqOutcome =
  */
 export function createRollingRfqIntake(config: RollingRfqIntakeConfig): {
   /** `null` ⇒ not an RFQ, fall through to legacy. */
-  handle(dataB64: string): Promise<RollingRfqOutcome | null>;
+  handle(
+    dataB64: string,
+    arrival?: { sourcePeer?: string }
+  ): Promise<RollingRfqOutcome | null>;
 } {
   const enabled = config.rfq?.enabled ?? true;
   const quoteTtlMs = config.rfq?.quoteTtlMs ?? DEFAULT_RFQ_QUOTE_TTL_MS;
@@ -326,7 +350,10 @@ export function createRollingRfqIntake(config: RollingRfqIntakeConfig): {
     }) as RollingRfqOutcome;
 
   return {
-    async handle(dataB64: string): Promise<RollingRfqOutcome | null> {
+    async handle(
+      dataB64: string,
+      arrival?: { sourcePeer?: string }
+    ): Promise<RollingRfqOutcome | null> {
       if (!enabled) return null;
       if (typeof dataB64 !== 'string' || dataB64.length === 0) return null;
 
@@ -399,6 +426,33 @@ export function createRollingRfqIntake(config: RollingRfqIntakeConfig): {
       // Quote validity only. The session's own lifetime is left to the store's
       // TTL (see `RollingRfqConfig.quoteTtlMs`) by omitting `expiresAt` below.
       const quoteExpiresAt = now() + quoteTtlMs;
+
+      // Leg-B deliverability, BEFORE anything is committed (spec §3 R4/R5:
+      // a maker that cannot return leg B can never fulfil a fill, and every
+      // such fill would burn a sender-minted condition for nothing). This is
+      // the only point at which failing is free.
+      const returnPath = config.bindReturnPath?.({
+        senderIlpAddress: parsed.senderIlpAddress,
+        ...(arrival?.sourcePeer !== undefined
+          ? { sourcePeer: arrival.sourcePeer }
+          : {}),
+      });
+      if (returnPath?.status === 'unreachable') {
+        logger?.warn?.('swap.rfq.no_return_path', {
+          streamNonce: parsed.streamNonce,
+          senderIlpAddress: parsed.senderIlpAddress,
+          sourcePeer: arrival?.sourcePeer,
+          reason: returnPath.reason,
+        });
+        return reject(
+          'F02',
+          'unreachable',
+          `no leg-B return path to ${parsed.senderIlpAddress}: ${returnPath.reason}. ` +
+            'Connect to this maker over BTP, or use the legacy swap path ' +
+            '(`rolling: "off"`).',
+          ROLLING_RFQ_REJECT_REASONS.NO_RETURN_PATH
+        );
+      }
 
       // Commit the session BEFORE answering: a sender that receives a quote
       // must be able to send fill seq 1 immediately. Registering after the
@@ -474,6 +528,10 @@ export function createRollingRfqIntake(config: RollingRfqIntakeConfig): {
         streamNonce: parsed.streamNonce,
         pair: `${pair.from.assetCode}:${pair.from.chain}→${pair.to.assetCode}:${pair.to.chain}`,
         quoteExpiresAt,
+        returnPath: returnPath?.status ?? 'unavailable',
+        ...(returnPath && 'nextHop' in returnPath
+          ? { returnNextHop: returnPath.nextHop }
+          : {}),
       });
 
       return {

--- a/packages/swap/src/swap-node.leg-b-wire.test.ts
+++ b/packages/swap/src/swap-node.leg-b-wire.test.ts
@@ -1,0 +1,473 @@
+/**
+ * Leg-B delivery — REAL WIRE test.
+ *
+ * ## What this proves, and why nothing weaker would
+ *
+ * A rolling session negotiated end to end against the live devnet maker and
+ * then died on delivery:
+ *
+ * ```
+ * maker: REJECT destination=g.toon.client errorCode=F02 "no route found"
+ * maker: swap.rolling.fill_unwound streamNonce=… seq=1 cause=F02
+ * client: F99 "leg B failed; fill not executed"  packetsAccepted 0
+ * ```
+ *
+ * Every existing rolling test injects `rollingLegBSender` or drives a fake
+ * connector, so leg B never touched a routing table and the defect was
+ * invisible. A unit test of how `senderIlpAddress` is derived would have been
+ * just as blind — the address was RIGHT; the maker simply had no way to reach
+ * it.
+ *
+ * So this suite boots a REAL standalone `startSwapNode()` (real
+ * `ConnectorNode`, real BTP server) and drives it from a REAL BTP client
+ * (`@toon-protocol/client`'s `BtpRuntimeClient`, the same transport a stock
+ * client uses, with the same `onMessage` seam its rolling leg-B router is
+ * installed on). Both legs cross a socket:
+ *
+ * ```
+ *  sender (BtpRuntimeClient, peerId g.toon.client.wire01)
+ *     │  leg 0  PREPARE kind:20033 RFQ ─────────────▶ maker BTP server
+ *     │  ◀───────────── FULFILL kind:20034 quote
+ *     │  leg A  PREPARE δ + condition C ────────────▶ maker
+ *     │                                       maker originates leg B …
+ *     │  ◀─── BTP MESSAGE: PREPARE(claim, C)   … over THIS session
+ *     │  ─────────────────────── FULFILL(P) ──▶
+ *     │  ◀───────────── FULFILL(P) for leg A
+ * ```
+ *
+ * Before the fix the leg-B PREPARE never left the maker's connector (F02) and
+ * the leg-A assert fails with `leg B failed; fill not executed`.
+ *
+ * The withhold property (spec R5/R8) has its own assertion here too: a session
+ * whose sender answers leg B with a REJECT must leave leg A rejected, with the
+ * preimage never revealed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { schnorr } from '@noble/curves/secp256k1.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
+import { wrapSwapPacketToToon, unwrapSwapPacket } from '@toon-protocol/sdk';
+import type { ConnectorNode } from '@toon-protocol/connector';
+import { BtpRuntimeClient } from '@toon-protocol/client';
+import {
+  PacketType,
+  deserializePrepare,
+  serializeFulfill,
+  serializeReject,
+} from '@toon-protocol/shared';
+import type { UnsignedEvent } from 'nostr-tools';
+
+import { startSwapNode } from './swap-node.js';
+import type { SwapNodeConfig, SwapNodeInstance } from './swap-node.js';
+import {
+  ROLLING_PROTOCOL,
+  createConnectorLegBSender,
+} from './rolling-engine.js';
+import type { LegBSender } from './rolling-engine.js';
+import {
+  ROLLING_RFQ_REQUEST_KIND,
+  ROLLING_RFQ_RESPONSE_KIND,
+  ROLLING_RFQ_REJECT_REASONS,
+  type RollingRfqResponse,
+} from './rolling-rfq.js';
+
+const VALID_MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+const CHAIN = 'evm:8453';
+const CHAIN_RECIPIENT = '0x' + '11'.repeat(20);
+const MAKER_ILP = 'g.toon.swap.wireseam';
+
+/**
+ * The sender's ILP address AND the `peerId` it authenticates its BTP session
+ * with — a stock `ToonClient` uses one expression for both
+ * (`getOwnIlpAddress()` === the BTP greeting `peerId`), and the maker's
+ * connector binds an inbound session under that string verbatim
+ * (connector `btp/btp-server.ts` `authenticatePeer`).
+ */
+const SENDER_ILP = 'g.toon.client.wire01';
+
+/** Ephemeral-range BTP port; the suite runs unforked, so randomize. */
+function freePort(): number {
+  return 20000 + Math.floor(Math.random() * 20000);
+}
+
+interface BootedMaker {
+  instance: SwapNodeInstance;
+  connector: ConnectorNode;
+  btpUrl: string;
+}
+
+async function bootMaker(
+  port: number,
+  overrides?: Partial<SwapNodeConfig>
+): Promise<BootedMaker> {
+  const instance = await startSwapNode({
+    mnemonic: VALID_MNEMONIC,
+    swapPairs: [
+      {
+        from: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+        to: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+        rate: '1.0',
+        minAmount: '1000',
+        maxAmount: '25000000',
+      },
+    ],
+    chains: ['evm'],
+    channels: {
+      [CHAIN]: [
+        {
+          channelId: '0x' + 'cd'.repeat(32),
+          cumulativeAmount: 0n,
+          nonce: 0n,
+          updatedAt: 0,
+        },
+      ],
+    },
+    inventory: { [CHAIN]: 1_000_000_000n },
+    chainProviders: [
+      {
+        chainType: 'evm',
+        chainId: CHAIN,
+        rpcUrl: 'http://127.0.0.1:1',
+        registryAddress: '0x' + '11'.repeat(20),
+        tokenAddress: '0x' + '22'.repeat(20),
+        tokenNetworkAddress: '0x' + '44'.repeat(20),
+        channelAddress: '0x' + '33'.repeat(20),
+      },
+    ],
+    relayUrls: ['ws://127.0.0.1:1'],
+    blsPort: 0,
+    publisher: { publish: async () => undefined },
+    // Standalone, parentless, direct-dialled — the deployed maker's shape.
+    btpServerPort: port,
+    ilpAddress: MAKER_ILP,
+    nodeId: 'toon-swap-wireseam',
+    ...overrides,
+  });
+  return {
+    instance,
+    connector: instance.connector as unknown as ConnectorNode,
+    btpUrl: `ws://127.0.0.1:${port}`,
+  };
+}
+
+function senderKeys(): { secretKey: Uint8Array; pubkey: string } {
+  const secretKey = schnorr.utils.randomSecretKey();
+  return { secretKey, pubkey: bytesToHex(schnorr.getPublicKey(secretKey)) };
+}
+
+function giftWrappedRfqDataB64(params: {
+  content: string;
+  senderSecretKey: Uint8Array;
+  makerPubkey: string;
+}): string {
+  const rumor = {
+    kind: ROLLING_RFQ_REQUEST_KIND,
+    content: params.content,
+    tags: [],
+    created_at: Math.floor(Date.now() / 1000),
+    pubkey: '',
+  } as unknown as UnsignedEvent;
+  const { ilpPrepare } = wrapSwapPacketToToon({
+    rumor,
+    senderSecretKey: params.senderSecretKey,
+    recipientPubkey: params.makerPubkey,
+    destination: MAKER_ILP,
+    amount: 1000n,
+  });
+  return ilpPrepare.data;
+}
+
+function rfqBody(streamNonce: string, senderIlpAddress = SENDER_ILP): string {
+  return JSON.stringify({
+    proto: ROLLING_PROTOCOL,
+    type: 'rfq',
+    streamNonce,
+    pair: {
+      from: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+      to: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+    },
+    chainRecipient: CHAIN_RECIPIENT,
+    senderIlpAddress,
+  });
+}
+
+function decodeQuote(
+  dataB64: string | undefined,
+  senderSecretKey: Uint8Array
+): { kind: number; quote: RollingRfqResponse } {
+  if (!dataB64) throw new Error('RFQ accept carried no data');
+  const giftWrap = JSON.parse(Buffer.from(dataB64, 'base64').toString('utf8'));
+  const { rumor } = unwrapSwapPacket({
+    giftWrap,
+    recipientSecretKey: senderSecretKey,
+  });
+  return {
+    kind: rumor.kind,
+    quote: JSON.parse(rumor.content) as RollingRfqResponse,
+  };
+}
+
+/** `data.reason` off a rolling reject's base64-JSON body. */
+function decodeRejectReason(dataB64: string | undefined): unknown {
+  if (!dataB64) return undefined;
+  return (
+    JSON.parse(Buffer.from(dataB64, 'base64').toString('utf8')) as {
+      reason?: unknown;
+    }
+  ).reason;
+}
+
+function randomNonce(): string {
+  const bytes = new Uint8Array(16);
+  globalThis.crypto.getRandomValues(bytes);
+  return bytesToHex(bytes);
+}
+
+function mintCondition(): { preimage: Uint8Array; conditionB64: string } {
+  const preimage = new Uint8Array(32);
+  globalThis.crypto.getRandomValues(preimage);
+  return {
+    preimage,
+    conditionB64: Buffer.from(sha256(preimage)).toString('base64'),
+  };
+}
+
+/** One leg-B PREPARE as the sender's daemon saw it come off the socket. */
+interface CapturedLegB {
+  destination: string;
+  amount: string;
+  executionCondition: string;
+  data: Buffer;
+}
+
+/**
+ * A sender daemon on a REAL BTP session. `onMessage` is the same seam a stock
+ * client installs its rolling leg-B router on (toon-client's `jobHandler`),
+ * so a PREPARE only lands here if it genuinely crossed the socket.
+ */
+async function connectSender(params: {
+  btpUrl: string;
+  peerId: string;
+  captured: CapturedLegB[];
+  /** `null` ⇒ REJECT, i.e. withhold the preimage (spec R5/R8). */
+  answer: (legB: CapturedLegB) => Uint8Array | null;
+}): Promise<BtpRuntimeClient> {
+  const client = new BtpRuntimeClient({
+    btpUrl: params.btpUrl,
+    peerId: params.peerId,
+    authToken: '',
+    onMessage: (message) => {
+      if (!message.ilpPacket) return {};
+      const prepare = deserializePrepare(Buffer.from(message.ilpPacket));
+      const legB: CapturedLegB = {
+        destination: prepare.destination,
+        amount: prepare.amount.toString(),
+        executionCondition: Buffer.from(prepare.executionCondition).toString(
+          'base64'
+        ),
+        data: Buffer.from(prepare.data),
+      };
+      params.captured.push(legB);
+      const preimage = params.answer(legB);
+      if (!preimage) {
+        return {
+          ilpPacket: serializeReject({
+            type: PacketType.REJECT,
+            code: 'F99',
+            triggeredBy: params.peerId,
+            message: 'sender withheld leg B',
+            data: Buffer.alloc(0),
+          }),
+        };
+      }
+      return {
+        ilpPacket: serializeFulfill({
+          type: PacketType.FULFILL,
+          fulfillment: Buffer.from(preimage),
+          data: Buffer.alloc(0),
+        }),
+      };
+    },
+  });
+  await client.connect();
+  return client;
+}
+
+/**
+ * The PRODUCTION leg-B egress: exactly what `startSwapNode` hands the rolling
+ * engine (`swap-node.ts` §11a-pre) — `ConnectorNode.sendPacket` with the
+ * sender-minted condition. Driving this, rather than a stub, is what makes
+ * the routing hop real: it is the call that answered `F02 no route found`.
+ */
+function productionLegBSender(connector: ConnectorNode): LegBSender {
+  return createConnectorLegBSender(connector, { nodeId: 'toon-swap-wireseam' });
+}
+
+describe('rolling leg-B delivery over a real BTP session', () => {
+  it('[P0] leg B reaches a direct-dialled sender on the session its RFQ arrived on', async () => {
+    const { instance, connector, btpUrl } = await bootMaker(freePort());
+    const sender = senderKeys();
+    const streamNonce = randomNonce();
+    const captured: CapturedLegB[] = [];
+    const { preimage, conditionB64 } = mintCondition();
+    let client: BtpRuntimeClient | undefined;
+    try {
+      client = await connectSender({
+        btpUrl,
+        peerId: SENDER_ILP,
+        captured,
+        answer: () => preimage,
+      });
+
+      // Nothing routes to the sender yet — it direct-dialled, and a
+      // direct-dialled client is in nobody's routing table. This is the
+      // pre-fix state in which every leg B was F02'd.
+      expect(connector.routingTable.getNextHop(SENDER_ILP)).toBe(null);
+
+      // --- leg 0: the RFQ, across the real socket ---------------------------
+      const rfq = await client.sendIlpPacket({
+        destination: MAKER_ILP,
+        amount: '0',
+        data: giftWrappedRfqDataB64({
+          content: rfqBody(streamNonce),
+          senderSecretKey: sender.secretKey,
+          makerPubkey: instance.identity.pubkey,
+        }),
+      });
+      expect(rfq.accepted).toBe(true);
+      const { kind, quote } = decodeQuote(rfq.data, sender.secretKey);
+      expect(kind).toBe(ROLLING_RFQ_RESPONSE_KIND);
+      expect(quote.streamNonce).toBe(streamNonce);
+
+      // The RFQ bound the arrival session as the session's return path.
+      expect(connector.routingTable.getNextHop(SENDER_ILP)).toBe(SENDER_ILP);
+
+      // --- leg B: the production egress, through the real connector --------
+      const legB = await productionLegBSender(connector)({
+        destination: SENDER_ILP,
+        amount: 3000n,
+        expiresAt: new Date(Date.now() + 10_000),
+        executionCondition: Buffer.from(conditionB64, 'base64'),
+        data: Buffer.from(
+          JSON.stringify({
+            proto: ROLLING_PROTOCOL,
+            type: 'advance',
+            streamNonce,
+            seq: 1,
+          }),
+          'utf8'
+        ),
+      });
+
+      // It crossed the socket …
+      expect(captured).toHaveLength(1);
+      expect(captured[0]?.destination).toBe(SENDER_ILP);
+      expect(captured[0]?.amount).toBe('3000');
+      // … carrying the sender-minted condition verbatim (spec R4 coupling) …
+      expect(captured[0]?.executionCondition).toBe(conditionB64);
+      // … and came back FULFILLed with the preimage that satisfies leg A.
+      expect(legB.type).toBe('fulfill');
+      expect(
+        legB.type === 'fulfill'
+          ? Buffer.from(legB.fulfillment!).toString('base64')
+          : undefined
+      ).toBe(Buffer.from(preimage).toString('base64'));
+    } finally {
+      await client?.disconnect().catch(() => undefined);
+      await instance.stop();
+    }
+  }, 30_000);
+
+  it('[P0] withhold survives the real wire: a rejected leg B yields no preimage', async () => {
+    const { instance, connector, btpUrl } = await bootMaker(freePort());
+    const sender = senderKeys();
+    const streamNonce = randomNonce();
+    const captured: CapturedLegB[] = [];
+    const { conditionB64 } = mintCondition();
+    let client: BtpRuntimeClient | undefined;
+    try {
+      client = await connectSender({
+        btpUrl,
+        peerId: SENDER_ILP,
+        captured,
+        answer: () => null, // withhold
+      });
+
+      const rfq = await client.sendIlpPacket({
+        destination: MAKER_ILP,
+        amount: '0',
+        data: giftWrappedRfqDataB64({
+          content: rfqBody(streamNonce),
+          senderSecretKey: sender.secretKey,
+          makerPubkey: instance.identity.pubkey,
+        }),
+      });
+      expect(rfq.accepted).toBe(true);
+
+      const legB = await productionLegBSender(connector)({
+        destination: SENDER_ILP,
+        amount: 3000n,
+        expiresAt: new Date(Date.now() + 10_000),
+        executionCondition: Buffer.from(conditionB64, 'base64'),
+        data: Buffer.from('{}', 'utf8'),
+      });
+
+      // Delivered (so this is a genuine withhold, not the old F02) but the
+      // maker learned nothing: no preimage ⇒ leg A can never fulfil (R5/R8).
+      expect(captured).toHaveLength(1);
+      expect(legB.type).toBe('reject');
+      expect(
+        legB.type === 'fulfill' ? legB.fulfillment : undefined
+      ).toBeUndefined();
+    } finally {
+      await client?.disconnect().catch(() => undefined);
+      await instance.stop();
+    }
+  }, 30_000);
+
+  it('[P0] a sender the maker cannot answer is refused at leg 0, not at the fill', async () => {
+    const { instance, connector, btpUrl } = await bootMaker(freePort());
+    const sender = senderKeys();
+    const captured: CapturedLegB[] = [];
+    let client: BtpRuntimeClient | undefined;
+    try {
+      // Authenticates as one name, advertises another: no session is bound
+      // under `g.toon.client.elsewhere` and no route reaches it.
+      client = await connectSender({
+        btpUrl,
+        peerId: SENDER_ILP,
+        captured,
+        answer: () => null,
+      });
+
+      const rfq = await client.sendIlpPacket({
+        destination: MAKER_ILP,
+        amount: '0',
+        data: giftWrappedRfqDataB64({
+          content: rfqBody(randomNonce(), 'g.toon.client.elsewhere'),
+          senderSecretKey: sender.secretKey,
+          makerPubkey: instance.identity.pubkey,
+        }),
+      });
+
+      // Refused at the RFQ — the one moment failing is free (no quote, no
+      // session, no inventory, no revealed leg A). A sender's existing
+      // RFQ-failure fallback then takes the legacy swap path.
+      expect(rfq.accepted).toBe(false);
+      expect(rfq.code).toBe('F02');
+      expect(decodeRejectReason(rfq.data)).toBe(
+        ROLLING_RFQ_REJECT_REASONS.NO_RETURN_PATH
+      );
+      // And no route was invented for an address the maker cannot reach.
+      expect(connector.routingTable.getNextHop('g.toon.client.elsewhere')).toBe(
+        null
+      );
+    } finally {
+      await client?.disconnect().catch(() => undefined);
+      await instance.stop();
+    }
+  }, 30_000);
+});

--- a/packages/swap/src/swap-node.ts
+++ b/packages/swap/src/swap-node.ts
@@ -28,8 +28,13 @@ import type { NostrEvent } from 'nostr-tools/pure';
 import {
   ConnectorNode,
   createLogger as createConnectorLogger,
+  createPaymentHandlerAdapter,
 } from '@toon-protocol/connector';
-import type { TransportConfig } from '@toon-protocol/connector';
+import type {
+  LocalDeliveryHandler,
+  LocalDeliveryRequest,
+  TransportConfig,
+} from '@toon-protocol/connector';
 
 import {
   HandlerRegistry,
@@ -104,6 +109,8 @@ import {
 import type { LegBSender, RollingSession } from './rolling-engine.js';
 import { createRollingRfqIntake } from './rolling-rfq.js';
 import type { RollingRfqConfig } from './rolling-rfq.js';
+import { createLegBReturnRouteBinder } from './leg-b-return-path.js';
+import type { LegBReturnRouteBinder } from './leg-b-return-path.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -1766,6 +1773,12 @@ export async function startSwapNode(
         peers: [],
         routes: [{ prefix: ilpAddress, nextHop: nodeId, priority: 100 }],
         localDelivery: { enabled: false },
+        // Zero fees on our own egress, mirroring the embedded-with-parent
+        // branch. Without it the connector's default fee shaves the ILP
+        // `amount` of the ONE thing a standalone maker ever forwards — its
+        // own rolling leg-B PREPARE — so the packet would understate the
+        // chain-B claim it carries (3000 → 2997).
+        settlement: { connectorFeePercentage: 0 },
         ...(resolvedChainProviders &&
           resolvedChainProviders.length > 0 && {
             chainProviders: resolvedChainProviders,
@@ -1860,8 +1873,23 @@ export async function startSwapNode(
   //
   // Quote source mirrors the engine's: the timestamped `rateProvider` when the
   // operator configured one, else the pair's static advertised rate.
+  // 10b-bis. Leg-B return path (see `leg-b-return-path.ts`). A direct-dialled
+  // sender is an inbound BTP session, not a routing-table entry, so without
+  // this every leg B is F02'd inside the maker's own connector and the
+  // rolling protocol is undeliverable. Driven purely off the connector's
+  // public routing API — NO new config key, and no operator route.
+  const legBReturnRoutes: LegBReturnRouteBinder = createLegBReturnRouteBinder(
+    effectiveConnector,
+    {
+      ilpAddress:
+        config.ilpAddress ?? `g.toon.swap.${identity.pubkey.slice(0, 16)}`,
+      logger: { debug: logger.debug, warn: logger.warn },
+    }
+  );
+
   const rfqIntake = createRollingRfqIntake({
     swapPairs: config.swapPairs,
+    bindReturnPath: (args) => legBReturnRoutes.bind(args),
     secretKey: identity.secretKey,
     signerAddresses,
     registerSession: (session) => rollingEngine.registerSession(session),
@@ -1939,7 +1967,16 @@ export async function startSwapNode(
   };
 
   const handlePacket = async (
-    request: HandlePacketRequest
+    request: HandlePacketRequest,
+    /**
+     * The peer id the connector bound this packet's arrival under — for a BTP
+     * arrival, the `peerId` the session authenticated with
+     * (connector `btp/btp-server.ts` `authenticatePeer`), surfaced as
+     * `LocalDeliveryRequest.sourcePeer`. Undefined when the connector does not
+     * report one (legacy `setPacketHandler` wiring / test doubles), which is
+     * exactly the pre-fix behaviour.
+     */
+    sourcePeer?: string
   ): Promise<HandlePacketResponse> => {
     const requestExt = request as HandlePacketRequest & {
       executionCondition?: string;
@@ -1999,7 +2036,9 @@ export async function startSwapNode(
     // by unwrapping and reading that kind. `handle()` returns null for
     // everything it cannot positively identify as an RFQ (including any unwrap
     // failure), so the legacy path below stays byte-for-byte as it was.
-    const rfq = await rfqIntake.handle(request.data);
+    const rfq = await rfqIntake.handle(request.data, {
+      ...(sourcePeer !== undefined ? { sourcePeer } : {}),
+    });
     if (rfq) return rfq as HandlePacketResponse;
 
     // Legacy path (zero-condition gift-wrap) — unchanged below.
@@ -2076,12 +2115,64 @@ export async function startSwapNode(
     return result;
   };
 
-  // Register the handler as the connector's local-delivery callback. Guarded
-  // because `setPacketHandler` is optional on EmbeddableConnectorLike (HTTP-mode
-  // connectors and test doubles may omit it).
-  if (effectiveConnector?.setPacketHandler) {
+  // Register the handler as the connector's local-delivery callback.
+  //
+  // PREFER `setLocalDeliveryHandler`: `setPacketHandler` is the same slot
+  // wrapped in the connector's own `createPaymentHandlerAdapter`, and that
+  // adapter DROPS `LocalDeliveryRequest.sourcePeer` when it narrows the
+  // request to a `PaymentRequest` (connector `core/payment-handler.ts`). The
+  // arrival peer is the only evidence the maker has of which BTP session to
+  // return leg B on, so the swap node applies the SAME adapter itself and
+  // threads `sourcePeer` through. Behaviour is otherwise byte-identical —
+  // it is literally the connector's own adapter.
+  //
+  // Both calls stay guarded: `setPacketHandler` is optional on
+  // `EmbeddableConnectorLike` (HTTP-mode connectors and test doubles may omit
+  // it) and `setLocalDeliveryHandler` is not on that interface at all.
+  const connectorWithLocalDelivery = effectiveConnector as
+    | (EmbeddableConnectorLike & {
+        setLocalDeliveryHandler?: (handler: LocalDeliveryHandler) => void;
+      })
+    | undefined;
+  if (connectorWithLocalDelivery?.setLocalDeliveryHandler) {
+    const adapterLogger = createConnectorLogger(
+      'swap-local-delivery',
+      (process.env['TOON_CONNECTOR_LOG_LEVEL'] as
+        | 'debug'
+        | 'info'
+        | 'warn'
+        | 'error'
+        | undefined) ?? 'warn'
+    );
+    type ConnectorPaymentHandler = Parameters<
+      typeof createPaymentHandlerAdapter
+    >[0];
+    const localDeliveryHandler: LocalDeliveryHandler = (
+      request: LocalDeliveryRequest,
+      sourcePeerId: string | undefined
+    ) => {
+      const arrivalPeer = sourcePeerId ?? request.sourcePeer;
+      // Built per packet so the arrival peer is captured in the closure
+      // rather than in shared mutable state (packets interleave).
+      const adapter = createPaymentHandlerAdapter(
+        ((paymentRequest: unknown) =>
+          handlePacket(
+            paymentRequest as HandlePacketRequest,
+            arrivalPeer
+          )) as unknown as ConnectorPaymentHandler,
+        adapterLogger
+      );
+      return adapter(request, sourcePeerId as string);
+    };
+    connectorWithLocalDelivery.setLocalDeliveryHandler(localDeliveryHandler);
+    logger.debug?.('swap.connector.packet_handler_wired', {
+      via: 'setLocalDeliveryHandler',
+    });
+  } else if (effectiveConnector?.setPacketHandler) {
     effectiveConnector.setPacketHandler(handlePacket);
-    logger.debug?.('swap.connector.packet_handler_wired', {});
+    logger.debug?.('swap.connector.packet_handler_wired', {
+      via: 'setPacketHandler',
+    });
   } else {
     logger.warn?.('swap.connector.packet_handler_unavailable', {
       reason:
@@ -2488,6 +2579,10 @@ export async function startSwapNode(
       stopRequested = true;
       status = 'stopping';
       reconciler.stop();
+      // Withdraw the ephemeral leg-B return routes this node installed, so a
+      // connector the caller OWNS (config.connector) is handed back with the
+      // routing table it came with.
+      legBReturnRoutes.release();
       try {
         await new Promise<void>((resolve) => {
           blsServer.close(() => resolve());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       '@toon-protocol/client':
         specifier: ^0.29.8
         version: 0.29.8(@toon-protocol/connector@3.30.0)(typescript@5.9.3)(zod@3.25.76)
+      '@toon-protocol/shared':
+        specifier: ^1.3.0
+        version: 1.3.0
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.32


### PR DESCRIPTION
## The failure

A real devnet swap negotiated a rolling session against `g.toon.swap.maker` for the first time ever — and delivered nothing:

```
client: "rolling": {"probed":true,"used":true,"streamNonce":"1007de73…","rate":"1.0", …}
maker:  REJECT destination=g.toon.client errorCode=F02 "no route found"
maker:  swap.rolling.fill_unwound streamNonce=1007de73… seq=1 targetAmount=3000 cause=F02
maker:  swap.rollbackRollingClaim.ok chain=evm:84532 asset=USDC targetAmount=3000
client: F99 "leg B failed; fill not executed"   packetsAccepted 0, valueReceived 0
```

The safety properties held perfectly — leg A was never revealed, the packet cost nothing, inventory unwound cleanly. This is a **delivery** defect, not a loss.

It is also a **live regression on the default path**: auto-probe is the default, this maker now answers the RFQ, and the client's fallback covers RFQ *failure* — not a successful RFQ followed by an undeliverable fill. Verified live: default → `F99`, `packetsAccepted: 0`; explicit `rolling: "off"` → `accepted: true`, `packetsAccepted: 1`, `valueReceived: 2000`, settled on-chain.

## Diagnosis

The maker is **not** the Rust connector. It is the swap node's embedded, parentless TypeScript `ConnectorNode` (`swap.config.json` sets no `connector`/`connectorUrl`; the CLI auto-creates it gated on `btpServerPort`). What it binds an inbound BTP session under, and how it resolves a destination — from the installed `@toon-protocol/connector@3.30.0` sources:

| what | where | behaviour |
|---|---|---|
| inbound session binding | `packages/connector/src/btp/btp-server.ts:739-741` (no-auth) and `:792-794` (shared-secret) | `peerConn.peerId = peerId; this.peers.set(peerId, peerConn)` — the `peerId` the client declares on the BTP **auth greeting**, stored **verbatim**, in a `Map` |
| what the app sees | `core/packet-handler.ts:1281` | `sourcePeer: sourcePeerId`, set from `peerConn.peerId` at `btp/btp-server.ts:941-943` |
| destination resolution | `core/packet-handler.ts:1214-1243` | `routingTable.getNextHop()` **only**. No route ⇒ `F02 "No route to destination"`, before any transport is chosen |
| reply-on-session | `core/packet-handler.ts:965-983` | `forwardToNextHop` *does* fall back to `btpServer.sendPacketToPeer(nextHop, …)` when `btpServer.hasPeer(nextHop)` — but only once the routing table has already named that peer as the next hop |

So the session exists and the connector knows how to write to it. Nothing in `ConnectorNode` ever turns an inbound session into a route, so a direct-dialled client is unreachable by address. `http:anon` (`http/ilp-http-adapter.ts:185-197`) is the *other* binding namespace, for ILP-over-HTTP arrivals — a request/response hop with no socket to originate on.

**The wire test then found a second layer.** With the route in place, leg B answers `T00 "No payment channel available for peer"` (`core/packet-handler.ts:1600,1636-1648`): `PacketHandler` requires a per-packet settlement claim on every value-bearing forward to a **non-`child`** next hop, and a maker holds no payment channel toward the client it is *paying*. Same undeliverable fill, one layer down. A route-only fix would have shipped, deployed, and failed live.

## Which side, and why

**Maker-side, both layers.** The client's `senderIlpAddress` was never wrong: `getOwnIlpAddress()` returns `config.btpPeerId ?? config.ilpInfo.ilpAddress`, which is *the same expression* `modes/http.ts:85` uses for the BTP greeting `peerId` — so a stock client's advertised address is, by construction, exactly the string this maker binds its session under. There is nothing for the client to say differently. Requiring an operator route per client would make the direct-dial model (swap#105, `docker-compose.relay.swap.yml`) unusable, which is the model the fleet actually runs.

`'child'` is the ILP-correct relation, not a workaround — the connector's own comment for that skip reads *"a parent settles DOWN to a child by letting the child accrue a balance owed up (the child settles via its own up-claims)"*, which is exactly the rolling swap's netting: the sender pays on leg A, and leg B's value is the signed chain-B claim **inside the packet**, never an ILP settlement owed back over the link.

## The change

New `packages/swap/src/leg-b-return-path.ts` resolves a session's return path at RFQ intake, from the session the RFQ actually arrived on. **No new config key** (swap#134's lesson), and no operator routing.

To see `sourcePeer` at all, the packet handler is now registered via `setLocalDeliveryHandler` wrapping the connector's **own** `createPaymentHandlerAdapter` — `setPacketHandler` is that same slot with that same adapter, and the adapter drops `sourcePeer` when it narrows `LocalDeliveryRequest` to `PaymentRequest` (`core/payment-handler.ts:218-231`). Byte-identical otherwise, and it falls back to `setPacketHandler` for any connector that lacks the newer hook (every existing test double).

Guards, because an RFQ payload is attacker-controlled:

- the route is only ever `prefix: X → nextHop: X` for the name the peer **authenticated under**. Without that, an RFQ claiming `senderIlpAddress: "g.proxy"` would install an entry shadowing the maker's own upstream route;
- a prefix that would shadow the maker's own `ilpAddress` is refused;
- an operator/static route for the same prefix always wins (a *replayed* return route from the persistent registry is adopted instead — the peer relation does not survive a restart, so deferring would leave leg B claim-gated forever);
- bindings are LRU-capped (256) and withdrawn on `stop()`;
- ordering is load-bearing: route first, relation second — `addRoute` refuses a `'child'`-held prefix that is not under the connector's own address.

## The fallback gap — refused at leg 0, not retried at the fill

A delivery failure is **not** retried as legacy. Re-running a fill on the legacy path after a rolling attempt is precisely the shape that risks double-delivery, and the withhold property is what made this failure free.

Instead the maker refuses the **RFQ** when it can positively determine it has no return path — `F02` / `reason: "no_return_path"`, message naming `rolling: "off"`. That is the one moment failing is free: nothing quoted, no session, no inventory reserved, no leg A revealed. And it needs no client change: toon-client#591's existing RFQ-failure fallback already covers a rejected RFQ, so a stock client quietly takes the legacy path. A connector that exposes no routing introspection resolves to `unavailable`, i.e. exactly the pre-fix behaviour — embedders are untouched.

## Withhold (R5/R8) preserved

The engine is not modified. This change is strictly upstream of it: it makes the destination resolvable. Leg A still fulfils only on a verified preimage, and the new wire test asserts it on the real socket — a sender that answers leg B with a REJECT leaves leg A rejected, no preimage learned, `fulfillment` undefined.

## Tests at the wire seam

`swap-node.leg-b-wire.test.ts` boots a REAL `startSwapNode()` (real `ConnectorNode`, real BTP server) and drives it from a REAL `BtpRuntimeClient` over a socket — the same `onMessage` seam a stock client installs its rolling leg-B router on. Leg 0 is a real gift-wrapped kind:20033 across the wire; leg B goes out through `createConnectorLegBSender`, the production egress, and is asserted to arrive at the client carrying the sender-minted condition verbatim and to come back FULFILLed with the preimage. This is what caught the `T00` layer. A unit test of address derivation would have caught neither defect.

Plus `leg-b-return-path.test.ts` for the guard/eviction decision table.

## Also

The standalone connector branch now sets `settlement: { connectorFeePercentage: 0 }`, mirroring the embedded-with-parent branch. Without it the default fee shaved the ILP `amount` of the one thing a standalone maker ever forwards — its own leg-B PREPARE — so the packet understated the chain-B claim it carried (3000 → 2997). The client does not read that field today; the wire should still be self-consistent.

## Upstream follow-up

`setPeerRelation` is exposed by `ConnectorNode` only to its admin HTTP server, and a swap node runs with `adminApi: { enabled: false }` — so this reaches `_packetHandler.setPeerRelation` directly, guarded and best-effort (no relation ⇒ the route still lands and a claim-gated leg B fails loudly and benignly). A public setter, or an automatic `child` relation for inbound sessions, belongs in the connector.

## Verify live

Maker auto-deploys on green `main`. Once `swap:release` has moved, a plain default swap is the whole test — no flags, no operator config:

```
toon_swap  { "from": "USDC:evm:84532", "to": "USDC:evm:84532", "amount": "3000" }
```

Expect `rolling.used: true`, `packetsAccepted: 1`, `valueReceived` > 0. Before this change the same call returned `F99 "leg B failed; fill not executed"` with `packetsAccepted: 0`.
