### PR TITLE
Adopt @toon-protocol/sdk@3.2.0's onFailure seam and delete the swap#137 workaround

### DIFF
--- a/.changeset/sdk-3.2.0-on-failure-seam.md
+++ b/.changeset/sdk-3.2.0-on-failure-seam.md
@@ -1,0 +1,22 @@
+---
+'@toon-protocol/swap': minor
+---
+
+**Adopt `@toon-protocol/sdk@3.2.0`'s `onFailure` seam and delete the workaround that stood in for it.**
+
+swap#137 had to reclaim the SDK swap handler's swallowed diagnoses from the outside, because `createSwapHandler` collapsed every non-`INSUFFICIENT_INVENTORY` failure into an opaque `T00 Internal error` and discarded the error object. SDK 3.2.0 (toon#204/#205) adds `CreateSwapHandlerConfig.onFailure`: a synchronous classifier called before the handler rejects on any *thrown* failure, handed the thrown value verbatim, the packet context, and the `defaultRejection` it would otherwise emit.
+
+`claim-refusal.ts` is now that classifier and nothing else. Deleted with the workaround:
+
+- the `AsyncLocalStorage` per-packet capture slot;
+- `instrument()`, which wrapped the claim issuer purely to observe its throws;
+- `wrap()`, which wrapped the whole handler and sniffed its response for the literal `T00` / `Internal error` to know when to rewrite it;
+- the inference that named the `encrypt` stage from the *absence* of an issuer throw.
+
+**The encrypt path is now observed, not inferred.** The SDK reports `stage: 'encrypt'` with `context.claimIssued: true`, `context.claimId`, and the thrown value, so the refusal carries the real encryption error (`claim_encrypt_failed: … : <error>`, plus `err` and `claimId` in the reject `data`) instead of a deduction with an empty payload.
+
+**No behaviour change on the wire.** An unredeemed channel still refuses with `T04` / `insufficient_funds`, the same `channel_unredeemed: …` message naming the channel and the unredeemed amount, and the same base64-JSON `data`. `INSUFFICIENT_INVENTORY` — and anything else the SDK already classified, signalled by `defaultRejection.code !== 'T00'` — is still left entirely to the SDK. `rate_provider` and `rate_conversion` are untouched; `RateFreshnessGuard` still owns staleness upstream. No new configuration key.
+
+`swap-node.claim-refusal.test.ts`, the end-to-end proof of the live-verified swap#137 contract, passes unchanged.
+
+Package surface: `createClaimRefusalDiagnostics` and the `ClaimRefusalDiagnostics` type are gone (they existed only to carry the workaround); `createClaimRefusalMapper` replaces them. `classifyClaimIssuerError`, `buildClaimRefusalReject`, `CLAIM_REFUSAL_REASONS`, `ClaimRefusal`, `ClaimRefusalReason` and `ClaimRefusalReject` are unchanged — `rolling-engine.ts` is a live caller of the classifier.

--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -59,7 +59,7 @@
     "@scure/bip39": "^2.0.0",
     "@toon-protocol/connector": "^3.30.0",
     "@toon-protocol/core": "^2.1.0",
-    "@toon-protocol/sdk": "^3.1.8",
+    "@toon-protocol/sdk": "^3.2.0",
     "@toon-protocol/settlement-digest": "^1.0.0",
     "ed25519-hd-key": "^1.3.0",
     "hono": "^4.11.10",

--- a/packages/swap/src/claim-refusal.test.ts
+++ b/packages/swap/src/claim-refusal.test.ts
@@ -1,23 +1,25 @@
 /**
- * swap#136 — unit coverage for the claim-refusal classifier and the two
- * wrappers that reclaim what the SDK swap handler throws away.
+ * swap#136 — unit coverage for the claim-refusal classifier and the
+ * `onFailure` mapper it feeds into the SDK swap handler (SDK ≥ 3.2.0).
  *
  * The end-to-end proof (a real gift-wrapped swap producing a logged,
  * actionable refusal) lives in `swap-node.claim-refusal.test.ts`; this file
- * pins the per-condition mapping and the concurrency property that makes the
- * handler wrapper safe.
+ * pins the per-condition mapping and which stages the mapper claims.
  */
 import { describe, it, expect, vi } from 'vitest';
+
+import type { SwapHandlerFailure } from '@toon-protocol/sdk';
 
 import {
   CLAIM_REFUSAL_REASONS,
   classifyClaimIssuerError,
   buildClaimRefusalReject,
-  createClaimRefusalDiagnostics,
+  createClaimRefusalMapper,
 } from './claim-refusal.js';
 import { SwapWalletError, SwapInventoryError } from './errors.js';
 
-const GENERIC = { accept: false, code: 'T00', message: 'Internal error' };
+/** The SDK's opaque catch-all, verbatim. */
+const GENERIC_DEFAULT = { code: 'T00', message: 'Internal error' };
 
 function unredeemedError(channelId = '0x0124a370', unredeemed = 1_000n) {
   return new SwapWalletError(
@@ -107,138 +109,169 @@ describe('buildClaimRefusalReject', () => {
   });
 });
 
-describe('createClaimRefusalDiagnostics', () => {
-  it('[P0] instrument() logs the refusal and rethrows unchanged', async () => {
-    const warn = vi.fn();
-    const diagnostics = createClaimRefusalDiagnostics({
+describe('createClaimRefusalMapper (SDK onFailure seam)', () => {
+  const PAIR = {
+    from: { assetCode: 'USDC', assetScale: 6, chain: 'evm:8453' },
+    to: { assetCode: 'USDC', assetScale: 6, chain: 'evm:8453' },
+    rate: '1.0',
+  };
+
+  /** A `SwapHandlerFailure` shaped exactly as the SDK hands it over. */
+  function failure(
+    stage: SwapHandlerFailure['stage'],
+    error: unknown,
+    overrides: {
+      defaultRejection?: { code: string; message: string };
+      claimIssued?: boolean;
+      claimId?: string;
+    } = {}
+  ): SwapHandlerFailure {
+    const code = (error as { code?: string } | undefined)?.code;
+    return {
+      stage,
+      error,
+      message: error instanceof Error ? error.message : String(error),
+      ...(typeof code === 'string' && { code }),
+      context: {
+        destination: 'g.toon.swap.fixture',
+        sourceAmount: 1_000n,
+        pair: PAIR,
+        senderPubkey: 'ab'.repeat(32),
+        chainRecipient: '0x' + '11'.repeat(20),
+        claimIssued: overrides.claimIssued ?? false,
+        ...(overrides.claimId !== undefined && { claimId: overrides.claimId }),
+      },
+      defaultRejection: overrides.defaultRejection ?? GENERIC_DEFAULT,
+    } as SwapHandlerFailure;
+  }
+
+  function loggerSpies(): {
+    logger: {
+      debug: ReturnType<typeof vi.fn>;
+      info: ReturnType<typeof vi.fn>;
+      warn: ReturnType<typeof vi.fn>;
+      error: ReturnType<typeof vi.fn>;
+    };
+  } {
+    return {
       logger: {
         debug: vi.fn(),
         info: vi.fn(),
-        warn,
+        warn: vi.fn(),
         error: vi.fn(),
       },
-    });
-    const thrown = unredeemedError();
-    const issuer = diagnostics.instrument({
-      issueClaim: async () => {
-        throw thrown;
-      },
-    });
+    };
+  }
 
-    await expect(issuer.issueClaim({})).rejects.toBe(thrown);
-    expect(warn).toHaveBeenCalledTimes(1);
-    const [event, fields] = warn.mock.calls[0] ?? [];
+  it("[P0] an issuer failure replaces the SDK's blanket T00 and logs the refusal", () => {
+    const { logger } = loggerSpies();
+    const mapper = createClaimRefusalMapper({ logger });
+
+    const rejection = mapper(failure('issuer', unredeemedError()));
+
+    expect(rejection?.code).toBe('T04');
+    expect(rejection?.message).toContain(
+      CLAIM_REFUSAL_REASONS.CHANNEL_UNREDEEMED
+    );
+    expect(rejection?.message).toContain('0x0124a370');
+    expect(rejection?.rejectReason?.code).toBe('insufficient_funds');
+    const data = JSON.parse(
+      Buffer.from(rejection?.data ?? '', 'base64').toString('utf8')
+    ) as Record<string, unknown>;
+    expect(data['reason']).toBe(CLAIM_REFUSAL_REASONS.CHANNEL_UNREDEEMED);
+    expect(data['unredeemed']).toBe('1000');
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const [event, fields] = logger.warn.mock.calls[0] ?? [];
     expect(event).toBe('swap.claim.refused');
     expect(fields).toMatchObject({
       reason: CLAIM_REFUSAL_REASONS.CHANNEL_UNREDEEMED,
       ilpCode: 'T04',
+      stage: 'issuer',
       channelId: '0x0124a370',
       unredeemed: '1000',
     });
   });
 
-  it('[P0] INSUFFICIENT_INVENTORY is left to the SDK (T04 "Insufficient liquidity" is unchanged)', async () => {
-    const warn = vi.fn();
-    const error = vi.fn();
-    const diagnostics = createClaimRefusalDiagnostics({
-      logger: { debug: vi.fn(), info: vi.fn(), warn, error },
-    });
-    const issuer = diagnostics.instrument({
-      issueClaim: async () => {
-        throw new SwapInventoryError('INSUFFICIENT_INVENTORY', 'no reserves');
-      },
-    });
-    await expect(issuer.issueClaim({})).rejects.toThrow('no reserves');
-    expect(warn).not.toHaveBeenCalled();
-    expect(error).not.toHaveBeenCalled();
+  it('[P0] INSUFFICIENT_INVENTORY is left to the SDK (T04 "Insufficient liquidity" unchanged)', () => {
+    const { logger } = loggerSpies();
+    const mapper = createClaimRefusalMapper({ logger });
 
-    // …and the handler wrapper leaves the SDK's own T04 alone.
-    const handler = diagnostics.wrap(async () => ({
-      accept: false,
-      code: 'T04',
-      message: 'Insufficient liquidity',
-    }));
-    expect(await handler({})).toEqual({
-      accept: false,
-      code: 'T04',
-      message: 'Insufficient liquidity',
-    });
+    const rejection = mapper(
+      failure(
+        'issuer',
+        new SwapInventoryError('INSUFFICIENT_INVENTORY', 'no reserves'),
+        {
+          defaultRejection: {
+            code: 'T04',
+            message: 'Insufficient liquidity',
+          },
+        }
+      )
+    );
+
+    expect(rejection).toBeUndefined();
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
   });
 
-  it("[P0] wrap() replaces the SDK's blanket T00 with the captured refusal", async () => {
-    const diagnostics = createClaimRefusalDiagnostics({});
-    const issuer = diagnostics.instrument({
-      issueClaim: async () => {
-        throw unredeemedError();
-      },
-    });
-    const handler = diagnostics.wrap(async () => {
-      // stand-in for the SDK handler: calls the issuer, swallows the throw
-      await issuer.issueClaim({}).catch(() => undefined);
-      return GENERIC;
-    });
-
-    const result = (await handler({})) as { code: string; message: string };
-    expect(result.code).toBe('T04');
-    expect(result.message).toContain(CLAIM_REFUSAL_REASONS.CHANNEL_UNREDEEMED);
+  it("[P1] an issuer failure the SDK already classified keeps the SDK's reject", () => {
+    const mapper = createClaimRefusalMapper({});
+    // The SDK's `/insufficient/i` message fallback → T04 without the code.
+    const rejection = mapper(
+      failure('issuer', new Error('insufficient something'), {
+        defaultRejection: { code: 'T04', message: 'Insufficient liquidity' },
+      })
+    );
+    expect(rejection).toBeUndefined();
   });
 
-  it('[P0] concurrent packets never cross-contaminate (per-packet AsyncLocalStorage slot)', async () => {
-    const diagnostics = createClaimRefusalDiagnostics({});
-    const issuer = diagnostics.instrument({
-      issueClaim: async (params: { fail?: string }) => {
-        await new Promise((r) => setTimeout(r, params.fail === 'a' ? 20 : 1));
-        if (params.fail === 'a') throw unredeemedError('0xAAA', 111n);
-        if (params.fail === 'b') throw unredeemedError('0xBBB', 222n);
-        return { ok: true };
-      },
-    });
-    const handler = diagnostics.wrap(async (ctx: { fail?: string }) => {
-      await issuer.issueClaim(ctx).catch(() => undefined);
-      return GENERIC;
-    });
+  it('[P0] the encrypt stage is OBSERVED — the real error, not an inference', () => {
+    const { logger } = loggerSpies();
+    const mapper = createClaimRefusalMapper({ logger });
 
-    const [a, b] = (await Promise.all([
-      handler({ fail: 'a' }),
-      handler({ fail: 'b' }),
-    ])) as { message: string }[];
-    expect(a.message).toContain('0xAAA');
-    expect(a.message).toContain('111');
-    expect(b.message).toContain('0xBBB');
-    expect(b.message).toContain('222');
-  });
+    const rejection = mapper(
+      failure('encrypt', new Error('invalid sender pubkey'), {
+        claimIssued: true,
+        claimId: 'claim-7',
+      })
+    );
 
-  it("[P1] a successful issuance followed by the SDK's T00 is named as the encrypt path", async () => {
-    const error = vi.fn();
-    const diagnostics = createClaimRefusalDiagnostics({
-      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error },
-    });
-    const issuer = diagnostics.instrument({
-      issueClaim: async () => ({ claim: new Uint8Array([1]) }),
-    });
-    const handler = diagnostics.wrap(async () => {
-      await issuer.issueClaim({});
-      return GENERIC; // the SDK's `swap_handler.encrypt_failed` branch
-    });
-
-    const result = (await handler({})) as { code: string; message: string };
-    expect(result.message).toContain(
+    expect(rejection?.code).toBe('T00');
+    expect(rejection?.message).toContain(
       CLAIM_REFUSAL_REASONS.CLAIM_ENCRYPT_FAILED
     );
-    expect(error).toHaveBeenCalledTimes(1);
+    // The thrown message reaches the wire — pre-3.2.0 it was discarded.
+    expect(rejection?.message).toContain('invalid sender pubkey');
+    const data = JSON.parse(
+      Buffer.from(rejection?.data ?? '', 'base64').toString('utf8')
+    ) as Record<string, unknown>;
+    expect(data['reason']).toBe(CLAIM_REFUSAL_REASONS.CLAIM_ENCRYPT_FAILED);
+    expect(data['err']).toContain('invalid sender pubkey');
+    expect(data['claimId']).toBe('claim-7');
+    expect(logger.error).toHaveBeenCalledTimes(1);
   });
 
-  it('[P1] a T00 with no issuance attempted at all is passed through untouched', async () => {
-    const diagnostics = createClaimRefusalDiagnostics({});
-    const handler = diagnostics.wrap(async () => GENERIC);
-    expect(await handler({})).toEqual(GENERIC);
+  it('[P1] rate stages are left alone — RateFreshnessGuard owns staleness', () => {
+    const mapper = createClaimRefusalMapper({});
+    expect(
+      mapper(
+        failure('rate_provider', new Error('rpc down'), {
+          defaultRejection: { code: 'T00', message: 'Rate provider error' },
+        })
+      )
+    ).toBeUndefined();
+    expect(
+      mapper(
+        failure('rate_conversion', new Error('bad rate'), {
+          defaultRejection: { code: 'T00', message: 'Rate conversion error' },
+        })
+      )
+    ).toBeUndefined();
   });
 
-  it('[P1] accepts and non-generic rejects are passed through untouched', async () => {
-    const diagnostics = createClaimRefusalDiagnostics({});
-    const accept = { accept: true, metadata: { claim: 'x' } };
-    expect(await diagnostics.wrap(async () => accept)({})).toBe(accept);
-    const stale = { accept: false, code: 'T99', message: 'stale_rate' };
-    expect(await diagnostics.wrap(async () => stale)({})).toBe(stale);
+  it('[P1] no logger configured is not a crash', () => {
+    const mapper = createClaimRefusalMapper({});
+    expect(mapper(failure('issuer', unredeemedError()))?.code).toBe('T04');
   });
 });

--- a/packages/swap/src/claim-refusal.ts
+++ b/packages/swap/src/claim-refusal.ts
@@ -16,15 +16,22 @@
  *
  * Live on devnet the thrown message was a perfectly actionable
  * `0x0124a370…: 1000 unredeemed` (from `channel-state.ts`'s `reserve()`), and
- * the client saw `{"code":"T00","message":"Internal error"}`. The SDK is a
- * pinned dependency, so this module reclaims both halves on our side:
+ * the client saw `{"code":"T00","message":"Internal error"}`.
  *
- *   - **logs** — the issuer wrapper below logs the classified refusal with a
- *     real logger before the SDK ever sees the error;
- *   - **wire** — the handler wrapper rewrites the SDK's generic
- *     `T00 Internal error` into the classified code/message/`data`, using the
- *     refusal captured for *that packet* (an `AsyncLocalStorage` slot, so
- *     concurrent `handlePacket` calls cannot cross-contaminate).
+ * ## The seam (`@toon-protocol/sdk@3.2.0`, toon#205)
+ *
+ * The SDK now offers `CreateSwapHandlerConfig.onFailure`: a synchronous
+ * classifier called *before* the handler rejects on any thrown failure, handed
+ * the thrown value verbatim, the packet context, and the `defaultRejection` it
+ * would otherwise emit. Returning a `SwapHandlerRejection` replaces the wire
+ * code/message and may attach `data` and `rejectReason`.
+ *
+ * `createClaimRefusalMapper()` below is that classifier, and it does both
+ * halves in one place — it logs the classified refusal AND returns the reject
+ * that goes on the wire. It replaced (swap#146) the pre-3.2.0 workaround: an
+ * `AsyncLocalStorage` slot plus a pair of wrappers that instrumented the claim
+ * issuer to capture the throw and then sniffed the handler's response for the
+ * literal `T00`/`Internal error` to know when to rewrite it.
  *
  * ## Code choices
  *
@@ -40,25 +47,27 @@
  * | `no_channel_available` | F99  | `application_error` | no channel is provisioned for this sender at all — retrying now cannot help; pick another maker |
  * | `persist_failed`       | T00  | `internal_error`    | genuinely internal and transient (disk), but now says so |
  * | `signing_failed`       | T00  | `internal_error`    | genuinely internal, but now says so                      |
- * | `claim_encrypt_failed` | T00  | `internal_error`    | see the SDK note below                                   |
+ * | `claim_encrypt_failed` | T00  | `internal_error`    | the SDK's `encrypt` stage — see below                    |
  *
  * Every refusal also carries base64-JSON `data` whose `reason` field is the
  * authoritative discriminator — the same contract `buildStaleRateReject()`
  * and `buildRollingReject()` already publish.
  *
- * ## Still owed by the SDK
+ * ## The encrypt stage is now observed, not inferred
  *
- * `swap_handler.encrypt_failed` (the SDK's *other* `T00 Internal error`)
- * discards its error object entirely — it never reaches a caller-supplied
- * seam, so no wrapper on this side can recover the message. What we can do,
- * and do below, is *identify* it: a T00/`Internal error` from the SDK handler
- * after a claim was issued successfully can only have come from the encrypt
- * branch. We log that and name it on the wire. The real fix — surfacing the
- * error and rejecting with something better than `T00 Internal error` —
- * belongs in `packages/sdk/src/swap-handler.ts` upstream.
+ * `swap_handler.encrypt_failed` is the SDK's *other* `T00 Internal error`, and
+ * pre-3.2.0 it discarded its error object entirely. swap#137 could only
+ * *infer* it: a blanket `T00 Internal error` from the handler after a claim
+ * was issued successfully can have come from nowhere else. That inference is
+ * gone. The SDK now hands us `stage: 'encrypt'` with `context.claimIssued:
+ * true`, `context.claimId`, and the thrown value itself, so the refusal names
+ * the real failure instead of deducing its existence.
  */
 
-import { AsyncLocalStorage } from 'node:async_hooks';
+import type {
+  SwapHandlerFailure,
+  SwapHandlerRejection,
+} from '@toon-protocol/sdk';
 
 import type { SwapNodeLogger } from './swap-node.js';
 
@@ -140,8 +149,8 @@ const SHAPES: Record<ClaimRefusalReason, RefusalShape> = {
     code: 'T00',
     semantic: 'internal_error',
     level: 'error',
-    describe: () =>
-      'the maker issued the claim but could not encrypt it to the sender key from the gift wrap',
+    describe: (d) =>
+      `the maker issued the claim but could not encrypt it to the sender key from the gift wrap${d['err'] ? `: ${String(d['err'])}` : ''}`,
   },
   [CLAIM_REFUSAL_REASONS.CLAIM_ISSUE_FAILED]: {
     code: 'T00',
@@ -232,10 +241,6 @@ export function classifyClaimIssuerError(err: unknown): ClaimRefusal {
   });
 }
 
-/** The SDK's generic swallow-everything reject, verbatim. */
-const SDK_GENERIC_REJECT_MESSAGE = 'Internal error';
-const SDK_GENERIC_REJECT_CODE = 'T00';
-
 /** Reject-response shape the connector's PaymentHandlerAdapter consumes. */
 export interface ClaimRefusalReject {
   accept: false;
@@ -265,108 +270,82 @@ export function buildClaimRefusalReject(
 }
 
 // ---------------------------------------------------------------------------
-// Per-packet capture + the two wrappers
+// The SDK seam
 // ---------------------------------------------------------------------------
 
-interface CaptureSlot {
-  refusal?: ClaimRefusal;
-  issued: boolean;
-}
+/** The SDK's opaque catch-all default — the only reject we take over. */
+const SDK_GENERIC_REJECT_CODE = 'T00';
 
-/** Minimal structural view of the SDK's `ClaimIssuer` (avoids a value import). */
-export interface IssueClaimLike<P, R> {
-  issueClaim(params: P): Promise<R>;
-}
-
-export interface ClaimRefusalDiagnostics {
-  /**
-   * Wrap the claim issuer handed to `createSwapHandler`. Logs the classified
-   * refusal and records it for the in-flight packet, then rethrows unchanged
-   * so the SDK's own `INSUFFICIENT_INVENTORY` handling is untouched.
-   */
-  instrument<P, R>(issuer: IssueClaimLike<P, R>): IssueClaimLike<P, R>;
-  /**
-   * Wrap the SDK handler so its generic `T00 Internal error` is replaced by
-   * the refusal captured for that same packet.
-   */
-  wrap<C, T>(handler: (ctx: C) => Promise<T>): (ctx: C) => Promise<T>;
-}
-
-export function createClaimRefusalDiagnostics(options: {
+/**
+ * Build the `CreateSwapHandlerConfig.onFailure` classifier (SDK ≥ 3.2.0).
+ *
+ * Synchronous by contract — it runs on the reject path of a live packet — and
+ * total: any stage it cannot improve on returns `undefined`, leaving the SDK's
+ * own `defaultRejection` exactly as it was.
+ *
+ * What it claims, and what it deliberately does not:
+ *
+ * - **`issuer`** — classifies whatever `issueClaim()` threw, and logs it.
+ *   `INSUFFICIENT_INVENTORY` is left entirely to the SDK (it already maps to
+ *   `T04 Insufficient liquidity` and logs at warn), and so is any other
+ *   already-classified failure — signalled by `defaultRejection.code !== 'T00'`
+ *   — so that contract stays byte-identical for existing senders.
+ * - **`encrypt`** — `claimIssued` is `true` here by construction: the claim
+ *   exists and is now stranded. The thrown value comes with it, so the refusal
+ *   names the real encryption failure.
+ * - **`rate_provider` / `rate_conversion`** — untouched. Rate freshness is
+ *   already refused upstream by `RateFreshnessGuard` (`rate-staleness.ts`)
+ *   with its own `T99 stale_rate` contract, and the SDK's own defaults for
+ *   these two stages already carry a specific message.
+ */
+export function createClaimRefusalMapper(options: {
   logger?: SwapNodeLogger;
-}): ClaimRefusalDiagnostics {
-  const store = new AsyncLocalStorage<CaptureSlot>();
+}): (failure: SwapHandlerFailure) => SwapHandlerRejection | undefined {
   const logger = options.logger;
 
-  return {
-    instrument<P, R>(issuer: IssueClaimLike<P, R>): IssueClaimLike<P, R> {
-      return {
-        issueClaim: async (params: P): Promise<R> => {
-          try {
-            const result = await issuer.issueClaim(params);
-            const slot = store.getStore();
-            if (slot) slot.issued = true;
-            return result;
-          } catch (err) {
-            // Leave the SDK's own liquidity contract alone.
-            if (
-              (err as { code?: string } | undefined)?.code !==
-              'INSUFFICIENT_INVENTORY'
-            ) {
-              const refusal = classifyClaimIssuerError(err);
-              const slot = store.getStore();
-              if (slot) slot.refusal = refusal;
-              logger?.[refusal.level]?.('swap.claim.refused', {
-                reason: refusal.reason,
-                ilpCode: refusal.code,
-                clientMessage: refusal.message,
-                ...(jsonSafe(refusal.detail) as Record<string, unknown>),
-              });
-            }
-            throw err;
-          }
-        },
-      };
-    },
+  const report = (refusal: ClaimRefusal, stage: string): void => {
+    logger?.[refusal.level]?.('swap.claim.refused', {
+      reason: refusal.reason,
+      ilpCode: refusal.code,
+      clientMessage: refusal.message,
+      stage,
+      ...(jsonSafe(refusal.detail) as Record<string, unknown>),
+    });
+  };
 
-    wrap<C, T>(handler: (ctx: C) => Promise<T>): (ctx: C) => Promise<T> {
-      return async (ctx: C): Promise<T> => {
-        const slot: CaptureSlot = { issued: false };
-        const result = await store.run(slot, () => handler(ctx));
-        const r = result as unknown as {
-          accept?: boolean;
-          code?: string;
-          message?: string;
-        };
-        if (
-          r?.accept !== false ||
-          r.code !== SDK_GENERIC_REJECT_CODE ||
-          r.message !== SDK_GENERIC_REJECT_MESSAGE
-        ) {
-          return result;
-        }
-        if (slot.refusal) {
-          return buildClaimRefusalReject(slot.refusal) as unknown as T;
-        }
-        if (slot.issued) {
-          // Nothing threw out of `issueClaim` and the claim was produced, so
-          // the SDK's only remaining `T00 Internal error` branch is
-          // `swap_handler.encrypt_failed` — whose error object the SDK
-          // discards, hence the inference. See this file's header.
-          const refusal = buildRefusal(
-            CLAIM_REFUSAL_REASONS.CLAIM_ENCRYPT_FAILED,
-            {}
-          );
-          logger?.error?.('swap.claim.refused', {
-            reason: refusal.reason,
-            ilpCode: refusal.code,
-            clientMessage: refusal.message,
-            note: 'inferred from the SDK handler response; the SDK discards the underlying encrypt error',
-          });
-          return buildClaimRefusalReject(refusal) as unknown as T;
-        }
-        return result;
-      };
-    },
+  const toRejection = (refusal: ClaimRefusal): SwapHandlerRejection => {
+    const { code, message, data, rejectReason } =
+      buildClaimRefusalReject(refusal);
+    return { code, message, data, rejectReason };
+  };
+
+  return (failure: SwapHandlerFailure): SwapHandlerRejection | undefined => {
+    if (failure.stage === 'issuer') {
+      // The SDK owns the liquidity contract end to end.
+      if (failure.code === 'INSUFFICIENT_INVENTORY') return undefined;
+      const refusal = classifyClaimIssuerError(failure.error);
+      report(refusal, failure.stage);
+      // Anything the SDK already classified (its `/insufficient/i` message
+      // fallback also lands on T04) keeps its own reject; we only take over
+      // the opaque `T00 Internal error`.
+      if (failure.defaultRejection.code !== SDK_GENERIC_REJECT_CODE) {
+        return undefined;
+      }
+      return toRejection(refusal);
+    }
+
+    if (failure.stage === 'encrypt') {
+      const refusal = buildRefusal(CLAIM_REFUSAL_REASONS.CLAIM_ENCRYPT_FAILED, {
+        err: failure.message,
+        ...(failure.code !== undefined && { code: failure.code }),
+        ...(failure.context.claimId !== undefined && {
+          claimId: failure.context.claimId,
+        }),
+      });
+      report(refusal, failure.stage);
+      return toRejection(refusal);
+    }
+
+    return undefined;
   };
 }

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -124,13 +124,12 @@ export {
   CLAIM_REFUSAL_REASONS,
   classifyClaimIssuerError,
   buildClaimRefusalReject,
-  createClaimRefusalDiagnostics,
+  createClaimRefusalMapper,
 } from './claim-refusal.js';
 export type {
   ClaimRefusal,
   ClaimRefusalReason,
   ClaimRefusalReject,
-  ClaimRefusalDiagnostics,
 } from './claim-refusal.js';
 
 // swap#136 — the process-level structured logger the CLI installs.

--- a/packages/swap/src/swap-node.ts
+++ b/packages/swap/src/swap-node.ts
@@ -83,7 +83,7 @@ import {
 } from './payment-channel-signer.js';
 import type { PaymentChannelSigner } from './payment-channel-signer.js';
 import { MultiChainClaimIssuer } from './claim-issuer.js';
-import { createClaimRefusalDiagnostics } from './claim-refusal.js';
+import { createClaimRefusalMapper } from './claim-refusal.js';
 import { SwapNodeStartError } from './errors.js';
 import {
   JsonFileSwapStateStore,
@@ -1524,18 +1524,16 @@ export async function startSwapNode(
       ? normalizeRateProvider(config.rateProvider)
       : undefined;
 
-  // swap#136 — reclaim the diagnosis the SDK handler throws away. `instrument`
-  // logs (and captures) whatever `issueClaim` threw; `wrap` (applied
-  // outermost, below) turns the SDK's blanket `T00 Internal error` into that
-  // captured refusal's code/message/data. See `claim-refusal.ts`.
-  const refusalDiagnostics = createClaimRefusalDiagnostics({ logger });
-
+  // swap#136 — reclaim the diagnosis the SDK handler used to throw away. Since
+  // `@toon-protocol/sdk@3.2.0` (toon#205) this is a first-class seam: the
+  // handler hands us the thrown value, the packet context and the reject it
+  // would otherwise emit, and we log the classified refusal and return the
+  // reject that actually goes on the wire. See `claim-refusal.ts`.
   const swapHandler = createSwapHandler({
     recipientSecretKey: identity.secretKey,
     swapPairs: [...config.swapPairs],
-    claimIssuer: refusalDiagnostics.instrument(
-      claimIssuer
-    ) as unknown as typeof claimIssuer,
+    claimIssuer,
+    onFailure: createClaimRefusalMapper({ logger }),
     ...(sdkRateProvider && { rateProvider: sdkRateProvider }),
     // Issue #46 — prefer the operator's set (verbatim, SDK contract), else
     // the swap-node-owned persistent replay set when persistence is enabled,
@@ -1567,15 +1565,10 @@ export async function startSwapNode(
       })
     : swapHandler;
 
-  // swap#136 — outermost, so it sees the final response of whatever ran
-  // inside (the staleness gate never produces the SDK's generic T00, so
-  // decorating outside the gate is safe and covers every dispatch path).
-  const diagnosedSwapHandler = refusalDiagnostics.wrap(gatedSwapHandler);
-
   // 9/10. HandlerRegistry — register on kind:1059 (NIP-59 gift-wrap).
   const registry = new HandlerRegistry();
   try {
-    registry.on(1059, diagnosedSwapHandler);
+    registry.on(1059, gatedSwapHandler);
   } catch (err) {
     throw new SwapNodeStartError(
       'HANDLER_REGISTRATION_FAILED',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0(@toon-protocol/connector@3.30.0)(typescript@5.9.3)
       '@toon-protocol/sdk':
-        specifier: ^3.1.8
-        version: 3.1.8(@toon-protocol/connector@3.30.0)(mina-signer@3.1.0)(typescript@5.9.3)
+        specifier: ^3.2.0
+        version: 3.2.0(@toon-protocol/connector@3.30.0)(mina-signer@3.1.0)(typescript@5.9.3)
       '@toon-protocol/settlement-digest':
         specifier: ^1.0.0
         version: 1.0.0
@@ -5223,7 +5223,7 @@ packages:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       '@toon-protocol/core': 3.3.0(@toon-protocol/connector@3.30.0)(typescript@5.9.3)
-      '@toon-protocol/sdk': 3.1.8(@toon-protocol/connector@3.30.0)(mina-signer@3.1.0)(typescript@5.9.3)
+      '@toon-protocol/sdk': 3.2.0(@toon-protocol/connector@3.30.0)(mina-signer@3.1.0)(typescript@5.9.3)
       nostr-tools: 2.23.1(typescript@5.9.3)
       viem: 2.47.2(typescript@5.9.3)(zod@3.25.76)
     optionalDependencies:
@@ -5516,8 +5516,8 @@ packages:
     dependencies:
       o1js: 2.14.0
 
-  /@toon-protocol/sdk@3.1.8(@toon-protocol/connector@3.30.0)(mina-signer@3.1.0)(typescript@5.9.3):
-    resolution: {integrity: sha512-aPJ5r9iL5j1dYhU1Oo2+oWsw2KLgNB4jlg214tcmCNs73GuKRx8S/biTsML9s4F2twZjUaoNyRabVK8mhvSQ1Q==}
+  /@toon-protocol/sdk@3.2.0(@toon-protocol/connector@3.30.0)(mina-signer@3.1.0)(typescript@5.9.3):
+    resolution: {integrity: sha512-KsHLiAiJc4DqCXdgnl3+Gh0uFsuP+Js4ALDZfI9gV8en0qZHJY55n3/HhkCoS6R3fVRNbcJgJW7w0r0DyJcY/Q==}
     engines: {node: '>=22'}
     peerDependencies:
       '@toon-protocol/connector': '>=3.3.3'


### PR DESCRIPTION
`@toon-protocol/sdk@3.2.0` (toon#204 → toon#205) shipped the seam swap#137 was written to live without. This adopts it and deletes the workaround.

## The workaround, and why it existed

Pre-3.2.0 `createSwapHandler` collapsed every non-`INSUFFICIENT_INVENTORY` failure into an opaque `T00 Internal error` and **discarded the error object**. Live on devnet the throw site had `0x0124a370…: 1000 unredeemed`; the client saw `{"code":"T00","message":"Internal error"}`. swap#137 reclaimed that from the outside, with:

- an `AsyncLocalStorage` slot holding a per-packet capture (so concurrent `handlePacket` calls could not cross-contaminate);
- `instrument()`, wrapping the claim issuer purely to observe its throws and record them into that slot;
- `wrap()`, wrapping the whole handler and **sniffing its response** for the literal `T00` / `Internal error` to know when to rewrite it;
- and, for the SDK's *other* `T00` — `swap_handler.encrypt_failed`, whose error object was discarded outright — an **inference**: a blanket `T00` after a claim was successfully issued can only be that branch.

## The seam

`CreateSwapHandlerConfig.onFailure` is a synchronous classifier called before the handler rejects on any *thrown* failure, handed the thrown value verbatim, the packet context, and the `defaultRejection` it would otherwise emit. Returning a `SwapHandlerRejection` replaces `code`/`message` and may attach `data` and `rejectReason` — precisely the shape `buildClaimRefusalReject()` already produced.

`claim-refusal.ts` is now the classifier and nothing else: `classifyClaimIssuerError` + `buildClaimRefusalReject`, wired up by `createClaimRefusalMapper()`, which both logs the refusal and returns the reject.

## Deleted

| gone | why it existed |
|---|---|
| `AsyncLocalStorage` slot + `CaptureSlot` | carried a throw from the issuer to the response rewriter across an await boundary |
| `instrument()` | the only way to see what `issueClaim()` threw |
| `wrap()` | the only way to replace the reject the handler had already built |
| `SDK_GENERIC_REJECT_CODE` / `SDK_GENERIC_REJECT_MESSAGE` sniffing | how `wrap()` recognised "this is the swallowed one" |
| `IssueClaimLike`, `ClaimRefusalDiagnostics`, `createClaimRefusalDiagnostics` | types/factory that existed only to hold the above |
| the encrypt-stage inference (and its `note: 'inferred from the SDK handler response'` log field) | the SDK used to discard the encrypt error |
| `node:async_hooks` import | — |

**Kept, with live callers checked:** `classifyClaimIssuerError` (also called by `rolling-engine.ts:941`), `buildClaimRefusalReject`, `CLAIM_REFUSAL_REASONS`, `ClaimRefusal`, `ClaimRefusalReason`, `ClaimRefusalReject`. One residual constant, `SDK_GENERIC_REJECT_CODE = 'T00'`, survives in a different role — it is now how the mapper tells an *already-classified* SDK default from the opaque one, per toon#205's own guidance.

## The encrypt path is now observed

`stage: 'encrypt'` arrives with `context.claimIssued: true` (true there by construction — the claim exists and is now stranded), `context.claimId`, and the thrown value. So the refusal names the real failure: `claim_encrypt_failed: the maker issued the claim but could not encrypt it to the sender key from the gift wrap: <error>`, with `err` and `claimId` in the reject `data`. Previously the message ended at "gift wrap" and `data` carried nothing but `reason`.

Proved by `[P0] the encrypt stage is OBSERVED — the real error, not an inference` in `claim-refusal.test.ts`, which drives a `stage: 'encrypt'` failure through the mapper and asserts the thrown message reaches both the wire message and `data.err`, and by the SDK's own `swap-handler.test.ts` case that reaches this stage from a **real** `encryptFulfillClaim` throw, unmocked (toon#205).

The empty-detail branch still renders exactly the pre-change sentence, so nothing that was previously observable drifted.

## Behaviour preserved

swap#137's contract is live-verified on devnet, so it is asserted end-to-end rather than by unit:

- `swap-node.claim-refusal.test.ts` — two real gift-wrapped swaps through the connector-facing `setPacketHandler` — **passes unchanged, not one line edited**. Unredeemed channel → `T04`, `rejectReason.code: insufficient_funds`, message naming the channel id and `1000`, `data.reason: channel_unredeemed` / `data.channelId` / `data.unredeemed` / `data.chain`, and no inventory moved.
- `INSUFFICIENT_INVENTORY` is still left entirely to the SDK (`T04 Insufficient liquidity`, warn-level). So is anything else the SDK already classified — its `/insufficient/i` message fallback included — via `defaultRejection.code !== 'T00'`.
- The `swap.claim.refused` log line keeps its event name and every field; it gains `stage` and loses the `note` that flagged the inference.
- `rate_provider` / `rate_conversion` return `undefined`: `RateFreshnessGuard` (`rate-staleness.ts`) already owns staleness upstream with its own `T99 stale_rate` contract.

**No new configuration key** — `onFailure` is internal wiring, not config. (Guarding against the swap#134 crash-loop, since `:release` auto-deploys.)

The `claim-refusal.test.ts` unit tests for `instrument()`/`wrap()`/the `AsyncLocalStorage` concurrency property went with the machinery; the classifier and `buildClaimRefusalReject` blocks are untouched, and the deleted wrapper cases are replaced by six cases driving `SwapHandlerFailure` fixtures shaped exactly as the SDK builds them.

## Gate

Local: `pnpm build`, `pnpm lint` (0 errors / 352 warnings — unchanged), `pnpm format:check`, `pnpm test` (**42 files, 517 passed / 2 skipped**), `pnpm gate:correctness` → **PASS**, typecheck 2 errors vs. a frozen allowlist of 25 (both pre-existing in `swap-node.leg-b-wire.test.ts` on `main`; this branch removes 4 others). Lockfile diff is five lines, `@toon-protocol/sdk` only.

The fleet-config gate (swap#143) runs on this PR against the connector repo's committed `swap.config.json`; nothing here changes the config surface it boots.
