### PR TITLE
Stage 0: make legacy-vs-rolling swap intake countable (#152)

### DIFF
--- a/.changeset/issue-152-intake-classification.md
+++ b/.changeset/issue-152-intake-classification.md
@@ -1,0 +1,47 @@
+---
+'@toon-protocol/swap': minor
+---
+
+Make legacy-vs-rolling swap intake countable — the removal gate was
+unmeasurable.
+
+ADR 0003 gates every stage of the legacy-swap removal on "no legacy traffic
+observed for N consecutive days", and that sentence could not be evaluated.
+swap#137 gave the maker a real logger, but everything it emits is a **refusal**
+(`swap.claim.refused`, `swap.packet.dispatch_failed`); nothing on the success
+path ever said which protocol served a swap, so a maker serving legacy all day
+and a maker serving none produced identical logs.
+
+The dispatch seam now classifies **every** arrival onto the row of the issue
+#47 dispatch matrix it landed on — `legacy` (a zero-condition gift wrap that
+reached the legacy handler, inner rumor kind reported verbatim),
+`rolling-rfq` (inner kind 20033), `rolling-fill` (a coupled fill under a real
+32-byte sender-chosen condition), or `refused` (a pre-dispatch reject, carrying
+the reason discriminator that was already on the wire) — and records it two
+ways:
+
+- one `swap.intake` JSON line per arrival, at `info`, carrying the class, the
+  arrival peer and source ILP address, the requested pair, the inner rumor
+  kind and the outcome. This is the durable reading: it is in the container's
+  log stream, so a windowed count survives the Watchtower recreate that a
+  `:release` move performs.
+- `GET /admin/intake` — the same counts without shell-parsing, on the swap#138
+  operator surface, unauthenticated exactly as `GET /admin/inventory` is (a
+  read, disclosing strictly less than the pre-existing `GET /health`). Also
+  `SwapNodeInstance.intakeReport()`. These counters are in-process, so the
+  report always carries `since`/`windowSec` — an in-process reset is visible
+  rather than silent.
+
+The class is the dispatch row, not the outcome: a rolling fill the engine later
+rejects is still `rolling-fill`, with `accepted:false` and the reject `code`.
+The inner rumor kind — the only thing separating a legacy request from a
+rolling RFQ inside an otherwise byte-identical envelope — is read from the
+unwrap the RFQ intake already performs, via a new read-only `sniff` by-product
+on `createRollingRfqIntake().handle()`, so nothing decrypts twice.
+
+**Removes nothing and changes no swap behaviour.** No routing decision moved,
+no packet outcome changed, and the meter swallows its own errors so accounting
+can never fail a packet. Only routing metadata is recorded — the gift wrap
+stays sealed, and counterparty-supplied strings are length-capped. **No new
+config key**, required or optional (swap#134): verbosity remains the existing
+optional `SWAP_LOG_LEVEL`.

--- a/deploy/swap/README.md
+++ b/deploy/swap/README.md
@@ -88,7 +88,86 @@ the kind:10032 fields — it *does* have an override, `TOON_ILP_ADDRESS`.)
 - `btpServerPort` (config field, no default in standalone mode — the
   maker.mjs wiring uses `3400`): BTP WebSocket server. The image declares no
   `EXPOSE`; publish it with `-p` to make the maker directly dialable.
-- `blsPort`: `/health` + `/admin/inventory*` HTTP.
+- `blsPort`: `/health` + `/admin/inventory*` + `/admin/intake` HTTP.
+
+## Which protocol served a swap (swap#152)
+
+The maker classifies **every** arrival at its dispatch seam and emits one
+JSON-line record for it. This is the reading ADR 0003's *"no legacy traffic
+observed for N consecutive days"* gate is taken from — before it, a maker
+serving legacy all day and a maker serving none looked identical, because the
+node logged only refusals.
+
+| class | what arrived |
+| --- | --- |
+| `legacy` | a zero-condition gift wrap that reached the legacy handler (inner rumor kind `20032`, reported as `innerKind`) |
+| `rolling-rfq` | the same envelope whose inner rumor is kind `20033` |
+| `rolling-fill` | a coupled fill under a real 32-byte sender-chosen condition |
+| `refused` | the dispatch table rejected the shape before any handler, with the reason discriminator already on the wire |
+
+The class is the **row of the dispatch table** the packet landed on, not its
+outcome: a rolling fill the engine later rejects is still `rolling-fill`, with
+`accepted:false` and the reject `code` saying what happened to it.
+
+**Reading 1 — the log stream (this is the gate reading).** Survives a
+Watchtower recreate, because it is not in the process:
+
+```sh
+C=$(docker ps -qf name=swap-node)
+
+# per-class counts over the last 24h
+docker logs --since 24h "$C" 2>&1 | grep '"event":"swap.intake"' \
+  | grep -o '"class":"[a-z-]*"' | sort | uniq -c
+
+# the gate itself: how many legacy arrivals today?
+docker logs --since 24h "$C" 2>&1 | grep '"event":"swap.intake"' \
+  | grep -c '"class":"legacy"'
+
+# and WHO is still on legacy
+docker logs --since 24h "$C" 2>&1 | grep '"event":"swap.intake"' \
+  | grep '"class":"legacy"' | grep -o '"peer":"[^"]*"' | sort | uniq -c
+```
+
+Each record carries `class`, `accepted`, the reject `code`/`reason`, the
+arrival `peer` and `sourceAccount`, the sender's `senderPubkey`, the requested
+`pair` (`from>to`) and the inner rumor `innerKind`. **No payload** — the gift
+wrap is not logged, only routing metadata. Verbosity is the existing optional
+`SWAP_LOG_LEVEL` env var (records are `info`, the default level); there is no
+new config key.
+
+**Reading 2 — `GET /admin/intake`.** The same counts without shell-parsing.
+Unauthenticated, same as `GET /admin/inventory`, behind the box nginx's
+`^~ /admin` 404:
+
+```sh
+curl -s http://127.0.0.1:<blsPort>/admin/intake | jq
+```
+
+```jsonc
+{
+  "since": "2026-08-16T09:00:00.000Z",  // process start — the counts cover no more than this
+  "windowSec": 7200,
+  "total": 12,
+  "classes": {
+    "legacy":       { "total": 0, "accepted": 0, "rejected": 0, "lastAt": null },
+    "rolling-rfq":  { "total": 6, "accepted": 6, "rejected": 0, "lastAt": "…" },
+    "rolling-fill": { "total": 6, "accepted": 6, "rejected": 0, "lastAt": "…" },
+    "refused":      { "total": 0, "accepted": 0, "rejected": 0, "lastAt": null }
+  },
+  "reasons": {},
+  "legacyPeers": [],
+  "legacyPeersTruncated": false
+}
+```
+
+These counters are **in-process** and restart at zero whenever the container
+is recreated — which is every `:release` move. That is why `since` and
+`windowSec` are always present: a reset is visible rather than silent. For a
+multi-day gate reading use the log lines, not these totals.
+
+A healthy post-cutover baseline is `classes.legacy.total: 0` with a non-empty
+`legacyPeers: []` staying empty, and `rolling-rfq`/`rolling-fill` accounting
+for all served traffic.
 
 ## Inventory recycling & the operator surface (issue #138)
 
@@ -113,6 +192,7 @@ the chain key of the `chainProviders` entry you already have.
 
 | Route | Auth | Purpose |
 | --- | --- | --- |
+| `GET /admin/intake` | none | **swap#152.** Per-protocol-class counts of what the dispatch seam admitted, and which peers are still on the legacy path. See above. |
 | `GET /admin/inventory` | none | Per-pool `available`/`total`/`unsettled`/`inFlight`/`free`, per-channel issued-vs-redeemed-on-chain, and a `blockedReason` naming what is holding the capacity when `free` is 0. |
 | `POST /admin/inventory/reconcile` | token | Force a chain-truth pass now; returns what it recycled. |
 | `POST /admin/inventory/credit` | token | `{ assetCode, chain, amount? }` — recycle burned capital. Applies **only** what an on-chain redemption corroborates: an uncorroborated request (or one larger than the chain backs) is refused `409` with nothing applied. |

--- a/packages/swap/src/admin-surface.ts
+++ b/packages/swap/src/admin-surface.ts
@@ -10,10 +10,15 @@
  * `nonce`/`cumulativeAmount` BELOW claims already issued and invites a
  * replay — see `state-store.ts`).
  *
- * Four routes, mounted on the existing BLS server under `/admin`:
+ * Five routes, mounted on the existing BLS server under `/admin`:
  *
  * - `GET  /admin/inventory`           — read: per-pool buckets, per-channel
  *   issued-vs-redeemed, and an explicit reason when issuance is blocked.
+ * - `GET  /admin/intake`              — read (swap#152): per-protocol-class
+ *   counts of what the dispatch seam admitted — `legacy`, `rolling-rfq`,
+ *   `rolling-fill`, `refused` — and which peers are still on legacy. This is
+ *   the reading ADR 0003's "no legacy traffic for N days" gate is taken from.
+ *   See `intake-classification.ts`.
  * - `POST /admin/inventory/reconcile` — write: force a chain-truth pass now.
  * - `POST /admin/inventory/credit`    — write: recycle burned capital, and
  *   ONLY the amount an on-chain redemption corroborates.
@@ -55,10 +60,11 @@
  *    ability to protect itself. The token is optional config, so no
  *    deployment can crash-loop on it (swap#134).
  *
- * The read route is not token-gated: it discloses strictly less than the
+ * The read routes are not token-gated: they disclose strictly less than the
  * pre-existing unauthenticated `GET /health` (same inventory numbers plus
- * on-chain watermarks, which are public), and an operator diagnosing a dead
- * maker should not be blocked on a secret they may not have set.
+ * on-chain watermarks, which are public; and for `/admin/intake`, arrival
+ * counts and peer ILP addresses), and an operator diagnosing a dead maker
+ * should not be blocked on a secret they may not have set.
  */
 
 import { createHash, timingSafeEqual } from 'node:crypto';
@@ -73,6 +79,7 @@ import type {
   ReconcileResult,
   SwapInventoryReconciler,
 } from './inventory-reconciler.js';
+import type { SwapIntakeReport } from './intake-classification.js';
 
 export interface AdminChannelView {
   channelId: string;
@@ -130,12 +137,20 @@ export interface AdminSurfaceDeps {
   /** Operator token; absent ⇒ writes disabled. */
   adminToken?: string;
   clock?: () => number;
+  /**
+   * Issue #152 — per-protocol-class intake accounting. Absent ⇒
+   * `GET /admin/intake` answers 503 with a reason rather than 404, so an
+   * operator can tell "this build has no meter" from "nginx ate the route".
+   */
+  intake?: { report(): SwapIntakeReport };
 }
 
 const WRITES_DISABLED_REASON =
   'no admin token configured — set SWAP_ADMIN_TOKEN (or SwapNodeConfig.adminToken) to enable inventory writes';
 const WRITES_ENABLED_REASON =
   'token required in Authorization: Bearer <token> or X-Swap-Admin-Token';
+const INTAKE_UNAVAILABLE_REASON =
+  'this node registered its admin routes without an intake meter; per-protocol-class counts are unavailable — count the `swap.intake` log lines instead';
 
 function constantTimeEquals(a: string, b: string): boolean {
   // Hash first so the comparison operands are always the same length (and so
@@ -414,6 +429,25 @@ export function registerAdminRoutes(app: Hono, deps: AdminSurfaceDeps): void {
   app.get('/admin/inventory', (c: Context) =>
     c.json(buildInventoryReport(deps))
   );
+
+  // Issue #152 — the legacy-removal gate reading. A read, so it follows the
+  // same rule `GET /admin/inventory` set: unauthenticated behind the box
+  // nginx's `^~ /admin` 404, because it discloses strictly less than the
+  // pre-existing unauthenticated `GET /health` (traffic counts and peer ILP
+  // addresses, no balances, no keys, no payload) and the person checking
+  // "has any legacy swap arrived today" is diagnosing, not mutating.
+  app.get('/admin/intake', (c: Context) => {
+    if (!deps.intake) {
+      return c.json(
+        {
+          error: 'intake_accounting_unavailable',
+          reason: INTAKE_UNAVAILABLE_REASON,
+        },
+        503
+      );
+    }
+    return c.json(deps.intake.report());
+  });
 
   app.post('/admin/inventory/reconcile', async (c: Context) => {
     const denied = denyWrite(c);

--- a/packages/swap/src/index.test.ts
+++ b/packages/swap/src/index.test.ts
@@ -56,4 +56,15 @@ describe('@toon-protocol/swap public API exports (Story 12.4 AC-9)', () => {
   it('[P2] re-exports createSwapHandler from @toon-protocol/sdk (Story 12.7)', () => {
     expect(typeof swapNode.createSwapHandler).toBe('function');
   });
+
+  it('[P2] exports the intake meter and its class list (swap#152)', () => {
+    expect(typeof swapNode.createSwapIntakeMeter).toBe('function');
+    expect(swapNode.SWAP_INTAKE_EVENT).toBe('swap.intake');
+    expect([...swapNode.SWAP_INTAKE_CLASSES]).toEqual([
+      'legacy',
+      'rolling-rfq',
+      'rolling-fill',
+      'refused',
+    ]);
+  });
 });

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -49,6 +49,26 @@ export type {
   AdminSurfaceDeps,
 } from './admin-surface.js';
 
+// swap#152 — per-protocol-class intake accounting (ADR 0003 Stage 0).
+export {
+  createSwapIntakeMeter,
+  formatIntakePair,
+  intakePairFromTags,
+  SWAP_INTAKE_CLASSES,
+  SWAP_INTAKE_EVENT,
+} from './intake-classification.js';
+export type {
+  SwapIntakeArrival,
+  SwapIntakeClass,
+  SwapIntakeClassCounts,
+  SwapIntakeDetails,
+  SwapIntakeMeter,
+  SwapIntakeMeterOptions,
+  SwapIntakeOrigin,
+  SwapIntakePeerCount,
+  SwapIntakeReport,
+} from './intake-classification.js';
+
 // Payment-channel signing (Story 12.4)
 export type {
   PaymentChannelSigner,

--- a/packages/swap/src/intake-classification.test.ts
+++ b/packages/swap/src/intake-classification.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Unit tests for the intake meter (issue #152).
+ *
+ * The wire-level proof — that the maker's real dispatch seam puts each of the
+ * four classes on the right row, and that a kind:20032 and a kind:20033
+ * arrival differing ONLY by inner rumor kind land on different ones — lives in
+ * `swap-node.intake-classification.test.ts`. This file covers the meter's own
+ * contract: one record per arrival, honest windows, bounded tables.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  SWAP_INTAKE_EVENT,
+  UNCLASSIFIED_REASON,
+  createSwapIntakeMeter,
+  formatIntakePair,
+  intakePairFromTags,
+} from './intake-classification.js';
+import type { SwapIntakeClass } from './intake-classification.js';
+
+interface Line {
+  event: string;
+  fields: Record<string, unknown>;
+}
+
+function capturing(): {
+  logger: { info: (msg: string, meta?: Record<string, unknown>) => void };
+  lines: Line[];
+} {
+  const lines: Line[] = [];
+  return {
+    logger: {
+      info: (event: string, fields?: Record<string, unknown>) => {
+        lines.push({ event, fields: fields ?? {} });
+      },
+    },
+    lines,
+  };
+}
+
+describe('formatIntakePair / intakePairFromTags', () => {
+  it('renders a pair as a single from>to token', () => {
+    expect(
+      formatIntakePair({
+        from: { assetCode: 'USDC', chain: 'evm:84532' },
+        to: { assetCode: 'USDC', chain: 'solana:devnet' },
+      })
+    ).toBe('USDC:evm:84532>USDC:solana:devnet');
+  });
+
+  it("recovers the pair from a legacy rumor's swap-from/swap-to tags", () => {
+    expect(
+      intakePairFromTags([
+        ['swap-from', 'USDC:evm:84532'],
+        ['amount', '1000'],
+        ['swap-to', 'USDC:solana:devnet'],
+      ])
+    ).toBe('USDC:evm:84532>USDC:solana:devnet');
+  });
+
+  it('is undefined when either side is missing, and never throws on junk', () => {
+    expect(intakePairFromTags([['swap-from', 'USDC:evm:1']])).toBeUndefined();
+    expect(intakePairFromTags(undefined)).toBeUndefined();
+    expect(intakePairFromTags('not-tags')).toBeUndefined();
+    expect(intakePairFromTags([['swap-from'], [1, 2], null])).toBeUndefined();
+  });
+
+  it('caps a hostile tag value so one packet cannot flood a log line', () => {
+    const pair = intakePairFromTags([
+      ['swap-from', 'A'.repeat(5000)],
+      ['swap-to', 'USDC:evm:1'],
+    ]);
+    expect(pair).toBeDefined();
+    expect((pair ?? '').length).toBeLessThan(200);
+  });
+});
+
+describe('swap intake meter — one record per arrival', () => {
+  it('emits exactly one swap.intake record, carrying class, peer and pair', () => {
+    const { logger, lines } = capturing();
+    const meter = createSwapIntakeMeter({ logger });
+
+    const arrival = meter.begin({
+      amount: '1000',
+      destination: 'g.toon.swap.maker',
+      sourceAccount: 'g.toon.relay.client01',
+      sourcePeer: 'client01',
+    });
+    arrival.note({ innerKind: 20032, pair: 'USDC:evm:1>USDC:evm:2' });
+    arrival.classify('legacy');
+    arrival.finish({ accept: true });
+
+    expect(lines).toHaveLength(1);
+    const [line] = lines;
+    expect(line?.event).toBe(SWAP_INTAKE_EVENT);
+    expect(line?.fields).toMatchObject({
+      class: 'legacy',
+      accepted: true,
+      innerKind: 20032,
+      pair: 'USDC:evm:1>USDC:evm:2',
+      peer: 'client01',
+      sourceAccount: 'g.toon.relay.client01',
+      amount: '1000',
+      destination: 'g.toon.swap.maker',
+    });
+  });
+
+  it('finish() is idempotent — a double call cannot double-count', () => {
+    const { logger, lines } = capturing();
+    const meter = createSwapIntakeMeter({ logger });
+    const arrival = meter.begin({});
+    arrival.classify('rolling-rfq');
+    arrival.finish({ accept: true });
+    arrival.finish({ accept: true });
+    expect(lines).toHaveLength(1);
+    expect(meter.report().classes['rolling-rfq'].total).toBe(1);
+  });
+
+  it('falls back to the ILP source address when no BTP peer id is reported', () => {
+    const { logger, lines } = capturing();
+    const meter = createSwapIntakeMeter({ logger });
+    const arrival = meter.begin({ sourceAccount: 'g.toon.client.sender' });
+    arrival.classify('legacy');
+    arrival.finish({ accept: false, code: 'T04' });
+    expect(lines[0]?.fields['peer']).toBe('g.toon.client.sender');
+    expect(meter.report().legacyPeers).toEqual([
+      { peer: 'g.toon.client.sender', count: 1, lastAt: expect.any(String) },
+    ]);
+  });
+
+  it('records an unclassified arrival rather than losing it', () => {
+    const { logger, lines } = capturing();
+    const meter = createSwapIntakeMeter({ logger });
+    meter.begin({}).finish();
+    expect(lines[0]?.fields).toMatchObject({
+      class: 'refused',
+      reason: UNCLASSIFIED_REASON,
+      accepted: false,
+    });
+  });
+
+  it('a logger that throws cannot escape into the packet path', () => {
+    const meter = createSwapIntakeMeter({
+      logger: {
+        info: () => {
+          throw new Error('sink is on fire');
+        },
+      },
+    });
+    const arrival = meter.begin({});
+    arrival.classify('rolling-fill');
+    expect(() => arrival.finish({ accept: true })).not.toThrow();
+    // The count still landed — the throw happens after the counter bump.
+    expect(meter.report().classes['rolling-fill'].total).toBe(1);
+  });
+});
+
+describe('swap intake meter — the report', () => {
+  it('counts per class, splitting accepted from rejected', () => {
+    const meter = createSwapIntakeMeter({});
+    const drive = (cls: SwapIntakeClass, accept: boolean): void => {
+      const a = meter.begin({ sourcePeer: 'peer-a' });
+      a.classify(cls);
+      a.finish({ accept });
+    };
+    drive('legacy', true);
+    drive('legacy', false);
+    drive('rolling-rfq', true);
+    drive('rolling-fill', true);
+
+    const report = meter.report();
+    expect(report.total).toBe(4);
+    expect(report.classes.legacy).toMatchObject({
+      total: 2,
+      accepted: 1,
+      rejected: 1,
+    });
+    expect(report.classes['rolling-rfq'].total).toBe(1);
+    expect(report.classes['rolling-fill'].total).toBe(1);
+    expect(report.classes.refused.total).toBe(0);
+    expect(report.classes.refused.lastAt).toBeNull();
+    // "Who is still on legacy" — the whole point of the stage.
+    expect(report.legacyPeers).toEqual([
+      { peer: 'peer-a', count: 2, lastAt: expect.any(String) },
+    ]);
+  });
+
+  it('tallies refusal reasons and omits the ones that never fired', () => {
+    const meter = createSwapIntakeMeter({});
+    for (const reason of ['condition_required', 'condition_required']) {
+      const a = meter.begin({});
+      a.classify('refused', { reason });
+      a.finish({ accept: false, code: 'F99' });
+    }
+    expect(meter.report().reasons).toEqual({ condition_required: 2 });
+  });
+
+  it('makes an in-process reset visible: since/windowSec bound every count', () => {
+    let clock = 1_000_000;
+    const meter = createSwapIntakeMeter({ now: () => clock });
+    clock += 3_600_000;
+    const report = meter.report();
+    expect(report.since).toBe(new Date(1_000_000).toISOString());
+    expect(report.windowSec).toBe(3600);
+    // The note has to say plainly that a Watchtower recreate zeroes these.
+    expect(report.note).toMatch(/in-process/);
+    expect(report.note).toMatch(/swap\.intake/);
+  });
+
+  it('bounds the legacy-peer table and says so when it stops growing', () => {
+    const meter = createSwapIntakeMeter({ maxTrackedPeers: 2 });
+    for (const peer of ['a', 'b', 'c', 'd']) {
+      const arrival = meter.begin({ sourcePeer: peer });
+      arrival.classify('legacy');
+      arrival.finish({ accept: true });
+    }
+    const report = meter.report();
+    expect(report.legacyPeers).toHaveLength(2);
+    expect(report.legacyPeersTruncated).toBe(true);
+    // Every arrival is still counted — only the per-peer attribution is capped.
+    expect(report.classes.legacy.total).toBe(4);
+  });
+
+  it('never attributes a peer to a non-legacy class table', () => {
+    const meter = createSwapIntakeMeter({});
+    const arrival = meter.begin({ sourcePeer: 'rolling-peer' });
+    arrival.classify('rolling-fill');
+    arrival.finish({ accept: true });
+    expect(meter.report().legacyPeers).toEqual([]);
+  });
+});

--- a/packages/swap/src/intake-classification.ts
+++ b/packages/swap/src/intake-classification.ts
@@ -1,0 +1,421 @@
+/**
+ * Per-protocol-class accounting for what the maker's dispatch seam ADMITS
+ * (issue #152 — Stage 0 of the legacy-swap-removal plan, ADR 0003).
+ *
+ * ## Why this exists
+ *
+ * ADR 0003 removes the legacy claim-in-FULFILL swap path, and every removal
+ * stage gates on an exit criterion of the form *"no legacy traffic observed
+ * for N consecutive days"*. That sentence was **not measurable**. swap#137
+ * gave the maker a real logger, but everything it emits is a **refusal** —
+ * `swap.claim.refused`, `swap.channelState.reserve_refused`,
+ * `swap.packet.dispatch_failed`. Nothing on the success path ever said WHICH
+ * protocol served a swap, so a maker serving legacy all day and a maker
+ * serving none looked identical in `docker logs`.
+ *
+ * This module supplies the missing reading, and **only** the reading: it
+ * changes no routing decision and no packet outcome. The classification it
+ * publishes already existed implicitly in `handlePacket`'s branch structure
+ * (`swap-node.ts`, the issue #47 dispatch matrix); all that was missing was a
+ * name for the branch and somewhere to put it.
+ *
+ * ## The four classes
+ *
+ * | class          | what arrived                                                      |
+ * | -------------- | ----------------------------------------------------------------- |
+ * | `legacy`       | zero-condition gift wrap that reached the legacy fall-through      |
+ * | `rolling-rfq`  | zero-condition gift wrap whose inner rumor is kind:20033           |
+ * | `rolling-fill` | a coupled fill under a real 32-byte sender-chosen condition        |
+ * | `refused`      | the dispatch table itself rejected the shape, before any handler   |
+ *
+ * `legacy` and `rolling-rfq` differ **only** by the inner rumor kind of an
+ * otherwise byte-identical envelope (20032 vs 20033), which is exactly why
+ * the class has to be recorded at the seam: nothing downstream can still tell
+ * them apart. The recorded `innerKind` carries the discriminator verbatim.
+ *
+ * A class is the **row of the dispatch table the packet landed on**, not its
+ * eventual outcome. A rolling fill the engine later rejects is still
+ * `rolling-fill`; `accepted:false` and the reject `code` say what happened to
+ * it. `refused` is reserved for the seam's own pre-dispatch rejects, whose
+ * `reason` discriminator is the one that was already on the wire.
+ *
+ * ## Two readings, deliberately
+ *
+ * 1. **A log line per arrival** — one `swap.intake` JSON record at `info`,
+ *    through the swap#137 console logger. This is the durable reading: it
+ *    survives a Watchtower recreate because it is in the container's log
+ *    stream, and it is what a windowed count is taken over:
+ *
+ *    ```
+ *    docker logs --since 24h swap-node \
+ *      | grep '"event":"swap.intake"' | grep -c '"class":"legacy"'
+ *    ```
+ *
+ * 2. **`GET /admin/intake`** — the same counts without shell-parsing, on the
+ *    swap#138 operator surface (see `admin-surface.ts`). These counters are
+ *    **in-process**: the box recreates the maker on every `:release` move and
+ *    the totals start again from zero. That is why the report always carries
+ *    `since` and `windowSec` — a reset is then *visible* rather than silent,
+ *    which is the property issue #152 actually requires. For a multi-day gate
+ *    reading, count log lines; the HTTP surface answers "what has this
+ *    process seen".
+ *
+ * ## What is never recorded
+ *
+ * The gift wrap is sealed and stays sealed. Only routing metadata is emitted:
+ * the arrival peer / source ILP address, the requested pair, the inner rumor
+ * kind, the sender's Nostr pubkey, and the packet's own (already-plaintext)
+ * amount and destination. No rumor content, no `chainRecipient`, no claim, no
+ * key material. Free-form strings that originate with a counterparty are
+ * length-capped before they are recorded, so a hostile sender cannot flood
+ * the log line or the peer table.
+ *
+ * ## No new config key
+ *
+ * Nothing here is configurable. swap#134 crash-looped the live maker by
+ * adding a required config key, and `:release` auto-deploys on green main —
+ * so this stage adds none, optional or otherwise. Verbosity is the existing
+ * optional `SWAP_LOG_LEVEL` env var and nothing else.
+ */
+
+/** `event` field of the intake log record. Grep target for the gate reading. */
+export const SWAP_INTAKE_EVENT = 'swap.intake';
+
+/** The dispatch-table row a packet landed on. */
+export type SwapIntakeClass =
+  | 'legacy'
+  | 'rolling-rfq'
+  | 'rolling-fill'
+  | 'refused';
+
+/** Every class, in report order. */
+export const SWAP_INTAKE_CLASSES: readonly SwapIntakeClass[] = [
+  'legacy',
+  'rolling-rfq',
+  'rolling-fill',
+  'refused',
+];
+
+/**
+ * Reason recorded for an arrival that was classified but never reached a
+ * class-specific branch — defensive only; every seam path classifies.
+ */
+export const UNCLASSIFIED_REASON = 'unclassified_arrival';
+
+/** Cap on any counterparty-supplied string that reaches a log line. */
+const MAX_FIELD_CHARS = 96;
+
+/** Cap on distinct peers tracked per class, so the table cannot grow unbounded. */
+const DEFAULT_MAX_TRACKED_PEERS = 50;
+
+/** Cap on distinct refusal reasons tracked (they are ours, so this is slack). */
+const MAX_TRACKED_REASONS = 32;
+
+function clip(value: string | undefined): string | undefined {
+  if (typeof value !== 'string' || value.length === 0) return undefined;
+  return value.length <= MAX_FIELD_CHARS
+    ? value
+    : value.slice(0, MAX_FIELD_CHARS) + '…';
+}
+
+/** An asset as it appears on either side of a requested pair. */
+export interface IntakePairSide {
+  assetCode: string;
+  chain: string;
+}
+
+/**
+ * Render a requested pair as the single `from>to` token both the log line and
+ * the report use — e.g. `USDC:evm:84532>USDC:solana:devnet`.
+ */
+export function formatIntakePair(pair: {
+  from: IntakePairSide;
+  to: IntakePairSide;
+}): string {
+  return `${pair.from.assetCode}:${pair.from.chain}>${pair.to.assetCode}:${pair.to.chain}`;
+}
+
+/**
+ * Recover the requested pair from a rumor's `swap-from` / `swap-to` tags.
+ *
+ * Both the legacy kind:20032 rumor (`buildSwapRumor`, `@toon-protocol/sdk`)
+ * and any future shape that adopts the same tags are covered; the values are
+ * already `assetCode:chain`, so this is a tag read and not a payload parse.
+ * Returns `undefined` when either tag is missing, which is how a non-swap
+ * rumor that happens to land on the seam is reported.
+ */
+export function intakePairFromTags(tags: unknown): string | undefined {
+  if (!Array.isArray(tags)) return undefined;
+  let from: string | undefined;
+  let to: string | undefined;
+  for (const tag of tags) {
+    if (!Array.isArray(tag) || tag.length < 2) continue;
+    const [name, value] = tag as unknown[];
+    if (typeof name !== 'string' || typeof value !== 'string') continue;
+    if (name === 'swap-from' && from === undefined) from = value;
+    else if (name === 'swap-to' && to === undefined) to = value;
+  }
+  if (from === undefined || to === undefined) return undefined;
+  return `${clip(from) ?? ''}>${clip(to) ?? ''}`;
+}
+
+/** What `handlePacket` knows about an arrival before it classifies it. */
+export interface SwapIntakeOrigin {
+  /** Packet amount, source-asset micro-units (already plaintext on the wire). */
+  amount?: string;
+  /** ILP destination the PREPARE named. */
+  destination?: string;
+  /** Sender's ILP address, when the connector reports one. */
+  sourceAccount?: string;
+  /** Peer id the BTP session authenticated under, when the connector has it. */
+  sourcePeer?: string;
+}
+
+/** Everything a branch can add once it knows which row it is on. */
+export interface SwapIntakeDetails {
+  /** Refusal discriminator, for `refused` (and for a rejected class outcome). */
+  reason?: string;
+  /** `from>to`, when the requested pair could be read. */
+  pair?: string;
+  /** Gift-wrap sender pubkey, when the wrap opened. */
+  senderPubkey?: string;
+  /** Sender's own advertised ILP address (rolling RFQ carries one). */
+  senderIlpAddress?: string;
+  /**
+   * Inner rumor kind — the ONLY thing separating legacy (20032) from a
+   * rolling RFQ (20033). `null` when the wrap could not be opened.
+   */
+  innerKind?: number | null;
+}
+
+/** Handle for one arrival. `finish` is idempotent and records exactly once. */
+export interface SwapIntakeArrival {
+  /** Name the dispatch row. Last call wins; a later refinement may add detail. */
+  classify(cls: SwapIntakeClass, details?: SwapIntakeDetails): void;
+  /** Add detail without changing the class (used by the RFQ sniff). */
+  note(details: SwapIntakeDetails): void;
+  /** Emit the single record for this arrival. Safe to call more than once. */
+  finish(response?: { accept?: boolean; code?: string }): void;
+}
+
+export interface SwapIntakeClassCounts {
+  total: number;
+  accepted: number;
+  rejected: number;
+  /** ISO timestamp of the most recent arrival of this class, or `null`. */
+  lastAt: string | null;
+}
+
+export interface SwapIntakePeerCount {
+  peer: string;
+  count: number;
+  lastAt: string;
+}
+
+export interface SwapIntakeReport {
+  generatedAt: string;
+  /** Process start — the counters cover `[since, generatedAt]` and no longer. */
+  since: string;
+  windowSec: number;
+  total: number;
+  classes: Record<SwapIntakeClass, SwapIntakeClassCounts>;
+  /** Non-zero refusal/reject discriminators only. */
+  reasons: Record<string, number>;
+  /** Who is still on the legacy path — the whole point of the stage. */
+  legacyPeers: SwapIntakePeerCount[];
+  /** `true` when the peer table hit its cap and stopped admitting new keys. */
+  legacyPeersTruncated: boolean;
+  /** Says plainly that these totals are in-process. */
+  note: string;
+}
+
+const REPORT_NOTE =
+  'counts are in-process and restart at zero when the container is recreated (Watchtower moves :release); ' +
+  '`since` is this process’s start. For a multi-day gate reading count the `swap.intake` log lines instead: ' +
+  'docker logs --since 24h <container> | grep \'"event":"swap.intake"\' | grep -c \'"class":"legacy"\'';
+
+export interface SwapIntakeMeterOptions {
+  /**
+   * Where the per-arrival record goes. `info`, so the swap#137 default level
+   * shows it without any env change. Absent ⇒ counters only.
+   */
+  logger?: {
+    info?: (msg: string, meta?: Record<string, unknown>) => void;
+  };
+  now?: () => number;
+  /** Distinct legacy peers tracked before the table stops growing. */
+  maxTrackedPeers?: number;
+}
+
+export interface SwapIntakeMeter {
+  /** Open an arrival. Always pair with exactly one `finish()`. */
+  begin(origin?: SwapIntakeOrigin): SwapIntakeArrival;
+  /** Snapshot for `GET /admin/intake`. */
+  report(): SwapIntakeReport;
+}
+
+function emptyCounts(): SwapIntakeClassCounts {
+  return { total: 0, accepted: 0, rejected: 0, lastAt: null };
+}
+
+/**
+ * Build the meter the swap node's dispatch seam records through.
+ *
+ * Nothing in here can fail a packet: `finish()` swallows every error from the
+ * logger, exactly as `logger.ts` does, because an accounting record must
+ * never be able to change a swap's outcome.
+ */
+export function createSwapIntakeMeter(
+  options: SwapIntakeMeterOptions = {}
+): SwapIntakeMeter {
+  const now = options.now ?? Date.now;
+  const maxPeers = options.maxTrackedPeers ?? DEFAULT_MAX_TRACKED_PEERS;
+  const startedAt = now();
+
+  const classes: Record<SwapIntakeClass, SwapIntakeClassCounts> = {
+    legacy: emptyCounts(),
+    'rolling-rfq': emptyCounts(),
+    'rolling-fill': emptyCounts(),
+    refused: emptyCounts(),
+  };
+  const reasons = new Map<string, number>();
+  const legacyPeers = new Map<string, { count: number; lastAt: number }>();
+  let legacyPeersTruncated = false;
+  let total = 0;
+
+  const bump = (
+    cls: SwapIntakeClass,
+    accepted: boolean,
+    at: number,
+    peer: string | undefined,
+    reason: string | undefined
+  ): void => {
+    const counts = classes[cls];
+    counts.total += 1;
+    if (accepted) counts.accepted += 1;
+    else counts.rejected += 1;
+    counts.lastAt = new Date(at).toISOString();
+    total += 1;
+
+    if (reason !== undefined) {
+      const prior = reasons.get(reason);
+      if (prior !== undefined) reasons.set(reason, prior + 1);
+      else if (reasons.size < MAX_TRACKED_REASONS) reasons.set(reason, 1);
+    }
+
+    if (cls === 'legacy' && peer !== undefined) {
+      const entry = legacyPeers.get(peer);
+      if (entry) {
+        entry.count += 1;
+        entry.lastAt = at;
+      } else if (legacyPeers.size < maxPeers) {
+        legacyPeers.set(peer, { count: 1, lastAt: at });
+      } else {
+        legacyPeersTruncated = true;
+      }
+    }
+  };
+
+  return {
+    begin(origin: SwapIntakeOrigin = {}): SwapIntakeArrival {
+      let cls: SwapIntakeClass | undefined;
+      const details: SwapIntakeDetails = {};
+      let done = false;
+
+      const merge = (extra?: SwapIntakeDetails): void => {
+        if (!extra) return;
+        if (extra.reason !== undefined) details.reason = extra.reason;
+        if (extra.pair !== undefined) details.pair = extra.pair;
+        if (extra.senderPubkey !== undefined)
+          details.senderPubkey = extra.senderPubkey;
+        if (extra.senderIlpAddress !== undefined)
+          details.senderIlpAddress = extra.senderIlpAddress;
+        if (extra.innerKind !== undefined) details.innerKind = extra.innerKind;
+      };
+
+      return {
+        classify(next: SwapIntakeClass, extra?: SwapIntakeDetails): void {
+          cls = next;
+          merge(extra);
+        },
+        note(extra: SwapIntakeDetails): void {
+          merge(extra);
+        },
+        finish(response?: { accept?: boolean; code?: string }): void {
+          if (done) return;
+          done = true;
+          const at = now();
+          const resolved: SwapIntakeClass = cls ?? 'refused';
+          if (cls === undefined && details.reason === undefined) {
+            details.reason = UNCLASSIFIED_REASON;
+          }
+          const accepted = response?.accept === true;
+          // A peer id is the connector's authenticated arrival identity; the
+          // source ILP address is what the sender claims. Prefer the former.
+          const peer = clip(origin.sourcePeer) ?? clip(origin.sourceAccount);
+          bump(resolved, accepted, at, peer, details.reason);
+
+          const info = options.logger?.info;
+          if (!info) return;
+          try {
+            info(SWAP_INTAKE_EVENT, {
+              class: resolved,
+              accepted,
+              ...(response?.code !== undefined ? { code: response.code } : {}),
+              ...(details.reason !== undefined
+                ? { reason: details.reason }
+                : {}),
+              peer: peer ?? null,
+              ...(clip(origin.sourceAccount) !== undefined
+                ? { sourceAccount: clip(origin.sourceAccount) }
+                : {}),
+              ...(details.senderIlpAddress !== undefined
+                ? { senderIlpAddress: clip(details.senderIlpAddress) }
+                : {}),
+              ...(details.senderPubkey !== undefined
+                ? { senderPubkey: clip(details.senderPubkey) }
+                : {}),
+              ...(details.innerKind !== undefined
+                ? { innerKind: details.innerKind }
+                : {}),
+              pair: details.pair ?? null,
+              ...(origin.amount !== undefined ? { amount: origin.amount } : {}),
+              ...(origin.destination !== undefined
+                ? { destination: clip(origin.destination) }
+                : {}),
+            });
+          } catch {
+            // Accounting must never take a packet — or the node — down.
+          }
+        },
+      };
+    },
+
+    report(): SwapIntakeReport {
+      const at = now();
+      const peers: SwapIntakePeerCount[] = [...legacyPeers.entries()]
+        .map(([peer, v]) => ({
+          peer,
+          count: v.count,
+          lastAt: new Date(v.lastAt).toISOString(),
+        }))
+        .sort((a, b) => b.count - a.count || a.peer.localeCompare(b.peer));
+      return {
+        generatedAt: new Date(at).toISOString(),
+        since: new Date(startedAt).toISOString(),
+        windowSec: Math.max(0, Math.floor((at - startedAt) / 1000)),
+        total,
+        classes: {
+          legacy: { ...classes.legacy },
+          'rolling-rfq': { ...classes['rolling-rfq'] },
+          'rolling-fill': { ...classes['rolling-fill'] },
+          refused: { ...classes.refused },
+        },
+        reasons: Object.fromEntries(reasons),
+        legacyPeers: peers,
+        legacyPeersTruncated,
+        note: REPORT_NOTE,
+      };
+    },
+  };
+}

--- a/packages/swap/src/rolling-rfq.ts
+++ b/packages/swap/src/rolling-rfq.ts
@@ -49,6 +49,10 @@ import {
   type RollingSession,
 } from './rolling-engine.js';
 import type { LegBReturnPath } from './leg-b-return-path.js';
+import {
+  formatIntakePair,
+  intakePairFromTags,
+} from './intake-classification.js';
 
 /** Inner rumor kind of an RFQ request (spec §2.2). */
 export const ROLLING_RFQ_REQUEST_KIND = 20033;
@@ -302,6 +306,31 @@ export interface RollingRfqIntakeConfig {
   };
 }
 
+/**
+ * What the intake learned while deciding whether a packet was an RFQ
+ * (issue #152).
+ *
+ * The sniff is a **read-only by-product** of a decision the intake was already
+ * making. It exists because the inner rumor kind is the ONLY thing separating
+ * a legacy swap request (20032) from a rolling RFQ (20033), it is visible only
+ * after NIP-59 decryption, and this function is the only place on the seam
+ * that decrypts. Without it the caller would have to unwrap a second time to
+ * classify a legacy arrival.
+ *
+ * Nothing here is payload content: the rumor's `content` is never surfaced,
+ * only its kind, its sender, and the `swap-from`/`swap-to` routing tags.
+ */
+export interface RollingRfqSniff {
+  /** Inner rumor kind, or `null` when the gift wrap could not be opened. */
+  rumorKind: number | null;
+  /** Gift-wrap sender pubkey, when the wrap opened. */
+  senderPubkey?: string;
+  /** Requested pair as `from>to`, when the packet named one. */
+  pair?: string;
+  /** Sender's advertised ILP address — well-formed RFQs only. */
+  senderIlpAddress?: string;
+}
+
 /** Accept/reject shape the packet handler returns, structurally. */
 export type RollingRfqOutcome =
   | { accept: true; data: string; message?: string }
@@ -327,7 +356,17 @@ export function createRollingRfqIntake(config: RollingRfqIntakeConfig): {
   /** `null` ⇒ not an RFQ, fall through to legacy. */
   handle(
     dataB64: string,
-    arrival?: { sourcePeer?: string }
+    arrival?: {
+      sourcePeer?: string;
+      /**
+       * Issue #152 — called at most once per `handle()` call, on every path
+       * that got as far as attempting to open the wrap, with what the sniff
+       * saw. Never called when the intake declined to look at all (disabled,
+       * or empty data). Purely observational: throwing from it is the
+       * caller's problem, not the packet's, so callers must not throw.
+       */
+      sniff?: (sniff: RollingRfqSniff) => void;
+    }
   ): Promise<RollingRfqOutcome | null>;
 } {
   const enabled = config.rfq?.enabled ?? true;
@@ -352,7 +391,10 @@ export function createRollingRfqIntake(config: RollingRfqIntakeConfig): {
   return {
     async handle(
       dataB64: string,
-      arrival?: { sourcePeer?: string }
+      arrival?: {
+        sourcePeer?: string;
+        sniff?: (sniff: RollingRfqSniff) => void;
+      }
     ): Promise<RollingRfqOutcome | null> {
       if (!enabled) return null;
       if (typeof dataB64 !== 'string' || dataB64.length === 0) return null;
@@ -371,14 +413,32 @@ export function createRollingRfqIntake(config: RollingRfqIntakeConfig): {
         rumor = unwrapped.rumor;
         senderPubkey = unwrapped.senderPubkey;
       } catch {
+        // Issue #152: an unopenable wrap still fell through to the legacy
+        // branch, so it still has to be counted — with `null` for the kind,
+        // which is what "we could not tell" looks like.
+        arrival?.sniff?.({ rumorKind: null });
         return null;
       }
-      if (rumor?.kind !== ROLLING_RFQ_REQUEST_KIND) return null;
+      if (rumor?.kind !== ROLLING_RFQ_REQUEST_KIND) {
+        // Not an RFQ. This is the legacy row (inner kind 20032) and everything
+        // else that reaches it — the discriminator issue #152 needs.
+        const taggedPair = intakePairFromTags(rumor?.tags);
+        arrival?.sniff?.({
+          rumorKind: typeof rumor?.kind === 'number' ? rumor.kind : null,
+          senderPubkey,
+          ...(taggedPair !== undefined ? { pair: taggedPair } : {}),
+        });
+        return null;
+      }
 
       const parsed = parseRollingRfqRequest(
         typeof rumor.content === 'string' ? rumor.content : ''
       );
       if (parsed === null || parsed === 'malformed') {
+        arrival?.sniff?.({
+          rumorKind: ROLLING_RFQ_REQUEST_KIND,
+          senderPubkey,
+        });
         // Kind:20033 is unambiguously rolling traffic. Falling through would
         // hand it to the legacy handler, whose error would misdescribe the
         // failure, so reject here with the actionable reason.
@@ -390,6 +450,17 @@ export function createRollingRfqIntake(config: RollingRfqIntakeConfig): {
           ROLLING_RFQ_REJECT_REASONS.MALFORMED_RFQ
         );
       }
+
+      // Issue #152 — the fully-identified case: a well-formed RFQ names its
+      // own pair and return address, so the intake record is at its richest
+      // here. Emitted before the pair/rate/session checks so an RFQ that is
+      // subsequently REFUSED is still counted as a rolling arrival.
+      arrival?.sniff?.({
+        rumorKind: ROLLING_RFQ_REQUEST_KIND,
+        senderPubkey,
+        pair: formatIntakePair(parsed.pair),
+        senderIlpAddress: parsed.senderIlpAddress,
+      });
 
       const pair = findRfqPair(config.swapPairs, parsed.pair);
       if (!pair) {

--- a/packages/swap/src/swap-node.intake-classification.test.ts
+++ b/packages/swap/src/swap-node.intake-classification.test.ts
@@ -1,0 +1,531 @@
+/**
+ * Intake classification — WIRE-LEVEL tests (issue #152).
+ *
+ * ADR 0003 gates every legacy-removal stage on "no legacy traffic observed for
+ * N consecutive days", and before this stage that was unmeasurable: the maker
+ * logged refusals only, so a maker serving legacy all day and a maker serving
+ * none looked identical.
+ *
+ * These tests drive the REAL dispatch seam — boot `startSwapNode()` against a
+ * fake connector, capture the `setPacketHandler` callback, feed it real
+ * packets — because the thing under test is which row of the issue #47
+ * dispatch matrix an arrival lands on. A unit test of the meter proves
+ * nothing about that; the classification only exists at the seam.
+ *
+ * The headline pair is `legacy` vs `rolling-rfq`: two gift wraps built by the
+ * same primitives, addressed to the same maker, differing ONLY by their inner
+ * rumor kind (20032 vs 20033). Nothing downstream of the unwrap can still tell
+ * them apart, which is exactly why the class has to be recorded here.
+ */
+import { describe, it, expect } from 'vitest';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { schnorr } from '@noble/curves/secp256k1.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
+import { wrapSwapPacketToToon } from '@toon-protocol/sdk';
+import type { UnsignedEvent } from 'nostr-tools';
+
+import { startSwapNode } from './swap-node.js';
+import type { SwapNodeConfig, SwapNodeInstance } from './swap-node.js';
+import { ROLLING_PROTOCOL, ROLLING_REJECT_REASONS } from './rolling-engine.js';
+import { ROLLING_RFQ_REQUEST_KIND } from './rolling-rfq.js';
+import { SWAP_INTAKE_EVENT } from './intake-classification.js';
+import type { SwapIntakeReport } from './intake-classification.js';
+
+const VALID_MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+const CHAIN = 'evm:8453';
+const STREAM_NONCE = '1f'.repeat(16);
+const CHAIN_RECIPIENT = '0x' + '11'.repeat(20);
+const SENDER_ILP = 'g.toon.client.sender01';
+const MAKER_ILP = 'g.toon.swap.x';
+/** The legacy discriminator: inner rumor kind of a legacy swap request. */
+const LEGACY_SWAP_RUMOR_KIND = 20032;
+
+interface PacketRequest {
+  amount: string;
+  destination: string;
+  data: string;
+  sourceAccount?: string;
+  executionCondition?: string;
+  expiresAt?: string;
+}
+type PacketHandlerFn = (request: PacketRequest) => Promise<{
+  accept: boolean;
+  code?: string;
+  data?: string;
+}>;
+
+/** One captured `swap.intake` record. */
+type IntakeLine = Record<string, unknown>;
+
+function capturingConnector(): {
+  connector: SwapNodeConfig['connector'];
+  handler: () => PacketHandlerFn;
+} {
+  let captured: PacketHandlerFn | undefined;
+  const connector = {
+    sendPacket: async () => ({
+      type: 'reject' as const,
+      code: 'F02',
+      message: 'no route (fixture)',
+    }),
+    registerPeer: async () => undefined,
+    removePeer: async () => undefined,
+    setPacketHandler: (h: unknown) => {
+      captured = h as PacketHandlerFn;
+    },
+    close: async () => undefined,
+  };
+  return {
+    connector: connector as unknown as SwapNodeConfig['connector'],
+    handler: () => {
+      if (!captured) throw new Error('setPacketHandler was never called');
+      return captured;
+    },
+  };
+}
+
+async function bootNode(overrides?: Partial<SwapNodeConfig>): Promise<{
+  instance: SwapNodeInstance;
+  handler: () => PacketHandlerFn;
+  intakeLines: () => IntakeLine[];
+}> {
+  const { connector, handler } = capturingConnector();
+  const lines: IntakeLine[] = [];
+  const record = (...args: unknown[]): void => {
+    const [event, fields] = args;
+    if (event === SWAP_INTAKE_EVENT) {
+      lines.push((fields as IntakeLine | undefined) ?? {});
+    }
+  };
+  const instance = await startSwapNode({
+    mnemonic: VALID_MNEMONIC,
+    connector,
+    logger: {
+      debug: () => undefined,
+      info: record,
+      warn: () => undefined,
+      error: () => undefined,
+    },
+    swapPairs: [
+      {
+        from: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+        to: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+        rate: '1.0',
+        minAmount: '1000',
+        maxAmount: '25000000',
+      },
+    ],
+    chains: ['evm'],
+    channels: {
+      [CHAIN]: [
+        {
+          channelId: '0x' + 'cd'.repeat(32),
+          cumulativeAmount: 0n,
+          nonce: 0n,
+          updatedAt: 0,
+        },
+      ],
+    },
+    inventory: { [CHAIN]: 1_000_000_000n },
+    chainProviders: [
+      {
+        chainType: 'evm',
+        chainId: CHAIN,
+        rpcUrl: 'http://127.0.0.1:1',
+        registryAddress: '0x' + '11'.repeat(20),
+        tokenAddress: '0x' + '22'.repeat(20),
+        tokenNetworkAddress: '0x' + '44'.repeat(20),
+        channelAddress: '0x' + '33'.repeat(20),
+      },
+    ],
+    relayUrls: ['ws://localhost:0'],
+    blsPort: 0,
+    publisher: { publish: async () => undefined },
+    ...overrides,
+  });
+  return { instance, handler, intakeLines: () => lines };
+}
+
+function senderKeys(): { secretKey: Uint8Array; pubkey: string } {
+  const secretKey = schnorr.utils.randomSecretKey();
+  return { secretKey, pubkey: bytesToHex(schnorr.getPublicKey(secretKey)) };
+}
+
+/**
+ * Build the base64 PREPARE `data` of a real NIP-59 gift wrap carrying an
+ * arbitrary inner rumor. The ONLY thing the legacy and RFQ cases below vary is
+ * `kind` (and the content that kind implies) — the envelope is identical.
+ */
+function giftWrappedDataB64(params: {
+  kind: number;
+  content: string;
+  tags?: string[][];
+  senderSecretKey: Uint8Array;
+  makerPubkey: string;
+}): string {
+  const rumor = {
+    kind: params.kind,
+    content: params.content,
+    tags: params.tags ?? [],
+    created_at: Math.floor(Date.now() / 1000),
+    pubkey: '',
+  } as unknown as UnsignedEvent;
+  const { ilpPrepare } = wrapSwapPacketToToon({
+    rumor,
+    senderSecretKey: params.senderSecretKey,
+    recipientPubkey: params.makerPubkey,
+    destination: MAKER_ILP,
+    amount: 1000n,
+  });
+  return ilpPrepare.data;
+}
+
+/** The tags a legacy kind:20032 swap rumor carries (`sdk` `buildSwapRumor`). */
+function legacyRumorTags(): string[][] {
+  return [
+    ['swap-from', `USDC:${CHAIN}`],
+    ['swap-to', `USDC:${CHAIN}`],
+    ['amount', '1000'],
+    ['seq', '1', '1'],
+    ['nonce', 'ab'.repeat(16)],
+    ['chain-recipient', CHAIN_RECIPIENT],
+  ];
+}
+
+function rfqRequestContent(): string {
+  return JSON.stringify({
+    proto: ROLLING_PROTOCOL,
+    type: 'rfq',
+    streamNonce: STREAM_NONCE,
+    pair: {
+      from: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+      to: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+    },
+    chainRecipient: CHAIN_RECIPIENT,
+    senderIlpAddress: SENDER_ILP,
+  });
+}
+
+function fillDataB64(seq = 1, streamNonce = STREAM_NONCE): string {
+  return Buffer.from(
+    JSON.stringify({ proto: ROLLING_PROTOCOL, type: 'fill', streamNonce, seq }),
+    'utf8'
+  ).toString('base64');
+}
+
+function nonZeroConditionB64(): string {
+  const preimage = new Uint8Array(32).fill(7);
+  return Buffer.from(sha256(preimage)).toString('base64');
+}
+
+function zeroConditionB64(): string {
+  return Buffer.from(new Uint8Array(32)).toString('base64');
+}
+
+describe('intake classification at the dispatch seam (#152)', () => {
+  it('a kind:20032 arrival is classified legacy, with the peer and the pair', async () => {
+    const sender = senderKeys();
+    const { instance, handler, intakeLines } = await bootNode();
+    try {
+      await handler()({
+        amount: '1000',
+        destination: MAKER_ILP,
+        sourceAccount: SENDER_ILP,
+        data: giftWrappedDataB64({
+          kind: LEGACY_SWAP_RUMOR_KIND,
+          content: '',
+          tags: legacyRumorTags(),
+          senderSecretKey: sender.secretKey,
+          makerPubkey: instance.identity.pubkey,
+        }),
+      });
+
+      const lines = intakeLines();
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatchObject({
+        class: 'legacy',
+        innerKind: LEGACY_SWAP_RUMOR_KIND,
+        pair: `USDC:${CHAIN}>USDC:${CHAIN}`,
+        peer: SENDER_ILP,
+        senderPubkey: sender.pubkey,
+        destination: MAKER_ILP,
+        amount: '1000',
+      });
+      expect(instance.intakeReport().classes.legacy.total).toBe(1);
+      expect(instance.intakeReport().legacyPeers).toEqual([
+        { peer: SENDER_ILP, count: 1, lastAt: expect.any(String) },
+      ]);
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('a kind:20033 arrival — same envelope, different inner kind — is classified rolling-rfq', async () => {
+    const sender = senderKeys();
+    const { instance, handler, intakeLines } = await bootNode();
+    try {
+      const res = await handler()({
+        amount: '1000',
+        destination: MAKER_ILP,
+        sourceAccount: SENDER_ILP,
+        data: giftWrappedDataB64({
+          kind: ROLLING_RFQ_REQUEST_KIND,
+          content: rfqRequestContent(),
+          senderSecretKey: sender.secretKey,
+          makerPubkey: instance.identity.pubkey,
+        }),
+      });
+      expect(res.accept).toBe(true);
+
+      const lines = intakeLines();
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatchObject({
+        class: 'rolling-rfq',
+        accepted: true,
+        innerKind: ROLLING_RFQ_REQUEST_KIND,
+        pair: `USDC:${CHAIN}>USDC:${CHAIN}`,
+        senderIlpAddress: SENDER_ILP,
+        senderPubkey: sender.pubkey,
+      });
+      const report = instance.intakeReport();
+      expect(report.classes['rolling-rfq'].total).toBe(1);
+      expect(report.classes.legacy.total).toBe(0);
+      // The gate's whole question: nobody is on legacy.
+      expect(report.legacyPeers).toEqual([]);
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('THE DISCRIMINATOR: two arrivals differing only by inner rumor kind land on different classes', async () => {
+    const sender = senderKeys();
+    const { instance, handler, intakeLines } = await bootNode();
+    try {
+      const wrap = (kind: number, content: string): string =>
+        giftWrappedDataB64({
+          kind,
+          content,
+          tags: kind === LEGACY_SWAP_RUMOR_KIND ? legacyRumorTags() : [],
+          senderSecretKey: sender.secretKey,
+          makerPubkey: instance.identity.pubkey,
+        });
+
+      // Identical outer shape for both: zero condition, kind:1059 gift wrap,
+      // same amount, same destination, same sender, same maker.
+      const packet = (data: string): PacketRequest => ({
+        amount: '1000',
+        destination: MAKER_ILP,
+        sourceAccount: SENDER_ILP,
+        executionCondition: zeroConditionB64(),
+        data,
+      });
+
+      await handler()(packet(wrap(LEGACY_SWAP_RUMOR_KIND, '')));
+      await handler()(
+        packet(wrap(ROLLING_RFQ_REQUEST_KIND, rfqRequestContent()))
+      );
+
+      expect(intakeLines().map((l) => l['class'])).toEqual([
+        'legacy',
+        'rolling-rfq',
+      ]);
+      const report = instance.intakeReport();
+      expect(report.classes.legacy.total).toBe(1);
+      expect(report.classes['rolling-rfq'].total).toBe(1);
+      expect(report.total).toBe(2);
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('a coupled fill is classified rolling-fill even when the engine rejects it', async () => {
+    const { instance, handler, intakeLines } = await bootNode();
+    try {
+      // No session was ever minted, so the engine refuses — the CLASS is the
+      // dispatch row taken, not the outcome, and `accepted:false` says what
+      // happened to it.
+      const res = await handler()({
+        amount: '250000',
+        destination: MAKER_ILP,
+        sourceAccount: SENDER_ILP,
+        data: fillDataB64(1),
+        executionCondition: nonZeroConditionB64(),
+        expiresAt: new Date(Date.now() + 30_000).toISOString(),
+      });
+      expect(res.accept).toBe(false);
+
+      const lines = intakeLines();
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatchObject({
+        class: 'rolling-fill',
+        accepted: false,
+      });
+      const report = instance.intakeReport();
+      expect(report.classes['rolling-fill']).toMatchObject({
+        total: 1,
+        accepted: 0,
+        rejected: 1,
+      });
+      expect(report.classes.refused.total).toBe(0);
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('each dispatch-table reject is classified refused, carrying its existing reason', async () => {
+    const sender = senderKeys();
+    const { instance, handler, intakeLines } = await bootNode();
+    try {
+      // Row: non-zero condition + a payload that is not a rolling fill.
+      await handler()({
+        amount: '1000',
+        destination: MAKER_ILP,
+        data: giftWrappedDataB64({
+          kind: LEGACY_SWAP_RUMOR_KIND,
+          content: '',
+          senderSecretKey: sender.secretKey,
+          makerPubkey: instance.identity.pubkey,
+        }),
+        executionCondition: nonZeroConditionB64(),
+      });
+      // Row: rolling fill with no sender-chosen condition.
+      await handler()({
+        amount: '1000',
+        destination: MAKER_ILP,
+        data: fillDataB64(1),
+      });
+      // Row: self-identified rolling/1 traffic violating the fill shape.
+      await handler()({
+        amount: '1000',
+        destination: MAKER_ILP,
+        data: Buffer.from(
+          JSON.stringify({ proto: ROLLING_PROTOCOL, type: 'fill' }),
+          'utf8'
+        ).toString('base64'),
+        executionCondition: nonZeroConditionB64(),
+      });
+
+      const lines = intakeLines();
+      expect(lines).toHaveLength(3);
+      expect(lines.map((l) => l['class'])).toEqual([
+        'refused',
+        'refused',
+        'refused',
+      ]);
+      expect(lines.map((l) => l['reason'])).toEqual([
+        ROLLING_REJECT_REASONS.CONDITION_UNSUPPORTED_LEGACY,
+        ROLLING_REJECT_REASONS.CONDITION_REQUIRED,
+        ROLLING_REJECT_REASONS.MALFORMED_FILL,
+      ]);
+      const report = instance.intakeReport();
+      expect(report.classes.refused).toMatchObject({ total: 3, rejected: 3 });
+      expect(report.reasons).toEqual({
+        [ROLLING_REJECT_REASONS.CONDITION_UNSUPPORTED_LEGACY]: 1,
+        [ROLLING_REJECT_REASONS.CONDITION_REQUIRED]: 1,
+        [ROLLING_REJECT_REASONS.MALFORMED_FILL]: 1,
+      });
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('an unopenable gift wrap still counts, with a null inner kind', async () => {
+    const other = senderKeys();
+    const stranger = senderKeys();
+    const { instance, handler, intakeLines } = await bootNode();
+    try {
+      // Wrapped to somebody else's pubkey: this maker cannot open it, so it
+      // falls through to the legacy handler exactly as it always did.
+      await handler()({
+        amount: '1000',
+        destination: MAKER_ILP,
+        data: giftWrappedDataB64({
+          kind: LEGACY_SWAP_RUMOR_KIND,
+          content: '',
+          senderSecretKey: other.secretKey,
+          makerPubkey: stranger.pubkey,
+        }),
+      });
+      const lines = intakeLines();
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatchObject({ class: 'legacy', innerKind: null });
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('exactly one intake record per arrival, whatever the outcome', async () => {
+    const sender = senderKeys();
+    const { instance, handler, intakeLines } = await bootNode();
+    try {
+      for (let i = 0; i < 3; i++) {
+        await handler()({
+          amount: '1000',
+          destination: MAKER_ILP,
+          data: giftWrappedDataB64({
+            kind: LEGACY_SWAP_RUMOR_KIND,
+            content: '',
+            tags: legacyRumorTags(),
+            senderSecretKey: sender.secretKey,
+            makerPubkey: instance.identity.pubkey,
+          }),
+        });
+      }
+      // Garbage that is neither a gift wrap nor rolling traffic.
+      await handler()({
+        amount: '1000',
+        destination: MAKER_ILP,
+        data: Buffer.from('not a toon event', 'utf8').toString('base64'),
+      });
+
+      expect(intakeLines()).toHaveLength(4);
+      expect(instance.intakeReport().total).toBe(4);
+    } finally {
+      await instance.stop();
+    }
+  });
+});
+
+describe('GET /admin/intake (#152)', () => {
+  it('serves the same counts the log lines were bumped from, unauthenticated', async () => {
+    const sender = senderKeys();
+    const { instance, handler } = await bootNode();
+    try {
+      await handler()({
+        amount: '1000',
+        destination: MAKER_ILP,
+        sourceAccount: SENDER_ILP,
+        data: giftWrappedDataB64({
+          kind: LEGACY_SWAP_RUMOR_KIND,
+          content: '',
+          tags: legacyRumorTags(),
+          senderSecretKey: sender.secretKey,
+          makerPubkey: instance.identity.pubkey,
+        }),
+      });
+
+      // No admin token configured, and the read still answers — same rule
+      // `GET /admin/inventory` set (writes are gated, reads are not).
+      const res = await fetch(
+        `http://127.0.0.1:${instance.blsPort}/admin/intake`
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SwapIntakeReport;
+
+      expect(body.classes.legacy.total).toBe(1);
+      expect(body.classes['rolling-rfq'].total).toBe(0);
+      expect(body.total).toBe(1);
+      expect(body.legacyPeers).toEqual([
+        { peer: SENDER_ILP, count: 1, lastAt: expect.any(String) },
+      ]);
+      // An in-process reset must never be silent.
+      expect(typeof body.since).toBe('string');
+      expect(typeof body.windowSec).toBe('number');
+      expect(body.note).toMatch(/in-process/);
+    } finally {
+      await instance.stop();
+    }
+  });
+});

--- a/packages/swap/src/swap-node.ts
+++ b/packages/swap/src/swap-node.ts
@@ -76,6 +76,12 @@ import {
 } from './inventory-reconciler.js';
 import type { ReconcileResult } from './inventory-reconciler.js';
 import { registerAdminRoutes } from './admin-surface.js';
+import { createSwapIntakeMeter } from './intake-classification.js';
+import type {
+  SwapIntakeArrival,
+  SwapIntakeMeter,
+  SwapIntakeReport,
+} from './intake-classification.js';
 import {
   EvmPaymentChannelSigner,
   MinaPaymentChannelSigner,
@@ -615,6 +621,18 @@ export interface SwapNodeInstance {
    * result and leave that channel's capacity blocked.
    */
   reconcileInventory(): Promise<ReconcileResult>;
+  /**
+   * Issue #152 — per-protocol-class counts of what the dispatch seam has
+   * admitted since this process started: `legacy`, `rolling-rfq`,
+   * `rolling-fill` and `refused`, with the peers still arriving on the legacy
+   * path. Also served, unauthenticated, as `GET /admin/intake`.
+   *
+   * The counters are **in-process** and restart at zero when the container is
+   * recreated, which is why the report always carries `since`/`windowSec`.
+   * For a multi-day gate reading (ADR 0003's "no legacy traffic for N days"),
+   * count the `swap.intake` log lines over the window instead.
+   */
+  intakeReport(): SwapIntakeReport;
   /** @internal — AC-10 test hook. */
   readonly _handlerRegistry?: HandlerRegistry;
   /** @internal — issue #47 test hook (rolling-engine introspection). */
@@ -1089,6 +1107,14 @@ export async function startSwapNode(
 
   const logger = config.logger ?? noopLogger();
   const startedAt = Date.now();
+
+  // Issue #152 — per-protocol-class accounting for the dispatch seam. Created
+  // here rather than at the seam so `GET /admin/intake` and the instance's
+  // `intakeReport()` read the same counters the log lines were bumped from.
+  // No config knob of any kind: verbosity is `SWAP_LOG_LEVEL` (optional) and
+  // nothing else, because `:release` auto-deploys and swap#134 proved what a
+  // newly-required key costs.
+  const intakeMeter: SwapIntakeMeter = createSwapIntakeMeter({ logger });
 
   // 2/3. swap node key derivation (BIP-32) REQUIRES a mnemonic (D12-011). Check
   //      this before resolving identity so callers passing only a secretKey
@@ -1959,17 +1985,16 @@ export async function startSwapNode(
     return new Uint8Array(buf);
   };
 
-  const handlePacket = async (
+  /**
+   * The dispatch seam proper — the issue #47 matrix, byte-for-byte the
+   * decisions it always made. `intake` is write-only from here: it records
+   * which row was taken and is never read back, so removing it would change
+   * nothing on the wire.
+   */
+  const dispatchPacket = async (
     request: HandlePacketRequest,
-    /**
-     * The peer id the connector bound this packet's arrival under — for a BTP
-     * arrival, the `peerId` the session authenticated with
-     * (connector `btp/btp-server.ts` `authenticatePeer`), surfaced as
-     * `LocalDeliveryRequest.sourcePeer`. Undefined when the connector does not
-     * report one (legacy `setPacketHandler` wiring / test doubles), which is
-     * exactly the pre-fix behaviour.
-     */
-    sourcePeer?: string
+    sourcePeer: string | undefined,
+    intake: SwapIntakeArrival
   ): Promise<HandlePacketResponse> => {
     const requestExt = request as HandlePacketRequest & {
       executionCondition?: string;
@@ -1984,6 +2009,9 @@ export async function startSwapNode(
       // Self-identified rolling/1 traffic that violates the fill shape:
       // reject F01 rather than letting it fall through to the legacy TOON
       // parser's misleading F06.
+      intake.classify('refused', {
+        reason: ROLLING_REJECT_REASONS.MALFORMED_FILL,
+      });
       return buildRollingReject({
         code: 'F01',
         semantic: 'invalid_request',
@@ -1993,6 +2021,9 @@ export async function startSwapNode(
     }
     if (senderCondition) {
       if (rollingFill === null) {
+        intake.classify('refused', {
+          reason: ROLLING_REJECT_REASONS.CONDITION_UNSUPPORTED_LEGACY,
+        });
         return buildRollingReject({
           code: 'F99',
           semantic: 'application_error',
@@ -2001,6 +2032,7 @@ export async function startSwapNode(
           reason: ROLLING_REJECT_REASONS.CONDITION_UNSUPPORTED_LEGACY,
         }) as HandlePacketResponse;
       }
+      intake.classify('rolling-fill');
       return (await rollingEngine.handleFill({
         amount: request.amount,
         destination: request.destination,
@@ -2015,6 +2047,9 @@ export async function startSwapNode(
       // A rolling fill without a sender-chosen condition has NO coupling
       // (spec R2: a zero condition is skipped by every verifier) — refuse
       // rather than fill uncoupled.
+      intake.classify('refused', {
+        reason: ROLLING_REJECT_REASONS.CONDITION_REQUIRED,
+      });
       return buildRollingReject({
         code: 'F99',
         semantic: 'application_error',
@@ -2029,16 +2064,42 @@ export async function startSwapNode(
     // by unwrapping and reading that kind. `handle()` returns null for
     // everything it cannot positively identify as an RFQ (including any unwrap
     // failure), so the legacy path below stays byte-for-byte as it was.
+    //
+    // Issue #152: the same unwrap is the ONLY place the inner kind is ever
+    // visible, so the intake records what it saw through `sniff` rather than
+    // decrypting a second time on the legacy branch.
     const rfq = await rfqIntake.handle(request.data, {
       ...(sourcePeer !== undefined ? { sourcePeer } : {}),
+      sniff: (s) =>
+        intake.note({
+          innerKind: s.rumorKind,
+          ...(s.senderPubkey !== undefined
+            ? { senderPubkey: s.senderPubkey }
+            : {}),
+          ...(s.pair !== undefined ? { pair: s.pair } : {}),
+          ...(s.senderIlpAddress !== undefined
+            ? { senderIlpAddress: s.senderIlpAddress }
+            : {}),
+        }),
     });
-    if (rfq) return rfq as HandlePacketResponse;
+    if (rfq) {
+      intake.classify('rolling-rfq');
+      return rfq as HandlePacketResponse;
+    }
 
     // Legacy path (zero-condition gift-wrap) — unchanged below.
+    //
+    // Everything that reaches here is on the legacy row of the dispatch
+    // table: it is about to be handed to `createSwapHandler`. The `innerKind`
+    // the sniff recorded above says whether it was a real legacy swap request
+    // (20032), some other rumor, or an envelope that would not open at all.
+    intake.classify('legacy');
+
     let meta;
     try {
       meta = shallowParseToon(Buffer.from(request.data, 'base64'));
     } catch {
+      intake.note({ reason: 'invalid_toon' });
       return {
         accept: false,
         code: 'F06',
@@ -2050,6 +2111,7 @@ export async function startSwapNode(
     try {
       amount = BigInt(request.amount);
     } catch {
+      intake.note({ reason: 'invalid_amount' });
       return { accept: false, code: 'T00', message: 'Invalid payment amount' };
     }
 
@@ -2066,6 +2128,7 @@ export async function startSwapNode(
       result = (await registry.dispatch(ctx)) as HandlePacketResponse;
     } catch (err) {
       logger.error?.('swap.packet.dispatch_failed', { err: errSummary(err) });
+      intake.note({ reason: 'dispatch_failed' });
       return { accept: false, code: 'T00', message: 'Internal error' };
     }
 
@@ -2106,6 +2169,49 @@ export async function startSwapNode(
     }
 
     return result;
+  };
+
+  const handlePacket = async (
+    request: HandlePacketRequest,
+    /**
+     * The peer id the connector bound this packet's arrival under — for a BTP
+     * arrival, the `peerId` the session authenticated with
+     * (connector `btp/btp-server.ts` `authenticatePeer`), surfaced as
+     * `LocalDeliveryRequest.sourcePeer`. Undefined when the connector does not
+     * report one (legacy `setPacketHandler` wiring / test doubles), which is
+     * exactly the pre-fix behaviour.
+     */
+    sourcePeer?: string
+  ): Promise<HandlePacketResponse> => {
+    // Issue #152 — open the intake record for this arrival. Every `return` in
+    // `dispatchPacket` is preceded by a `classify()`, and the `finally` here
+    // emits exactly one `swap.intake` record however the dispatch ends —
+    // including an unexpected throw, which is why this is a `finally` and not
+    // a line after the call. Nothing here changes a packet's outcome: no
+    // classify call is on the critical path of a decision, and the meter
+    // swallows its own errors.
+    const intake = intakeMeter.begin({
+      amount: request.amount,
+      destination: request.destination,
+      ...(typeof request.sourceAccount === 'string'
+        ? { sourceAccount: request.sourceAccount }
+        : {}),
+      ...(sourcePeer !== undefined ? { sourcePeer } : {}),
+    });
+    let outcome: HandlePacketResponse | undefined;
+    try {
+      outcome = await dispatchPacket(request, sourcePeer, intake);
+      return outcome;
+    } finally {
+      intake.finish(
+        outcome === undefined
+          ? undefined
+          : {
+              accept: outcome.accept,
+              ...(!outcome.accept ? { code: outcome.code } : {}),
+            }
+      );
+    }
   };
 
   // Register the handler as the connector's local-delivery callback.
@@ -2259,6 +2365,9 @@ export async function startSwapNode(
   registerAdminRoutes(app, {
     inventory,
     reconciler,
+    // Issue #152 — `GET /admin/intake`: the same counters the `swap.intake`
+    // log lines bump, readable without shell-parsing the log stream.
+    intake: intakeMeter,
     ...(config.adminToken !== undefined && { adminToken: config.adminToken }),
   });
 
@@ -2507,6 +2616,7 @@ export async function startSwapNode(
       rollingEngine.registerSession(session);
     },
     reconcileInventory: () => reconciler.reconcile(),
+    intakeReport: () => intakeMeter.report(),
     recordSettlement: (event: SettlementEvent): bigint => {
       // Resolve the (assetCode, chain) pool via the provisioned channel
       // state: stored keys are `${assetCode}:${chain}:${channelId}`.


### PR DESCRIPTION
Closes #152. Part of toon-protocol/toon-meta#411 (ADR 0003, Stage 0).

**This stage removes nothing and changes no swap behaviour.** It adds the reading the later removal stages gate on.

## The problem

ADR 0003 gates every removal stage on *"no legacy traffic observed for N consecutive days"* — and that was not measurable. swap#137 gave the maker a real logger, but everything it emits is a **refusal** (`swap.claim.refused`, `swap.channelState.reserve_refused`, `swap.packet.dispatch_failed`). Nothing on the success path ever said which protocol served a swap, so a maker serving legacy all day and a maker serving none produced identical `docker logs`.

## What this does

Every arrival at the dispatch seam is classified onto the row of the issue #47 dispatch matrix it landed on, and recorded exactly once:

| class | what arrived |
| --- | --- |
| `legacy` | a zero-condition gift wrap that reached the legacy fall-through (inner rumor kind carried verbatim as `innerKind`, `20032` for a real legacy request) |
| `rolling-rfq` | the same envelope whose inner rumor is kind `20033` |
| `rolling-fill` | a coupled fill under a real 32-byte sender-chosen condition |
| `refused` | the dispatch table rejected the shape before any handler, carrying the reason discriminator already on the wire |

The class is the **dispatch row, not the outcome**: a rolling fill the engine later rejects is still `rolling-fill`, with `accepted:false` and the reject `code` saying what happened to it. Each record carries the arrival `peer` / `sourceAccount`, the sender's `senderPubkey`, the requested `pair` (`from>to`) and the outcome.

### Two readings, deliberately

1. **`swap.intake` log lines** — one JSON record per arrival, at `info`, through swap#137's console logger. This is the reading the multi-day gate is taken over, because it lives in the container's log stream and survives the Watchtower recreate every `:release` move performs:

   ```sh
   C=\$(docker ps -qf name=swap-node)
   docker logs --since 24h "\$C" 2>&1 | grep '\"event\":\"swap.intake\"' \
     | grep -o '\"class\":\"[a-z-]*\"' | sort | uniq -c
   ```

2. **`GET /admin/intake`** — the same counts without shell-parsing, on swap#138's operator surface, following its conventions exactly: mounted under `/admin` so the fleet's `^~ /admin` nginx 404 covers it, and **unauthenticated because it is a read** — the same rule `GET /admin/inventory` set, and it discloses strictly less than the pre-existing unauthenticated `GET /health`. Also `SwapNodeInstance.intakeReport()`.

   Those counters are in-process, so the report always carries `since` / `windowSec` and a `note` saying so: an in-process reset is **visible**, not silent. That is the property #152 asks for; the durable multi-day count is reading 1.

### How the inner kind is known without decrypting twice

`legacy` and `rolling-rfq` differ **only** by the inner rumor kind of a byte-identical envelope, and that kind is visible only after NIP-59 decryption. `rfqIntake.handle()` is the one place on the seam that decrypts, so it now reports what it saw through a new read-only `sniff` by-product on its `arrival` argument. Nothing unwraps a second time, and `handle()`'s return contract is unchanged.

## Constraints honoured

- **No new config key**, required or optional (swap#134 / ADR 0041). Verbosity stays the existing optional `SWAP_LOG_LEVEL`. The fleet-config gate on this PR proves the committed `infra/linode-relay/swap.config.json` still boots this build.
- **No wire behaviour change.** No routing decision moved and no packet outcome changed; the seam body is byte-for-byte the decisions it always made, with write-only `classify()`/`note()` calls added. Every pre-existing test passes unmodified. The meter swallows its own errors, so accounting can never fail a packet, and `finish()` is in a `finally` so exactly one record is emitted even on an unexpected throw.
- **The gift wrap stays sealed.** Only routing metadata is recorded — never rumor content, `chainRecipient`, claims or key material — and counterparty-supplied strings are length-capped, with the legacy-peer table bounded and a `legacyPeersTruncated` flag when it stops growing.

## Tests

- `packages/swap/src/swap-node.intake-classification.test.ts` — wire-level, against the real `startSwapNode()` seam: all four classes, **including a kind:20032 and a kind:20033 arrival that differ only by inner rumor kind and land on different classes**, a rolling fill classified by row while the engine rejects it, all three dispatch-table refusals with their reasons, an unopenable wrap (`innerKind: null`), exactly-one-record-per-arrival, and `GET /admin/intake` served over the live BLS server.
- `packages/swap/src/intake-classification.test.ts` — the meter's own contract: idempotent `finish`, peer fallback, bounded tables, honest `since`/`windowSec`, a throwing logger that cannot escape.

`gate:correctness` PASS (lint 0/352 frozen 0/352, typecheck 2 frozen 25); 540 tests pass.

## After merge

`swap:release` moves and the relay box's Watchtower recreates the maker within ~60s. First baseline reading to be posted on #152 — `deploy/swap/README.md` has the exact commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)