### PR TITLE
ci(release): push the Release PR branch with the App token — #147 is blocked with zero checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # The App token, NOT the default GITHUB_TOKEN. changesets/action
+          # pushes `changeset-release/main` with the git credentials checkout
+          # persists, and checkout defaults that to GITHUB_TOKEN. A push made
+          # by GITHUB_TOKEN does not trigger workflows, so the Version Packages
+          # PR's `synchronize` event fires no CI at all and the required
+          # `CI OK` context can never appear — leaving the PR permanently
+          # BLOCKED. The PR is still CREATED fine, because creation goes
+          # through the env token below, which was already the App's; that is
+          # why `opened` is green and every later push is not.
+          # With the App as the push credential, the Release PR's pull_request
+          # events fire CI like any human push would. (toon-client#467, toon#208)
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
## The trap

A `Version Packages` PR in this repo lands in a state where it can never merge:

- `mergeable: true`, `mergeable_state: "blocked"`
- `gh pr checks <n>` returns **nothing at all** — not pending, not failed, *no checks*
- `CI OK` is a required status context on `main`, so `blocked` is permanent

The only exits are an admin override or a manual close/reopen (`reopened` is in the default activity types for `on: pull_request`, so it fires CI). That is a ritual nobody will remember.

## Root cause — the push credential, not the commit identity

`actions/checkout` was given no `token:`, so it persists the default `GITHUB_TOKEN` into `.git/config`. `changesets/action` then pushes `changeset-release/main` over that persisted credential, and GitHub deliberately does not trigger workflows from `GITHUB_TOKEN`-authored events. So the PR's `synchronize` produces no runs and `CI OK` never appears.

The PR is still *created* fine, because creation goes through the octokit client in `changesets/action` using `env.GITHUB_TOKEN` — which was **already** the App token. Only the git push was left on `GITHUB_TOKEN`. Hence the confusing split: `opened` runs CI green, every subsequent push runs nothing.

## The fix

Pass the App token to `actions/checkout` so the push is a GitHub App installation push, which triggers workflows normally.

- **No new secret and no widened scope.** Same `APP_ID` / `APP_PRIVATE_KEY` this workflow already mints two steps above and already hands to `changesets/action`. It is now also the git credential for the branch it was already authorised to write.
- **Branch protection untouched.** No context removed, nothing made skippable — the point is to let `CI OK` *run*, not to bypass it.
- Falls back to `github.token` if the App is absent, matching the existing `|| secrets.GITHUB_TOKEN` fallback below.

## Why not the alternatives

- **`workflow_dispatch` on `ci.yml`** — still manual; it replaces "close and reopen" with "remember to dispatch".
- **A PAT** — strictly worse than the App token already present here: long-lived, tied to a person, org-wide, where the App installation token is short-lived and installation-scoped. The narrower option was sufficient.
- **Having `release.yml` post `CI OK` itself** — manufactures a required check without running it; that is exactly the gate-weakening we must not do.

## Org convention

Not a new mechanism. `rig` and `toon-client` already carry the identical `token:` line on their release checkout, added for this same failure in `toon-client#467`, and neither has a blocked release PR. `toon` is getting it in toon#208. This brings this repo in line, so all five changesets repos in the org (toon, swap, relay, rig, toon-client) behave the same way.

## This repo is affected *right now*

`#147` ("Version Packages") is open and **BLOCKED**: 0 check runs on its head SHA `8c58413`, and `gh pr checks 147` reports "no checks reported on the changeset-release/main branch". Its last force-push (2026-08-16 21:49:14Z) was attributed to `github-actions[bot]`.

Once this merges, the next release run pushes as the App and `#147` picks up CI normally. If it stays stuck on its current SHA, one last close/reopen clears it — for the last time.
