### PR TITLE
Port the Docker cross-chain E2E suites to rolling — and make them actually cross a chain (#153)

### DIFF
--- a/packages/swap/tests/e2e/README.md
+++ b/packages/swap/tests/e2e/README.md
@@ -1,13 +1,38 @@
 # Docker cross-chain E2E harness
 
-Four suites here drive a real `streamSwap()` session over real BTP against a
-real swap node (`peer1`), then check settlement-bundle construction on each
-target chain:
+Ten suites here drive a real swap session over real BTP against a real swap
+node (`peer1`), then check settlement-bundle construction on each target chain.
+There are **two families**, and they run side by side:
 
-- `docker-swap-flow-evm-e2e.test.ts` (AC-3..6)
-- `docker-swap-flow-solana-e2e.test.ts` (AC-7)
-- `docker-swap-flow-mina-e2e.test.ts` (AC-8)
-- `docker-swap-flow-pair-matrix-e2e.test.ts` (AC-9/10 — all 9 ordered chain pairs)
+### Rolling (swap#153) — the protocol ADR 0003 keeps
+
+kind:20033 RFQ → kind:20034 quote → coupled fills carrying a real 32-byte
+sender-minted execution condition, with the chain-B claim arriving on **leg B**.
+
+| suite | collects | what it covers |
+| --- | --- | --- |
+| `docker-rolling-swap-evm-e2e.test.ts` | 5 | RFQ, coupled fills, R4/R6 coupling, R5/R8 withhold, EVM settlement bundle |
+| `docker-rolling-swap-cross-chain-e2e.test.ts` | 3 | `evm:base:31337 → evm:base:31338` — a REAL chain boundary, no operator infra |
+| `docker-rolling-swap-pair-matrix-e2e.test.ts` | 17 | 16 ordered pairs over 4 chains + a coverage guard |
+| `docker-rolling-swap-solana-e2e.test.ts` | 2 | Solana target (skips without a validator) |
+| `docker-rolling-swap-mina-e2e.test.ts` | 2 | Mina target (skips without a lightnet) |
+| `docker-rolling-leg-b-routing-e2e.test.ts` | 3 | the swap#148 `F02` and `T00` routing shapes |
+
+### Legacy (`streamSwap`) — kept until Stage 5 of toon-meta#411
+
+| suite | collects |
+| --- | --- |
+| `docker-swap-flow-evm-e2e.test.ts` (AC-3..6) | 4 |
+| `docker-swap-flow-solana-e2e.test.ts` (AC-7) | 2 |
+| `docker-swap-flow-mina-e2e.test.ts` (AC-8) | 2 |
+| `docker-swap-flow-pair-matrix-e2e.test.ts` (AC-9/10) | 10 |
+
+**Do not delete the legacy four before the rolling six are green in CI** — they
+were the project's only multi-chain E2E swap coverage, and swap#106 had already
+found four of them silently collecting *zero* tests while reporting a pass.
+The counts in the tables above are the guard against that happening again: a
+suite that collects fewer than its number has lost coverage, whatever colour CI
+reports.
 
 Run with:
 
@@ -32,14 +57,23 @@ required Docker daemon — just `anvil` on PATH.
 
 ## Topology
 
-### EVM leg — fully automatic, no setup
+### EVM legs — fully automatic, no setup
 
 `tests/e2e/global-setup.ts` (a Vitest `globalSetup`) boots, once per test
 run, before any suite file:
 
-1. **Anvil**, loaded with the same vendored `rolling-e2e-anvil-state.hex`
-   fixture the integration suite uses (`TokenNetworkRegistry` / `TokenNetwork`
-   (USDC) already deployed at the fixed addresses the EVM suite asserts).
+1. **Anvil (chain A, 31337)**, loaded with the same vendored
+   `rolling-e2e-anvil-state.hex` fixture the integration suite uses
+   (`TokenNetworkRegistry` / `TokenNetwork` (USDC) already deployed at the
+   fixed addresses the EVM suite asserts).
+1b. **Anvil (chain B, 31338)** — swap#153. The same blob at a different chain
+   id, so peer1 can advertise `evm:base:31337 → evm:base:31338` and the
+   rolling suites cross a **real** chain boundary on every CI run. Before
+   this, the only pair that ever executed here was same-chain EVM: Solana,
+   Mina and 8 of the 9 matrix pairs all skip for want of infra this repo does
+   not vendor, so "multi-chain coverage" had never once been exercised. Same
+   trick `tests/integration/rolling-settlement.integration.test.ts` uses; it
+   costs one extra `anvil` process and no new dependency.
 2. An **in-process Nostr relay** (`tests/e2e/helpers/local-nostr-relay.ts`)
    — just enough NIP-01 (`EVENT`/`REQ`/`EOSE`/`CLOSE`) for kind:10032
    discovery (AC-4). `startSwapNode()`'s default relay publisher
@@ -60,6 +94,30 @@ pointing back here. Under `CI=1`, that same "EVM core did not come up" case
 throws instead of skipping (see `skipIfNotReady()`'s doc comment) — this
 repo owns and boots that infra itself, so its absence under CI is a real
 regression, not an expected gap.
+
+### The rolling sender
+
+A rolling sender is the same `ConnectorNode` the legacy suites build
+(`helpers/build-live-sender.ts`), with two additions the legacy path never
+needed:
+
+- **its `nodeId` IS its ILP address.** The maker refuses to mint a session it
+  cannot answer, and decides that by comparing the RFQ's `senderIlpAddress`
+  against the peer id the arriving BTP session authenticated under
+  (`src/leg-b-return-path.ts` — the swap#148 `F02` fix). A `ConnectorNode`
+  greets with its `nodeId` verbatim, so the two have to be one string;
+- **a local-delivery handler terminates leg B** — the sender daemon's
+  verify-before-reveal seam (spec R5), built by
+  `helpers/rolling-driver.ts`'s `createLegBDaemon()`.
+
+Leg A is genuinely paid: δ > 0 means the maker's `InboundClaimValidator`
+demands a payment-channel claim it can verify on chain, and the sender
+connector's `PerPacketClaimService` signs it against the real Anvil channel —
+which is why the sender here is a connector and not a bare `BtpRuntimeClient`.
+The daemon enforces the structural half of R5 (recipient equality, monotone
+`(nonce, cumulativeAmount)`, Δcumulative covering `targetAmount`, the signer
+the quote promised); the v2 EIP-712 signature itself is verified by the real
+client pipeline in `tests/integration/rolling-settlement.integration.test.ts`.
 
 There used to be a second peer (`peer2`) in the pre-extraction Docker
 topology. None of the four suites assert anything about a distinct peer2

--- a/packages/swap/tests/e2e/docker-rolling-leg-b-routing-e2e.test.ts
+++ b/packages/swap/tests/e2e/docker-rolling-leg-b-routing-e2e.test.ts
@@ -1,0 +1,359 @@
+/**
+ * swap#153 — the two ROUTING-shaped ways a rolling swap dies on delivery.
+ *
+ * Both showed up on rolling's first live day and were fixed by swap#148, and
+ * both are invisible to a unit test: the addresses were right, the sessions
+ * registered, the engine behaved. What was missing was a routing table entry
+ * and a peer relation, i.e. facts that only exist once a real connector is
+ * carrying a real socket. So this suite boots a REAL standalone
+ * `startSwapNode()` and drives it from a REAL BTP client.
+ *
+ * ```
+ *   F02  maker: REJECT destination=g.toon.client errorCode=F02 "no route found"
+ *        → a leg B addressed to a DIRECT-DIALLED sender, which by definition
+ *          is in nobody's routing table. Refused now at leg 0 instead, where
+ *          failing is free.
+ *
+ *   T00  maker: "No payment channel available for peer"
+ *        → leg B is VALUE-BEARING, and a connector demands a settlement claim
+ *          before forwarding value to any next hop that is not its `child`.
+ *          The maker can never hold a channel toward its own customer, so the
+ *          return peer is marked `child` when the route is bound.
+ * ```
+ *
+ * Why a maker of its own rather than the shared peer1: `global-setup.ts` boots
+ * peer1 in the Vitest globalSetup process, so a suite file cannot reach its
+ * connector's routing table or peer relations — and these are assertions about
+ * exactly those two things. This maker is standalone, parentless and
+ * direct-dialled, which is the deployed maker's shape.
+ *
+ * Nothing here needs a chain: leg 0 is free and the leg-B egress is driven at
+ * the production seam (`createConnectorLegBSender` — literally what
+ * `startSwapNode()` hands the rolling engine), so the assertions are about
+ * routing, not about claims.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { schnorr } from '@noble/curves/secp256k1.js';
+import { wrapSwapPacketToToon } from '@toon-protocol/sdk';
+import { BtpRuntimeClient } from '@toon-protocol/client';
+import {
+  PacketType,
+  deserializePrepare,
+  serializeFulfill,
+} from '@toon-protocol/shared';
+import type { UnsignedEvent } from 'nostr-tools';
+import {
+  startSwapNode,
+  createConnectorLegBSender,
+  ROLLING_PROTOCOL,
+  ROLLING_RFQ_REQUEST_KIND,
+  ROLLING_RFQ_REJECT_REASONS,
+} from '@toon-protocol/swap';
+import type { SwapNodeInstance } from '@toon-protocol/swap';
+
+import { randomStreamNonce, rejectReason } from './helpers/rolling-driver.js';
+import { present } from './helpers/present.js';
+
+const MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+const CHAIN = 'evm:8453';
+const CHAIN_RECIPIENT = '0x' + '11'.repeat(20);
+const MAKER_ILP = 'g.toon.swap.e2eroute';
+const MAKER_BTP_PORT = 19940;
+
+/**
+ * The sender's ILP address AND the BTP `peerId` it authenticates under — a
+ * stock client uses one expression for both, and the maker binds an inbound
+ * session under that string verbatim.
+ */
+const SENDER_ILP = 'g.toon.client.e2eroute01';
+/** An address no session ever authenticated under and no route reaches. */
+const UNREACHABLE_ILP = 'g.toon.client.e2eroute-elsewhere';
+
+/** Minimal introspection surface `ConnectorNode` exposes at runtime. */
+interface MakerConnector {
+  routingTable: { getNextHop(addr: string): string | null };
+  _packetHandler?: {
+    setPeerRelation?: (peerId: string, relation: string) => void;
+    getPeerRelation?: (peerId: string) => string | undefined;
+  };
+}
+
+/** Narrowed handles the tests read — see `present()` for why not `!`. */
+function handles(
+  connector: MakerConnector | null,
+  client: BtpRuntimeClient | null
+): {
+  connector: MakerConnector;
+  client: BtpRuntimeClient;
+  setRelation: (peerId: string, relation: string) => void;
+  getRelation: (peerId: string) => string | undefined;
+} {
+  const conn = present(connector, "the maker's connector");
+  const packetHandler = present(
+    conn._packetHandler,
+    "the connector's packet handler"
+  );
+  return {
+    connector: conn,
+    client: present(client, 'the BTP sender'),
+    setRelation: present(
+      packetHandler.setPeerRelation,
+      'PacketHandler.setPeerRelation'
+    ).bind(packetHandler),
+    getRelation: present(
+      packetHandler.getPeerRelation,
+      'PacketHandler.getPeerRelation'
+    ).bind(packetHandler),
+  };
+}
+
+interface CapturedLegB {
+  destination: string;
+  amount: string;
+  executionCondition: string;
+}
+
+describe('Docker Rolling leg-B routing E2E (swap#153) — the F02 and T00 shapes', () => {
+  let instance: SwapNodeInstance | null = null;
+  let connector: MakerConnector | null = null;
+  let client: BtpRuntimeClient | null = null;
+  const captured: CapturedLegB[] = [];
+  const preimages = new Map<string, Uint8Array>();
+
+  beforeAll(async () => {
+    instance = await startSwapNode({
+      mnemonic: MNEMONIC,
+      swapPairs: [
+        {
+          from: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+          to: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+          rate: '1.0',
+          minAmount: '1000',
+          maxAmount: '25000000',
+        },
+      ],
+      chains: ['evm'],
+      channels: {
+        [CHAIN]: [
+          {
+            channelId: '0x' + 'cd'.repeat(32),
+            cumulativeAmount: 0n,
+            nonce: 0n,
+            updatedAt: 0,
+          },
+        ],
+      },
+      inventory: { [CHAIN]: 1_000_000_000n },
+      chainProviders: [
+        {
+          chainType: 'evm',
+          chainId: CHAIN,
+          rpcUrl: 'http://127.0.0.1:1',
+          registryAddress: '0x' + '11'.repeat(20),
+          tokenAddress: '0x' + '22'.repeat(20),
+          tokenNetworkAddress: '0x' + '44'.repeat(20),
+          channelAddress: '0x' + '33'.repeat(20),
+        },
+      ],
+      relayUrls: ['ws://127.0.0.1:1'],
+      blsPort: 19941,
+      publisher: { publish: async () => undefined },
+      // Standalone, parentless, direct-dialled — the deployed maker's shape.
+      btpServerPort: MAKER_BTP_PORT,
+      ilpAddress: MAKER_ILP,
+      nodeId: 'toon-swap-e2eroute',
+    });
+    connector = instance.connector as unknown as MakerConnector;
+
+    client = new BtpRuntimeClient({
+      btpUrl: `ws://127.0.0.1:${MAKER_BTP_PORT}`,
+      peerId: SENDER_ILP,
+      authToken: '',
+      onMessage: (message) => {
+        if (!message.ilpPacket) return {};
+        const prepare = deserializePrepare(Buffer.from(message.ilpPacket));
+        const conditionB64 = Buffer.from(prepare.executionCondition).toString(
+          'base64'
+        );
+        captured.push({
+          destination: prepare.destination,
+          amount: prepare.amount.toString(),
+          executionCondition: conditionB64,
+        });
+        const preimage = preimages.get(conditionB64);
+        if (!preimage) return {};
+        return {
+          ilpPacket: serializeFulfill({
+            type: PacketType.FULFILL,
+            fulfillment: Buffer.from(preimage),
+            data: Buffer.alloc(0),
+          }),
+        };
+      },
+    });
+    await client.connect();
+  }, 60_000);
+
+  afterAll(async () => {
+    await client?.disconnect().catch(() => undefined);
+    await instance?.stop().catch(() => undefined);
+  });
+
+  // ---------------------------------------------------------------------
+  // F02 — a session the maker could not answer is refused at leg 0
+  // ---------------------------------------------------------------------
+  it('T-1 [P0] an RFQ advertising an address the maker cannot reach is refused F02 at leg 0, and invents no route', async () => {
+    const h = handles(connector, client);
+    expect(h.connector.routingTable.getNextHop(UNREACHABLE_ILP)).toBe(null);
+
+    const rfq = await h.client.sendIlpPacket({
+      destination: MAKER_ILP,
+      amount: '0',
+      data: rfqData(randomStreamNonce(), UNREACHABLE_ILP),
+    });
+
+    // Refused at the one moment failing is free: no quote, no session, no
+    // inventory reserved, no leg A revealed.
+    expect(rfq.accepted).toBe(false);
+    expect(rfq.code).toBe('F02');
+    expect(rejectReason(rfq.data)).toBe(
+      ROLLING_RFQ_REJECT_REASONS.NO_RETURN_PATH
+    );
+    // And nothing was invented for an address the maker cannot reach.
+    expect(h.connector.routingTable.getNextHop(UNREACHABLE_ILP)).toBe(null);
+  }, 30_000);
+
+  // ---------------------------------------------------------------------
+  // The fix — the arrival session becomes the return path, marked `child`
+  // ---------------------------------------------------------------------
+  it('T-2 [P0] an RFQ on a direct-dialled session binds that session as the return path and marks it `child`', async () => {
+    // Pre-state: a direct-dialled client is in nobody's routing table. This
+    // is the state in which every leg B was F02-rejected before swap#148.
+    const h = handles(connector, client);
+    expect(h.connector.routingTable.getNextHop(SENDER_ILP)).toBe(null);
+
+    const rfq = await h.client.sendIlpPacket({
+      destination: MAKER_ILP,
+      amount: '0',
+      data: rfqData(randomStreamNonce(), SENDER_ILP),
+    });
+    expect(rfq.accepted).toBe(true);
+
+    expect(h.connector.routingTable.getNextHop(SENDER_ILP)).toBe(SENDER_ILP);
+    // `child`, not `peer`: see T-3 for what the difference costs.
+    expect(h.getRelation(SENDER_ILP)).toBe('child');
+  }, 30_000);
+
+  // ---------------------------------------------------------------------
+  // T00 — a value-bearing forward to a non-`child` next hop
+  // ---------------------------------------------------------------------
+  it('T-3 [P0] leg B to a non-`child` next hop is refused T00 before it reaches the wire — and delivered once the relation is restored', async () => {
+    const h = handles(connector, client);
+    // Arm the session (idempotent — the route is already bound).
+    const rfq = await h.client.sendIlpPacket({
+      destination: MAKER_ILP,
+      amount: '0',
+      data: rfqData(randomStreamNonce(), SENDER_ILP),
+    });
+    expect(rfq.accepted).toBe(true);
+
+    const legB = createConnectorLegBSender(h.connector, {
+      nodeId: 'toon-swap-e2eroute',
+    });
+
+    // --- the defect: demote the return peer to an ordinary `peer` ---------
+    h.setRelation(SENDER_ILP, 'peer');
+    const before = captured.length;
+    const demoted = await legB(prepare(mint().conditionB64));
+
+    expect(demoted.type).toBe('reject');
+    expect(demoted.type === 'reject' ? demoted.code : undefined).toBe('T00');
+    expect(demoted.type === 'reject' ? demoted.message : '').toMatch(
+      /payment channel/i
+    );
+    // The packet never left the maker — a value-bearing hop is gated BEFORE
+    // forwarding, so the sender saw nothing at all.
+    expect(captured.length).toBe(before);
+
+    // --- the fix: `child`, as the RFQ's return-route binder sets it -------
+    h.setRelation(SENDER_ILP, 'child');
+    const { preimage, conditionB64 } = mint();
+    const delivered = await legB(prepare(conditionB64));
+
+    expect(captured.length).toBe(before + 1);
+    const seen = present(captured.at(-1), 'the delivered leg-B PREPARE');
+    expect(seen.destination).toBe(SENDER_ILP);
+    expect(seen.amount).toBe('3000');
+    // The sender-minted condition rode across verbatim (spec R4 coupling) …
+    expect(seen.executionCondition).toBe(conditionB64);
+    // … and came back as the preimage that alone can satisfy leg A.
+    expect(delivered.type).toBe('fulfill');
+    expect(
+      delivered.type === 'fulfill' && delivered.fulfillment
+        ? Buffer.from(delivered.fulfillment).toString('base64')
+        : undefined
+    ).toBe(Buffer.from(preimage).toString('base64'));
+  }, 30_000);
+
+  // -------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------
+  function mint(): { preimage: Uint8Array; conditionB64: string } {
+    const preimage = new Uint8Array(32);
+    globalThis.crypto.getRandomValues(preimage);
+    const conditionB64 = Buffer.from(sha256(preimage)).toString('base64');
+    preimages.set(conditionB64, preimage);
+    return { preimage, conditionB64 };
+  }
+
+  function prepare(conditionB64: string) {
+    return {
+      destination: SENDER_ILP,
+      amount: 3000n,
+      expiresAt: new Date(Date.now() + 10_000),
+      executionCondition: Buffer.from(conditionB64, 'base64'),
+      data: Buffer.from(
+        JSON.stringify({
+          proto: ROLLING_PROTOCOL,
+          type: 'advance',
+          streamNonce: randomStreamNonce(),
+          seq: 1,
+        }),
+        'utf8'
+      ),
+    };
+  }
+
+  function rfqData(streamNonce: string, senderIlpAddress: string): string {
+    const secretKey = schnorr.utils.randomSecretKey();
+    const rumor = {
+      kind: ROLLING_RFQ_REQUEST_KIND,
+      content: JSON.stringify({
+        proto: ROLLING_PROTOCOL,
+        type: 'rfq',
+        streamNonce,
+        pair: {
+          from: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+          to: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+        },
+        chainRecipient: CHAIN_RECIPIENT,
+        senderIlpAddress,
+      }),
+      tags: [],
+      created_at: Math.floor(Date.now() / 1000),
+      pubkey: '',
+    } as unknown as UnsignedEvent;
+    const { ilpPrepare } = wrapSwapPacketToToon({
+      rumor,
+      senderSecretKey: secretKey,
+      recipientPubkey: present(instance, 'the maker instance').identity.pubkey,
+      destination: MAKER_ILP,
+      amount: 1000n,
+    });
+    return ilpPrepare.data;
+  }
+});

--- a/packages/swap/tests/e2e/docker-rolling-swap-cross-chain-e2e.test.ts
+++ b/packages/swap/tests/e2e/docker-rolling-swap-cross-chain-e2e.test.ts
@@ -1,0 +1,195 @@
+/**
+ * swap#153 — ROLLING swap ACROSS A CHAIN BOUNDARY.
+ *
+ * This is the suite the whole port exists to protect.
+ *
+ * `tests/e2e/` is described as the project's multi-chain E2E swap coverage,
+ * and on paper it is: a Solana suite, a Mina suite, and a 9-pair matrix. In
+ * practice every one of those needs infra this repo does not vendor — a
+ * `solana-test-validator`, a Mina lightnet — so in CI they skip, and the only
+ * pair that has ever actually EXECUTED is `evm:base:31337 → evm:base:31337`.
+ * A same-chain swap at parity. The chain boundary was never crossed.
+ *
+ * swap#153 fixes that with the trick `tests/integration/
+ * rolling-settlement.integration.test.ts` already proved out: a second
+ * `anvil`. Leg A is paid on chain A (31337) through a real `TokenNetwork`
+ * payment channel; the leg-B claim the maker returns is signed for chain B
+ * (31338) — a different chain id, a different RPC, a different
+ * `RollingSwapChannel` deployment, and therefore a different EIP-712 domain.
+ * `from.chain !== to.chain` for real, with no external dependency, on every
+ * CI run.
+ *
+ * Solana and Mina still need their own infra and still skip; see
+ * `tests/e2e/README.md`. What changes is that "multi-chain" is no longer
+ * entirely aspirational.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { buildSettlementTx } from '@toon-protocol/sdk';
+import type { SwapPair } from '@toon-protocol/core';
+
+import {
+  buildLiveSender,
+  type LiveSender,
+} from './helpers/build-live-sender.js';
+import {
+  createLegBDaemon,
+  runRollingSwap,
+  type LegBDaemon,
+  type RollingSwapResult,
+} from './helpers/rolling-driver.js';
+import { present } from './helpers/present.js';
+
+import {
+  checkAllServicesReady,
+  waitForPeer2Bootstrap,
+  skipIfNotReady,
+  PEER1_NOSTR_PUBKEY,
+  PEER1_ILP_ADDRESS,
+  ROLLING_CHANNEL_ADDRESS,
+  CHAIN_B_ID,
+  DOCKER_CHAIN_EVM,
+  DOCKER_CHAIN_EVM_B,
+} from './helpers/infra-gate.js';
+import { ROLLING_SENDER_ILP } from './helpers/topology.js';
+
+/**
+ * The sender's payout address ON CHAIN B — deliberately NOT the address its
+ * chain-A settlement key controls, so a claim that silently came back bound
+ * to the source chain's recipient would fail rather than pass by coincidence.
+ */
+const CHAIN_B_RECIPIENT = '0x' + '7e57'.repeat(10);
+
+const PAIR: SwapPair = {
+  from: { assetCode: 'USD', assetScale: 6, chain: DOCKER_CHAIN_EVM },
+  to: { assetCode: 'USD', assetScale: 6, chain: DOCKER_CHAIN_EVM_B },
+  rate: '1',
+};
+
+const TOTAL = 900_000n;
+const PACKETS = 3;
+
+describe('Docker Rolling Swap CROSS-CHAIN E2E (swap#153) — evm:31337 → evm:31338', () => {
+  let servicesReady = false;
+  let sender: LiveSender | null = null;
+  let daemon: LegBDaemon = createLegBDaemon();
+  let result: RollingSwapResult | null = null;
+
+  beforeAll(async () => {
+    const ready = await checkAllServicesReady();
+    if (!ready) return;
+    const bootstrapped = await waitForPeer2Bootstrap(45_000);
+    if (!bootstrapped) return;
+    servicesReady = true;
+
+    try {
+      daemon = createLegBDaemon();
+      sender = await buildLiveSender({
+        nodeIdPrefix: 'roll-xc',
+        btpServerPort: 19932,
+        healthCheckPort: 19933,
+        loggerName: 'swap-e2e-rolling-xchain-connector',
+        senderIlpAddress: ROLLING_SENDER_ILP.crossChain,
+        localDeliveryHandler: daemon.handler,
+      });
+      result = await runRollingSwap({
+        sender,
+        daemon,
+        makerPubkey: PEER1_NOSTR_PUBKEY,
+        makerIlpAddress: PEER1_ILP_ADDRESS,
+        pair: PAIR,
+        chainRecipient: CHAIN_B_RECIPIENT,
+        totalAmount: TOTAL,
+        packetCount: PACKETS,
+      });
+    } catch (err) {
+      console.error('cross-chain rolling swap failed in beforeAll:', err);
+    }
+  }, 120_000);
+
+  afterAll(async () => {
+    if (sender) await sender.close();
+    await new Promise((r) => setTimeout(r, 250));
+  });
+
+  // ---------------------------------------------------------------------
+  // X-1 — the pair really does cross a boundary, and the maker quotes it
+  // ---------------------------------------------------------------------
+  it('X-1 [P1] peer1 quotes a pair whose source and target chains differ', async (ctx) => {
+    if (skipIfNotReady(servicesReady)) return ctx.skip();
+
+    const swap = present(result, 'the cross-chain swap result');
+    expect(
+      swap.rfqReject,
+      `leg 0 was refused: ${JSON.stringify(swap.rfqReject)}`
+    ).toBeUndefined();
+    // The guard that makes this suite mean something: if these two ever
+    // become the same string, this is a same-chain test wearing a
+    // cross-chain name.
+    expect(PAIR.from.chain).not.toBe(PAIR.to.chain);
+    expect(swap.quote?.streamNonce).toBe(swap.streamNonce);
+  });
+
+  // ---------------------------------------------------------------------
+  // X-2 — value lands on the TARGET chain, bound to the target recipient
+  // ---------------------------------------------------------------------
+  it('X-2 [P1] every leg-B claim is issued on the TARGET chain, to the target-chain recipient', async (ctx) => {
+    if (skipIfNotReady(servicesReady)) return ctx.skip();
+
+    const swap = present(result, 'the cross-chain swap result');
+    expect(swap.state, `rejections: ${JSON.stringify(swap.rejections)}`).toBe(
+      'completed'
+    );
+    expect(swap.claims).toHaveLength(PACKETS);
+    expect(daemon.refusals).toEqual([]);
+
+    for (const claim of swap.claims) {
+      expect(claim.pair.to.chain).toBe(DOCKER_CHAIN_EVM_B);
+      expect(claim.pair.from.chain).toBe(DOCKER_CHAIN_EVM);
+      expect(claim.recipient?.toLowerCase()).toBe(CHAIN_B_RECIPIENT);
+      expect(claim.claimBytes.length).toBeGreaterThan(0);
+    }
+
+    // The chain-B channel the claims advance is NOT a chain-A channel: the
+    // maker binds a separate seed per chain (`peer-node.ts`).
+    const channelIds = new Set(swap.claims.map((c) => c.channelId));
+    expect(channelIds.size).toBe(1);
+  });
+
+  // ---------------------------------------------------------------------
+  // X-3 — the target-chain claims settle against the TARGET chain's domain
+  // ---------------------------------------------------------------------
+  it('X-3 [P1] the leg-B claims build an EVM settlement bundle for the TARGET chain', async (ctx) => {
+    if (skipIfNotReady(servicesReady)) return ctx.skip();
+    const swap = present(result, 'the cross-chain swap result');
+    expect(swap.claims.length).toBeGreaterThanOrEqual(1);
+
+    const lastClaim = present(swap.claims.at(-1), 'the last leg-B claim');
+    const settlement = buildSettlementTx({
+      claims: swap.claims,
+      signers: {
+        [DOCKER_CHAIN_EVM_B]: {
+          address: present(
+            lastClaim.swapSignerAddress,
+            'claim.swapSignerAddress'
+          ).toLowerCase(),
+          contractAddress: ROLLING_CHANNEL_ADDRESS.toLowerCase(),
+          // Chain B's own id — the EIP-712 domain separator that makes a
+          // chain-A claim unredeemable here and vice versa.
+          chainId: CHAIN_B_ID,
+        },
+      },
+      recipients: { [DOCKER_CHAIN_EVM_B]: CHAIN_B_RECIPIENT },
+      verifySignatures: false,
+    });
+
+    expect(settlement.bundles).toHaveLength(1);
+    const bundle = present(settlement.bundles[0], 'the settlement bundle');
+    expect(bundle.chain).toBe(DOCKER_CHAIN_EVM_B);
+    expect(bundle.recipient).toBe(CHAIN_B_RECIPIENT);
+    expect(bundle.cumulativeAmount).toBe(lastClaim.cumulativeAmount);
+    // N cross-chain fills net to ONE on-chain settlement (spec §8).
+    expect(bundle.claimsMerged).toBe(PACKETS);
+    expect(bundle.unsignedTxBytes.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/swap/tests/e2e/docker-rolling-swap-evm-e2e.test.ts
+++ b/packages/swap/tests/e2e/docker-rolling-swap-evm-e2e.test.ts
@@ -1,0 +1,305 @@
+/**
+ * swap#153 — ROLLING swap-flow + settlement E2E, EVM leg.
+ *
+ * The rolling counterpart of `docker-swap-flow-evm-e2e.test.ts` (AC-3..AC-6),
+ * which drives the legacy zero-condition `streamSwap` sender ADR 0003
+ * removes. Same infra, same peer1, same socket — different protocol:
+ * kind:20033 RFQ → kind:20034 quote → coupled fills carrying a real 32-byte
+ * sender-minted execution condition, with the chain-B claim arriving on LEG B
+ * rather than inside the leg-A FULFILL.
+ *
+ * Both suites run side by side until Stage 5 removes the maker's legacy
+ * intake; nothing here deletes anything.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { buildSettlementTx, fillEvmSettlementTxGas } from '@toon-protocol/sdk';
+import type { SwapPair } from '@toon-protocol/core';
+
+import {
+  buildLiveSender,
+  type LiveSender,
+} from './helpers/build-live-sender.js';
+import {
+  createLegBDaemon,
+  openRollingSession,
+  runRollingSwap,
+  type LegBDaemon,
+  type RollingSession,
+  type RollingSwapResult,
+} from './helpers/rolling-driver.js';
+import { present } from './helpers/present.js';
+
+import {
+  checkAllServicesReady,
+  waitForPeer2Bootstrap,
+  skipIfNotReady,
+  PEER1_NOSTR_PUBKEY,
+  PEER1_ILP_ADDRESS,
+  TOKEN_NETWORK_ADDRESS,
+  ROLLING_CHANNEL_ADDRESS,
+  CHAIN_ID,
+  createViemClient,
+  SWAP_E2E_EVM_SENDER_ADDRESS,
+  DOCKER_CHAIN_EVM,
+} from './helpers/infra-gate.js';
+import { ROLLING_SENDER_ILP } from './helpers/topology.js';
+
+/** Sender's 20-byte EVM payout address (lowercase hex with `0x`). */
+const EVM_CHAIN_RECIPIENT = SWAP_E2E_EVM_SENDER_ADDRESS.toLowerCase();
+
+/** The same-chain pair peer1 has always advertised (see `peer-node.ts`). */
+const PAIR: SwapPair = {
+  from: { assetCode: 'USD', assetScale: 6, chain: DOCKER_CHAIN_EVM },
+  to: { assetCode: 'USD', assetScale: 6, chain: DOCKER_CHAIN_EVM },
+  rate: '1',
+};
+
+const TOTAL = 1_000_000n;
+const PACKETS = 2;
+
+describe('Docker Rolling Swap EVM E2E (swap#153)', () => {
+  let servicesReady = false;
+  let sender: LiveSender | null = null;
+  let daemon: LegBDaemon = createLegBDaemon();
+  let result: RollingSwapResult | null = null;
+
+  beforeAll(async () => {
+    const ready = await checkAllServicesReady();
+    if (!ready) return;
+    const bootstrapped = await waitForPeer2Bootstrap(45_000);
+    if (!bootstrapped) return;
+    servicesReady = true;
+
+    try {
+      daemon = createLegBDaemon();
+      sender = await buildLiveSender({
+        nodeIdPrefix: 'roll-evm',
+        btpServerPort: 19930,
+        healthCheckPort: 19931,
+        loggerName: 'swap-e2e-rolling-evm-connector',
+        senderIlpAddress: ROLLING_SENDER_ILP.evm,
+        localDeliveryHandler: daemon.handler,
+      });
+      result = await runRollingSwap({
+        sender,
+        daemon,
+        makerPubkey: PEER1_NOSTR_PUBKEY,
+        makerIlpAddress: PEER1_ILP_ADDRESS,
+        pair: PAIR,
+        chainRecipient: EVM_CHAIN_RECIPIENT,
+        totalAmount: TOTAL,
+        packetCount: PACKETS,
+      });
+    } catch (err) {
+      console.error('EVM rolling swap failed in beforeAll:', err);
+    }
+  }, 120_000);
+
+  afterAll(async () => {
+    if (sender) await sender.close();
+    await new Promise((r) => setTimeout(r, 250));
+  });
+
+  // ---------------------------------------------------------------------
+  // R-1 — leg 0: the RFQ is answered with a kind:20034 quote
+  // ---------------------------------------------------------------------
+  it('R-1 [P1] the RFQ round-trips over real BTP and returns a quote bound to the session', async (ctx) => {
+    if (skipIfNotReady(servicesReady)) return ctx.skip();
+
+    const swap = present(result, 'the rolling swap result');
+    expect(
+      swap.rfqReject,
+      `leg 0 was refused: ${JSON.stringify(swap.rfqReject)}`
+    ).toBeUndefined();
+
+    const quote = present(swap.quote, 'the kind:20034 quote');
+    expect(quote.proto).toBe('rolling/1');
+    expect(quote.type).toBe('quote');
+    // The session id the SENDER minted, echoed — this is what every fill and
+    // every leg B in the session is keyed by.
+    expect(quote.streamNonce).toBe(swap.streamNonce);
+    expect(Number(quote.rate)).toBeGreaterThan(0);
+    expect(quote.expiresAt).toBeGreaterThan(Date.now() - 60_000);
+    // Armed before the first fill so the sender can verify leg B on arrival
+    // rather than trusting whatever the first advance echoes (spec §2.2).
+    expect(quote.swapSignerAddress).toBeDefined();
+  });
+
+  // ---------------------------------------------------------------------
+  // R-2 — legs A and B complete, coupled by the sender's own condition
+  // ---------------------------------------------------------------------
+  it('R-2 [P1] coupled fills complete: leg B delivers a recipient-bound claim and leg A fulfils with the sender preimage', async (ctx) => {
+    if (skipIfNotReady(servicesReady)) return ctx.skip();
+
+    const swap = present(result, 'the rolling swap result');
+    expect(swap.state, `rejections: ${JSON.stringify(swap.rejections)}`).toBe(
+      'completed'
+    );
+
+    // One accept record per fill, and one leg-B advance per fill: the claim
+    // now travels on leg B, which is the headline change vs the legacy path.
+    expect(swap.accepts).toHaveLength(PACKETS);
+    expect(swap.advances).toHaveLength(PACKETS);
+    expect(swap.claims).toHaveLength(PACKETS);
+    expect(daemon.refusals, 'no leg B should have failed R5').toEqual([]);
+
+    for (const claim of swap.claims) {
+      expect(claim.recipient?.toLowerCase()).toBe(EVM_CHAIN_RECIPIENT);
+      expect(claim.claimBytes.length).toBeGreaterThan(0);
+      expect(claim.channelId).toBeDefined();
+      expect(claim.swapSignerAddress).toBeDefined();
+    }
+
+    // The watermark advanced monotonically across the stream (spec §4).
+    const cumulatives = swap.claims.map((c) =>
+      BigInt(present(c.cumulativeAmount, 'claim.cumulativeAmount'))
+    );
+    for (let i = 1; i < cumulatives.length; i++) {
+      const prev = present(cumulatives[i - 1], 'previous cumulative');
+      const next = present(cumulatives[i], 'next cumulative');
+      expect(next > prev).toBe(true);
+    }
+
+    // Every accept echoes the maker's quote tape for the fill it accepted.
+    for (const accept of swap.accepts) {
+      expect(accept.streamNonce).toBe(swap.streamNonce);
+      expect(Number(accept.rate)).toBeGreaterThan(0);
+      expect(BigInt(accept.targetAmount)).toBeGreaterThan(0n);
+    }
+  });
+
+  // ---------------------------------------------------------------------
+  // R-3 — the coupling itself: sha256(fulfillment) === the sender's condition
+  // ---------------------------------------------------------------------
+  it('R-3 [P1] a fresh fill returns the preimage of the condition the SENDER minted (spec R4/R6)', async (ctx) => {
+    if (skipIfNotReady(servicesReady)) return ctx.skip();
+
+    const live = present(sender, 'the rolling sender');
+    const session = await openSession(live, daemonForProbe(live));
+    const outcome = await session.fill({ seq: 1, amount: 250_000n });
+    expect(
+      outcome.accepted,
+      outcome.accepted ? '' : `${outcome.code}: ${outcome.message}`
+    ).toBe(true);
+    if (!outcome.accepted) return;
+
+    expect(outcome.fulfillment.length).toBe(32);
+    expect(Buffer.from(sha256(outcome.fulfillment)).toString('base64')).toBe(
+      Buffer.from(sha256(outcome.preimage)).toString('base64')
+    );
+    expect(
+      Buffer.from(outcome.fulfillment).equals(Buffer.from(outcome.preimage))
+    ).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------
+  // R-4 — withhold: a sender that refuses leg B gets no fill and pays nothing
+  // ---------------------------------------------------------------------
+  it('R-4 [P1] withholding the leg-B preimage leaves leg A rejected — no claim, no debit (spec R5/R8)', async (ctx) => {
+    if (skipIfNotReady(servicesReady)) return ctx.skip();
+
+    const live = present(sender, 'the rolling sender');
+    const probe = daemonForProbe(live);
+    const session = await openSession(live, probe);
+    probe.reveal = false;
+    const outcome = await session.fill({ seq: 1, amount: 250_000n });
+
+    // Leg B was DELIVERED (so this is a real withhold, not the pre-swap#148
+    // `F02 no route found`) …
+    expect(probe.advances.length).toBe(1);
+    // … but the sender never revealed, so leg A cannot fulfil and no claim
+    // was accepted.
+    expect(outcome.accepted).toBe(false);
+    expect(probe.claims).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------
+  // R-5 — settlement: the leg-B claims build a valid EVM settlement bundle
+  // ---------------------------------------------------------------------
+  it('R-5 [P1] buildSettlementTx() over the LEG-B claims produces a valid EVM bundle', async (ctx) => {
+    if (skipIfNotReady(servicesReady)) return ctx.skip();
+
+    const swap = present(result, 'the rolling swap result');
+    expect(swap.claims.length).toBeGreaterThanOrEqual(1);
+
+    // Config-drift guards — leg A and leg B are two different contracts
+    // (issue #133), and a claim built against the wrong one is unredeemable.
+    expect(TOKEN_NETWORK_ADDRESS).toBe(
+      '0xCafac3dD18aC6c6e92c921884f9E4176737C052c'
+    );
+    expect(ROLLING_CHANNEL_ADDRESS).toBe(
+      '0x0165878A594ca255338adfa4d48449f69242Eb8F'
+    );
+
+    const lastClaim = present(swap.claims.at(-1), 'the last leg-B claim');
+    const signerConfig = {
+      address: present(
+        lastClaim.swapSignerAddress,
+        'claim.swapSignerAddress'
+      ).toLowerCase(),
+      contractAddress: ROLLING_CHANNEL_ADDRESS.toLowerCase(),
+      chainId: CHAIN_ID,
+    };
+
+    const settlement = buildSettlementTx({
+      claims: swap.claims,
+      signers: { [DOCKER_CHAIN_EVM]: signerConfig },
+      recipients: { [DOCKER_CHAIN_EVM]: EVM_CHAIN_RECIPIENT },
+      verifySignatures: false,
+    });
+
+    expect(settlement.bundles.length).toBeGreaterThanOrEqual(1);
+    const bundle = present(settlement.bundles[0], 'the settlement bundle');
+    expect(bundle.chainKind).toBe('evm');
+    expect(bundle.chain).toBe(DOCKER_CHAIN_EVM);
+    expect(bundle.channelId).toBe(lastClaim.channelId);
+    expect(bundle.nonce).toBe(lastClaim.nonce);
+    expect(bundle.cumulativeAmount).toBe(lastClaim.cumulativeAmount);
+    expect(bundle.recipient).toBe(EVM_CHAIN_RECIPIENT);
+    expect(bundle.unsignedTxBytes.length).toBeGreaterThan(0);
+    // N fills netted into ONE bundle for the channel — the whole point of
+    // rolling settlement (spec §8).
+    expect(bundle.claimsMerged).toBe(swap.claims.length);
+
+    const publicClient = createViemClient();
+    const gasPrice = await publicClient.getGasPrice();
+    const gasFilled = fillEvmSettlementTxGas(
+      bundle,
+      { nonce: 0n, gasPrice, gasLimit: 500_000n },
+      signerConfig
+    );
+    expect(gasFilled.length).toBeGreaterThan(bundle.unsignedTxBytes.length);
+  });
+
+  // -------------------------------------------------------------------
+  // Helpers — a fresh session per probe so one probe cannot perturb the
+  // watermark the main stream's assertions read.
+  // -------------------------------------------------------------------
+  function daemonForProbe(live: LiveSender): LegBDaemon {
+    const probe = createLegBDaemon();
+    live.connector.setLocalDeliveryHandler(probe.handler);
+    return probe;
+  }
+
+  async function openSession(
+    live: LiveSender,
+    probe: LegBDaemon
+  ): Promise<RollingSession> {
+    const opened = await openRollingSession({
+      sender: live,
+      daemon: probe,
+      makerPubkey: PEER1_NOSTR_PUBKEY,
+      makerIlpAddress: PEER1_ILP_ADDRESS,
+      pair: PAIR,
+      chainRecipient: EVM_CHAIN_RECIPIENT,
+    });
+    if (!opened.ok) {
+      throw new Error(
+        `RFQ refused: ${opened.code} ${opened.reason ?? ''} ${opened.message ?? ''}`
+      );
+    }
+    return opened.session;
+  }
+});

--- a/packages/swap/tests/e2e/docker-rolling-swap-mina-e2e.test.ts
+++ b/packages/swap/tests/e2e/docker-rolling-swap-mina-e2e.test.ts
@@ -1,0 +1,164 @@
+/**
+ * swap#153 — ROLLING swap-flow + settlement E2E, Mina target (AC-8's rolling
+ * counterpart).
+ *
+ * Same gate as the legacy Mina suite it replaces: this repo vendors no Mina
+ * lightnet, so `waitForMinaHealth()` reports not-ready and both cases skip
+ * unless an operator brought one up and exported `MINA_E2E_GRAPHQL_URL` /
+ * `MINA_E2E_ZKAPP_ADDRESS` (see `tests/e2e/README.md`).
+ *
+ * Mina carries a SECOND, deeper gap that no infra fixes: the SDK's Mina
+ * settlement builder is still a stub (Story 12.6 AC-9 deferred the zkApp
+ * wiring), so even with a lightnet the most this can assert is that a Mina
+ * claim is routed to the Mina builder and refused there. The rolling port
+ * keeps that assertion rather than pretending the chain is covered.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { buildSettlementTx } from '@toon-protocol/sdk';
+import type { SwapPair } from '@toon-protocol/core';
+
+import {
+  buildLiveSender,
+  type LiveSender,
+} from './helpers/build-live-sender.js';
+import {
+  createLegBDaemon,
+  runRollingSwap,
+  type LegBDaemon,
+  type RollingSwapResult,
+} from './helpers/rolling-driver.js';
+import { present } from './helpers/present.js';
+
+import {
+  checkAllServicesReady,
+  waitForPeer2Bootstrap,
+  waitForMinaHealth,
+  skipIfNotReady,
+  acquireMinaAccount,
+  releaseMinaAccount,
+  PEER1_NOSTR_PUBKEY,
+  PEER1_ILP_ADDRESS,
+  MINA_GRAPHQL,
+  MINA_ZKAPP_ADDRESS,
+  DOCKER_CHAIN_EVM,
+  DOCKER_CHAIN_MINA,
+} from './helpers/infra-gate.js';
+import { ROLLING_SENDER_ILP } from './helpers/topology.js';
+
+const PAIR: SwapPair = {
+  from: { assetCode: 'USD', assetScale: 6, chain: DOCKER_CHAIN_EVM },
+  to: { assetCode: 'USD', assetScale: 6, chain: DOCKER_CHAIN_MINA },
+  rate: '1',
+};
+
+describe('Docker Rolling Swap Mina E2E (swap#153)', () => {
+  let servicesReady = false;
+  let minaAccount: { pk: string; sk: string } | null = null;
+  let sender: LiveSender | null = null;
+  let daemon: LegBDaemon = createLegBDaemon();
+  let result: RollingSwapResult | null = null;
+
+  beforeAll(async () => {
+    const ready = await checkAllServicesReady();
+    if (!ready) return;
+    const bootstrapped = await waitForPeer2Bootstrap(45_000);
+    if (!bootstrapped) return;
+    const minaReady = await waitForMinaHealth(180_000);
+    if (!minaReady) return;
+    minaAccount = await acquireMinaAccount();
+    if (!minaAccount) return;
+    servicesReady = true;
+
+    try {
+      daemon = createLegBDaemon();
+      sender = await buildLiveSender({
+        nodeIdPrefix: 'roll-mina',
+        btpServerPort: 19938,
+        healthCheckPort: 19939,
+        loggerName: 'swap-e2e-rolling-mina-connector',
+        senderIlpAddress: ROLLING_SENDER_ILP.mina,
+        localDeliveryHandler: daemon.handler,
+      });
+      result = await runRollingSwap({
+        sender,
+        daemon,
+        makerPubkey: PEER1_NOSTR_PUBKEY,
+        makerIlpAddress: PEER1_ILP_ADDRESS,
+        pair: PAIR,
+        chainRecipient: minaAccount.pk,
+        totalAmount: 1_000_000n,
+        packetCount: 1,
+      });
+    } catch (err) {
+      console.error('Mina rolling swap failed in beforeAll:', err);
+    }
+  }, 240_000);
+
+  afterAll(async () => {
+    if (minaAccount) await releaseMinaAccount(minaAccount.pk);
+    if (sender) await sender.close();
+    await new Promise((r) => setTimeout(r, 250));
+  });
+
+  it('N-1 [P1] a rolling session to mina:devnet delivers leg-B claims bound to the acquired Mina pk', async (ctx) => {
+    if (skipIfNotReady(servicesReady)) return ctx.skip();
+
+    const account = present(minaAccount, 'the acquired Mina account');
+    const swap = present(result, 'the Mina rolling swap result');
+    expect(
+      swap.state,
+      `rfq: ${JSON.stringify(swap.rfqReject)} rejections: ${JSON.stringify(swap.rejections)}`
+    ).toBe('completed');
+    expect(swap.claims.length).toBeGreaterThanOrEqual(1);
+    const first = present(swap.claims[0], 'the first leg-B claim');
+    expect(first.recipient).toBe(account.pk);
+    expect(first.pair.to.chain).toBe(DOCKER_CHAIN_MINA);
+  });
+
+  it('N-2 [P1] Mina leg-B claims carry settlement context and route to the (still deferred) Mina builder', async (ctx) => {
+    if (skipIfNotReady(servicesReady)) return ctx.skip();
+
+    expect(
+      MINA_ZKAPP_ADDRESS,
+      'MINA_ZKAPP_ADDRESS not exported — see tests/e2e/README.md'
+    ).not.toBe('');
+    expect(MINA_GRAPHQL).toBe('http://localhost:19085/graphql');
+    const account = present(minaAccount, 'the acquired Mina account');
+    const swap = present(result, 'the Mina rolling swap result');
+    expect(swap.claims.length).toBeGreaterThanOrEqual(1);
+
+    const lastClaim = present(swap.claims.at(-1), 'the last leg-B claim');
+    expect(lastClaim.channelId).toBeDefined();
+    expect(lastClaim.nonce).toBeDefined();
+    expect(lastClaim.cumulativeAmount).toBeDefined();
+    expect(lastClaim.recipient).toBe(account.pk);
+    const signerAddress = present(
+      lastClaim.swapSignerAddress,
+      'claim.swapSignerAddress'
+    );
+
+    // The Mina settlement builder is a stub (Story 12.6 AC-9), so the
+    // honest assertion is that the claim REACHES it and is refused there.
+    expect(() =>
+      buildSettlementTx({
+        claims: swap.claims,
+        signers: { [DOCKER_CHAIN_MINA]: { address: signerAddress } },
+        recipients: { [DOCKER_CHAIN_MINA]: account.pk },
+        verifySignatures: false,
+      })
+    ).toThrow(/UNSUPPORTED_CHAIN|mina/i);
+
+    const health = await fetch(MINA_GRAPHQL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: '{syncStatus}' }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    expect(health.ok).toBe(true);
+    const healthData = (await health.json()) as {
+      data?: { syncStatus?: string };
+    };
+    expect(healthData.data?.syncStatus).toBe('SYNCED');
+  });
+});

--- a/packages/swap/tests/e2e/docker-rolling-swap-pair-matrix-e2e.test.ts
+++ b/packages/swap/tests/e2e/docker-rolling-swap-pair-matrix-e2e.test.ts
@@ -1,0 +1,248 @@
+/**
+ * swap#153 — ROLLING pair-matrix coverage.
+ *
+ * The rolling counterpart of `docker-swap-flow-pair-matrix-e2e.test.ts`
+ * (AC-9/AC-10), with two differences that both make the matrix say more:
+ *
+ * 1. **Four chains, sixteen ordered pairs**, not three and nine — the second
+ *    anvil (`topology.ts`'s `ANVIL_B_CHAIN_ID`) is in the matrix, so a pair
+ *    that genuinely crosses a chain boundary is exercised on every CI run
+ *    instead of only when an operator has brought up Solana or Mina.
+ * 2. **A pair peer1 does not advertise is asserted to be REFUSED**, not
+ *    skipped. The legacy matrix could only skip, so "the maker quotes a pair
+ *    it cannot deliver" would have passed. Here `unsupported_pair` is the
+ *    expected answer and its absence fails.
+ *
+ * A pair whose chains have no live backing service still skips, exactly as
+ * before — see `tests/e2e/README.md` for what it takes to bring Solana and
+ * Mina up.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { generateSolanaKeypair } from '@toon-protocol/sdk';
+import type { SwapPair } from '@toon-protocol/core';
+
+import {
+  buildLiveSender,
+  type LiveSender,
+} from './helpers/build-live-sender.js';
+import {
+  createLegBDaemon,
+  openRollingSession,
+  runRollingSwap,
+  type LegBDaemon,
+} from './helpers/rolling-driver.js';
+import { present } from './helpers/present.js';
+
+import {
+  checkAllServicesReady,
+  waitForPeer2Bootstrap,
+  waitForSolanaHealth,
+  waitForMinaHealth,
+  skipIfNotReady,
+  acquireMinaAccount,
+  releaseMinaAccount,
+  PEER1_NOSTR_PUBKEY,
+  PEER1_ILP_ADDRESS,
+  DOCKER_CHAIN_EVM,
+  DOCKER_CHAIN_EVM_B,
+  DOCKER_CHAIN_SOLANA,
+  DOCKER_CHAIN_MINA,
+  ROLLING_CHAINS,
+  ROLLING_PAIR_MATRIX,
+  peer1AdvertisesPair,
+  SWAP_E2E_EVM_SENDER_ADDRESS,
+  type RollingChain,
+} from './helpers/infra-gate.js';
+import { ROLLING_SENDER_ILP } from './helpers/topology.js';
+
+/** Lazily generated Solana recipient — reused across all Solana-target pairs. */
+let cachedSolanaRecipient: string | null = null;
+
+/** Distinct EVM payout address per EVM chain, so a mis-bound claim shows up. */
+const EVM_B_RECIPIENT = '0x' + '7e57'.repeat(10);
+
+function chainRecipientForTarget(
+  target: RollingChain,
+  minaAccountPk: string | null
+): string {
+  switch (target) {
+    case DOCKER_CHAIN_EVM:
+      return SWAP_E2E_EVM_SENDER_ADDRESS.toLowerCase();
+    case DOCKER_CHAIN_EVM_B:
+      return EVM_B_RECIPIENT;
+    case DOCKER_CHAIN_SOLANA: {
+      if (!cachedSolanaRecipient) {
+        // generateSolanaKeypair() returns publicKey already base58-encoded;
+        // do NOT re-encode (would throw "Cannot convert R to a BigInt").
+        cachedSolanaRecipient = generateSolanaKeypair().publicKey;
+      }
+      return cachedSolanaRecipient;
+    }
+    case DOCKER_CHAIN_MINA:
+      if (!minaAccountPk) {
+        throw new Error(
+          'Mina account not acquired — cannot generate chainRecipient for mina:devnet target'
+        );
+      }
+      return minaAccountPk;
+  }
+}
+
+describe('Docker Rolling Swap pair-matrix E2E (swap#153) — 16 ordered chain pairs', () => {
+  let coreReady = false;
+  const chainReady: Record<RollingChain, boolean> = {
+    [DOCKER_CHAIN_EVM]: false,
+    [DOCKER_CHAIN_EVM_B]: false,
+    [DOCKER_CHAIN_SOLANA]: false,
+    [DOCKER_CHAIN_MINA]: false,
+  };
+  let minaAccount: { pk: string; sk: string } | null = null;
+  let sender: LiveSender | null = null;
+  let daemon: LegBDaemon = createLegBDaemon();
+
+  beforeAll(async () => {
+    const ready = await checkAllServicesReady();
+    if (!ready) return;
+
+    // Both EVM chains are implied by checkAllServicesReady() (it probes both
+    // anvils). Solana/Mina get a SHORT probe so a missing lightnet costs the
+    // matrix 30 s, not 180 s, and never masks the EVM pairs.
+    const [bootstrapped, solanaReady, minaReady] = await Promise.all([
+      waitForPeer2Bootstrap(45_000),
+      waitForSolanaHealth(30_000),
+      waitForMinaHealth(30_000),
+    ]);
+    if (!bootstrapped) return;
+
+    chainReady[DOCKER_CHAIN_EVM] = true;
+    chainReady[DOCKER_CHAIN_EVM_B] = true;
+    chainReady[DOCKER_CHAIN_SOLANA] = solanaReady;
+    chainReady[DOCKER_CHAIN_MINA] = minaReady;
+
+    if (minaReady) {
+      minaAccount = await acquireMinaAccount();
+      if (!minaAccount) chainReady[DOCKER_CHAIN_MINA] = false;
+    }
+
+    coreReady = true;
+
+    try {
+      daemon = createLegBDaemon();
+      sender = await buildLiveSender({
+        nodeIdPrefix: 'roll-mtx',
+        btpServerPort: 19934,
+        healthCheckPort: 19935,
+        loggerName: 'swap-e2e-rolling-matrix-connector',
+        senderIlpAddress: ROLLING_SENDER_ILP.matrix,
+        localDeliveryHandler: daemon.handler,
+        initialDeposit: '50000000', // 50 USDC — enough for the whole matrix
+      });
+    } catch (err) {
+      console.error('Failed to build the rolling matrix sender:', err);
+    }
+  }, 240_000);
+
+  afterAll(async () => {
+    if (minaAccount) await releaseMinaAccount(minaAccount.pk);
+    if (sender) await sender.close();
+    await new Promise((r) => setTimeout(r, 250));
+  });
+
+  // -------------------------------------------------------------------
+  // Coverage guard — the matrix is what it claims to be
+  // -------------------------------------------------------------------
+  it('M-0 coverage guard — the matrix enumerates every ordered pair over 4 chains, and at least one crosses a boundary without operator infra', () => {
+    expect(ROLLING_CHAINS.length).toBe(4);
+    expect(ROLLING_PAIR_MATRIX.length).toBe(16);
+    const uniq = new Set(
+      ROLLING_PAIR_MATRIX.map(({ from, to }) => `${from}->${to}`)
+    );
+    expect(uniq.size).toBe(16);
+
+    // The pair that keeps this harness honest: advertised by peer1, backed by
+    // infra this repo vendors, and crossing a chain boundary. If this ever
+    // stops holding, "multi-chain coverage" is back to being a claim only.
+    expect(peer1AdvertisesPair(DOCKER_CHAIN_EVM, DOCKER_CHAIN_EVM_B)).toBe(
+      true
+    );
+    expect(DOCKER_CHAIN_EVM).not.toBe(DOCKER_CHAIN_EVM_B);
+  });
+
+  // -------------------------------------------------------------------
+  // One it() per ordered pair
+  // -------------------------------------------------------------------
+  it.each(ROLLING_PAIR_MATRIX)(
+    'M [P1] pair $from -> $to — rolling session behaves as the maker advertises',
+    async (pair) => {
+      if (skipIfNotReady(coreReady)) return;
+
+      if (!chainReady[pair.from] || !chainReady[pair.to]) {
+        console.log(
+          `Skipping pair ${pair.from} -> ${pair.to}: chain not ready ` +
+            `(from=${chainReady[pair.from]}, to=${chainReady[pair.to]})`
+        );
+        return;
+      }
+
+      const live = present(sender, 'the matrix sender');
+
+      const recipient = chainRecipientForTarget(
+        pair.to,
+        minaAccount?.pk ?? null
+      );
+      expect(recipient.length).toBeGreaterThan(0);
+
+      const swapPair: SwapPair = {
+        from: { assetCode: 'USD', assetScale: 6, chain: pair.from },
+        to: { assetCode: 'USD', assetScale: 6, chain: pair.to },
+        rate: '1',
+      };
+
+      if (!peer1AdvertisesPair(pair.from, pair.to)) {
+        // Not advertised: the maker must REFUSE at leg 0 rather than quote a
+        // pair it has no inventory, signer or channel for.
+        const probe = createLegBDaemon();
+        const opened = await openRollingSession({
+          sender: live,
+          daemon: probe,
+          makerPubkey: PEER1_NOSTR_PUBKEY,
+          makerIlpAddress: PEER1_ILP_ADDRESS,
+          pair: swapPair,
+          chainRecipient: recipient,
+        });
+        expect(
+          opened.ok,
+          `peer1 quoted ${pair.from} -> ${pair.to}, which it does not advertise`
+        ).toBe(false);
+        if (!opened.ok) {
+          expect(opened.reason).toBe('unsupported_pair');
+        }
+        return;
+      }
+
+      const perPairDaemon = createLegBDaemon();
+      live.connector.setLocalDeliveryHandler(perPairDaemon.handler);
+      const result = await runRollingSwap({
+        sender: live,
+        daemon: perPairDaemon,
+        makerPubkey: PEER1_NOSTR_PUBKEY,
+        makerIlpAddress: PEER1_ILP_ADDRESS,
+        pair: swapPair,
+        chainRecipient: recipient,
+        totalAmount: 1_000_000n,
+        packetCount: 1,
+      });
+
+      expect(
+        result.state,
+        `rejections: ${JSON.stringify(result.rejections)} rfq: ${JSON.stringify(result.rfqReject)}`
+      ).toBe('completed');
+      expect(result.claims.length).toBeGreaterThanOrEqual(1);
+      for (const claim of result.claims) {
+        expect(claim.recipient?.toLowerCase()).toBe(recipient.toLowerCase());
+        expect(claim.pair.to.chain).toBe(pair.to);
+      }
+    }
+  );
+});

--- a/packages/swap/tests/e2e/docker-rolling-swap-solana-e2e.test.ts
+++ b/packages/swap/tests/e2e/docker-rolling-swap-solana-e2e.test.ts
@@ -1,0 +1,157 @@
+/**
+ * swap#153 — ROLLING swap-flow + settlement E2E, Solana target (AC-7's
+ * rolling counterpart).
+ *
+ * Same gate as the legacy Solana suite it replaces: this repo vendors no
+ * `solana-test-validator`, so `waitForSolanaHealth()` reports not-ready and
+ * both cases skip unless an operator brought the chain up and exported
+ * `SOLANA_E2E_RPC_URL` / `SOLANA_E2E_PROGRAM_ID` (see `tests/e2e/README.md`).
+ * That gap is infra, not protocol: leg A on Solana is exercisable against a
+ * local validator that clones the real devnet program so PDAs match — the
+ * toon-meta#394 T6 rig did exactly that — and `peer-node.ts` grew a
+ * multi-chain shape in this ticket precisely so wiring a Solana pair here is
+ * a config change rather than a rewrite.
+ *
+ * Until then the chain boundary that IS crossed on every CI run is the second
+ * anvil — `docker-rolling-swap-cross-chain-e2e.test.ts`.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { buildSettlementTx, generateSolanaKeypair } from '@toon-protocol/sdk';
+import type { SwapPair } from '@toon-protocol/core';
+
+import {
+  buildLiveSender,
+  type LiveSender,
+} from './helpers/build-live-sender.js';
+import {
+  createLegBDaemon,
+  runRollingSwap,
+  type LegBDaemon,
+  type RollingSwapResult,
+} from './helpers/rolling-driver.js';
+import { present } from './helpers/present.js';
+
+import {
+  checkAllServicesReady,
+  waitForPeer2Bootstrap,
+  waitForSolanaHealth,
+  skipIfNotReady,
+  PEER1_NOSTR_PUBKEY,
+  PEER1_ILP_ADDRESS,
+  SOLANA_RPC,
+  SOLANA_PROGRAM_ID,
+  DOCKER_CHAIN_EVM,
+  DOCKER_CHAIN_SOLANA,
+} from './helpers/infra-gate.js';
+import { ROLLING_SENDER_ILP } from './helpers/topology.js';
+
+const PAIR: SwapPair = {
+  from: { assetCode: 'USD', assetScale: 6, chain: DOCKER_CHAIN_EVM },
+  to: { assetCode: 'USD', assetScale: 6, chain: DOCKER_CHAIN_SOLANA },
+  rate: '1',
+};
+
+describe('Docker Rolling Swap Solana E2E (swap#153)', () => {
+  let servicesReady = false;
+  let sender: LiveSender | null = null;
+  let daemon: LegBDaemon = createLegBDaemon();
+  let solanaRecipient = '';
+  let result: RollingSwapResult | null = null;
+
+  beforeAll(async () => {
+    const ready = await checkAllServicesReady();
+    if (!ready) return;
+    const bootstrapped = await waitForPeer2Bootstrap(45_000);
+    if (!bootstrapped) return;
+    const solanaReady = await waitForSolanaHealth(30_000);
+    if (!solanaReady) return;
+    servicesReady = true;
+
+    try {
+      daemon = createLegBDaemon();
+      sender = await buildLiveSender({
+        nodeIdPrefix: 'roll-sol',
+        btpServerPort: 19936,
+        healthCheckPort: 19937,
+        loggerName: 'swap-e2e-rolling-solana-connector',
+        senderIlpAddress: ROLLING_SENDER_ILP.solana,
+        localDeliveryHandler: daemon.handler,
+      });
+      // generateSolanaKeypair() returns publicKey already base58-encoded;
+      // do NOT re-encode (that would treat the string as a byte array and
+      // throw "Cannot convert R to a BigInt" inside base58Encode).
+      solanaRecipient = generateSolanaKeypair().publicKey;
+      result = await runRollingSwap({
+        sender,
+        daemon,
+        makerPubkey: PEER1_NOSTR_PUBKEY,
+        makerIlpAddress: PEER1_ILP_ADDRESS,
+        pair: PAIR,
+        chainRecipient: solanaRecipient,
+        totalAmount: 1_000_000n,
+        packetCount: 1,
+      });
+    } catch (err) {
+      console.error('Solana rolling swap failed in beforeAll:', err);
+    }
+  }, 120_000);
+
+  afterAll(async () => {
+    if (sender) await sender.close();
+    await new Promise((r) => setTimeout(r, 250));
+  });
+
+  it('S-1 [P1] a rolling session to solana:devnet delivers leg-B claims bound to a 32-byte base58 pubkey', async (ctx) => {
+    if (skipIfNotReady(servicesReady)) return ctx.skip();
+
+    const swap = present(result, 'the Solana rolling swap result');
+    expect(
+      swap.state,
+      `rfq: ${JSON.stringify(swap.rfqReject)} rejections: ${JSON.stringify(swap.rejections)}`
+    ).toBe('completed');
+    expect(swap.claims.length).toBeGreaterThanOrEqual(1);
+    const first = present(swap.claims[0], 'the first leg-B claim');
+    expect(first.recipient).toBe(solanaRecipient);
+    expect(first.pair.to.chain).toBe(DOCKER_CHAIN_SOLANA);
+  });
+
+  it('S-2 [P1] buildSettlementTx() over the leg-B claims produces a valid Solana bundle', async (ctx) => {
+    if (skipIfNotReady(servicesReady)) return ctx.skip();
+
+    expect(
+      SOLANA_PROGRAM_ID,
+      'SOLANA_PROGRAM_ID not exported — see tests/e2e/README.md'
+    ).not.toBe('');
+    expect(SOLANA_RPC).toBe('http://localhost:19899');
+    const swap = present(result, 'the Solana rolling swap result');
+    expect(swap.claims.length).toBeGreaterThanOrEqual(1);
+
+    const lastClaim = present(swap.claims.at(-1), 'the last leg-B claim');
+    const settlement = buildSettlementTx({
+      claims: swap.claims,
+      signers: {
+        [DOCKER_CHAIN_SOLANA]: {
+          address: present(
+            lastClaim.swapSignerAddress,
+            'claim.swapSignerAddress'
+          ),
+          programId: SOLANA_PROGRAM_ID,
+        },
+      },
+      recipients: { [DOCKER_CHAIN_SOLANA]: solanaRecipient },
+      verifySignatures: false,
+    });
+
+    expect(settlement.bundles.length).toBeGreaterThanOrEqual(1);
+    const bundle = present(settlement.bundles[0], 'the settlement bundle');
+    expect(bundle.chainKind).toBe('solana');
+    expect(bundle.chain).toBe(DOCKER_CHAIN_SOLANA);
+    expect(bundle.channelId).toBe(lastClaim.channelId);
+    expect(bundle.nonce).toBe(lastClaim.nonce);
+    expect(bundle.cumulativeAmount).toBe(lastClaim.cumulativeAmount);
+    expect(bundle.recipient).toBe(solanaRecipient);
+    expect(bundle.unsignedTxBytes.length).toBeGreaterThan(0);
+    expect(bundle.claimsMerged).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/swap/tests/e2e/global-setup.ts
+++ b/packages/swap/tests/e2e/global-setup.ts
@@ -5,14 +5,18 @@
  * is collected (`vitest.e2e.config.ts`'s `pool: 'forks'` +
  * `singleFork: true` keeps every suite file in one shared test process, so
  * the infra booted here stays reachable for the whole run). Boots the
- * self-contained EVM leg only:
+ * self-contained EVM legs only:
  *
- *   1. Anvil, loaded with the vendored `rolling-e2e-anvil-state.hex` fixture
- *      (the same one `tests/integration/helpers/rolling-e2e-harness.ts`
- *      uses — one deployed TokenNetwork/Registry/USDC surface, reused here
- *      rather than redeployed).
- *   2. A minimal in-process Nostr relay (`local-nostr-relay.ts`).
- *   3. Peer1 — a real `startSwapNode()` instance (`peer-node.ts`).
+ *   1. Anvil chain A (31337), loaded with the vendored
+ *      `rolling-e2e-anvil-state.hex` fixture (the same one
+ *      `tests/integration/helpers/rolling-e2e-harness.ts` uses — one deployed
+ *      TokenNetwork/Registry/USDC surface, reused here rather than
+ *      redeployed).
+ *   2. Anvil chain B (31338) — swap#153. Same blob, different chain id, so
+ *      peer1 can advertise a pair with `from.chain !== to.chain` and the
+ *      rolling suites cross a real chain boundary with no operator infra.
+ *   3. A minimal in-process Nostr relay (`local-nostr-relay.ts`).
+ *   4. Peer1 — a real `startSwapNode()` instance (`peer-node.ts`).
  *
  * Solana and Mina are NOT started here — this repo vendors no
  * `solana-test-validator` / Mina lightnet binary or image (see
@@ -36,26 +40,41 @@ import {
   ROLLING_SWAP_CHANNEL_ADDRESS,
   MAKER_EVM_PRIVATE_KEY,
 } from '../integration/helpers/rolling-e2e-harness.js';
-import { startLocalRelay, type LocalRelay } from './helpers/local-nostr-relay.js';
+import {
+  startLocalRelay,
+  type LocalRelay,
+} from './helpers/local-nostr-relay.js';
 import { startPeerNode, type PeerNodeHandle } from './helpers/peer-node.js';
 import {
   ANVIL_PORT,
   ANVIL_CHAIN_ID,
+  ANVIL_B_PORT,
+  ANVIL_B_CHAIN_ID,
   RELAY_PORT,
   RELAY_URL,
   PEER1_BTP_PORT,
   PEER1_BLS_PORT,
   PEER1_MNEMONIC,
+  PEER1_ILP_ADDRESS,
 } from './helpers/topology.js';
 
 export default async function globalSetup(): Promise<() => Promise<void>> {
   let anvil: AnvilInstance | null = null;
+  let anvilB: AnvilInstance | null = null;
   let relay: LocalRelay | null = null;
   let peer1: PeerNodeHandle | null = null;
 
   if (isAnvilAvailable()) {
     try {
       anvil = await startAnvil({ port: ANVIL_PORT, chainId: ANVIL_CHAIN_ID });
+      // Chain B (swap#153) — the same vendored blob at a different chain id,
+      // so peer1 can advertise a pair that genuinely crosses a chain
+      // boundary. Same trick `tests/integration/rolling-settlement.
+      // integration.test.ts` uses; no new external dependency.
+      anvilB = await startAnvil({
+        port: ANVIL_B_PORT,
+        chainId: ANVIL_B_CHAIN_ID,
+      });
       relay = await startLocalRelay(RELAY_PORT);
       peer1 = await startPeerNode({
         mnemonic: PEER1_MNEMONIC,
@@ -63,7 +82,7 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
         btpServerPort: PEER1_BTP_PORT,
         blsPort: PEER1_BLS_PORT,
         relayUrls: [RELAY_URL],
-        ilpAddress: 'g.toon.peer1',
+        ilpAddress: PEER1_ILP_ADDRESS,
         evm: {
           chainId: ANVIL_CHAIN_ID,
           rpcUrl: `http://127.0.0.1:${ANVIL_PORT}`,
@@ -71,6 +90,14 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
           tokenAddress: USDC_TOKEN_ADDRESS,
           // Leg A (client opens its channel here) vs leg B (claims verify
           // here) — two different deployed contracts, issue #133.
+          tokenNetworkAddress: TOKEN_NETWORK_ADDRESS,
+          channelAddress: ROLLING_SWAP_CHANNEL_ADDRESS,
+        },
+        evmB: {
+          chainId: ANVIL_B_CHAIN_ID,
+          rpcUrl: `http://127.0.0.1:${ANVIL_B_PORT}`,
+          registryAddress: TOKEN_NETWORK_REGISTRY_ADDRESS,
+          tokenAddress: USDC_TOKEN_ADDRESS,
           tokenNetworkAddress: TOKEN_NETWORK_ADDRESS,
           channelAddress: ROLLING_SWAP_CHANNEL_ADDRESS,
         },
@@ -82,10 +109,7 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
       // `infra-gate.ts`'s probes are the authority on readiness and will
       // skip (or fail under CI) if peer1 never came up.
       const deadline = Date.now() + 15_000;
-      while (
-        peer1.instance.health().status !== 'ok' &&
-        Date.now() < deadline
-      ) {
+      while (peer1.instance.health().status !== 'ok' && Date.now() < deadline) {
         await new Promise((r) => setTimeout(r, 100));
       }
     } catch (err) {
@@ -96,9 +120,11 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
       await peer1?.stop().catch(() => undefined);
       await relay?.stop().catch(() => undefined);
       await anvil?.stop().catch(() => undefined);
+      await anvilB?.stop().catch(() => undefined);
       peer1 = null;
       relay = null;
       anvil = null;
+      anvilB = null;
     }
   }
 
@@ -106,5 +132,6 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
     await peer1?.stop().catch(() => undefined);
     await relay?.stop().catch(() => undefined);
     await anvil?.stop().catch(() => undefined);
+    await anvilB?.stop().catch(() => undefined);
   };
 }

--- a/packages/swap/tests/e2e/helpers/build-live-sender.ts
+++ b/packages/swap/tests/e2e/helpers/build-live-sender.ts
@@ -10,6 +10,7 @@
 import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
 import type { StreamSwapParams } from '@toon-protocol/sdk';
 import { ConnectorNode, createLogger } from '@toon-protocol/connector';
+import type { LocalDeliveryHandler } from '@toon-protocol/connector';
 
 import {
   PEER1_BTP_URL,
@@ -31,6 +32,11 @@ export interface LiveSender {
   senderSecretKey: Uint8Array;
   senderPubkey: string;
   channelId: string;
+  /**
+   * The ILP address this sender is reachable at — set only in rolling mode
+   * (see {@link BuildLiveSenderOptions.senderIlpAddress}).
+   */
+  senderIlpAddress?: string;
   close: () => Promise<void>;
 }
 
@@ -45,6 +51,30 @@ export interface BuildLiveSenderOptions {
   loggerName: string;
   /** Initial EVM deposit in smallest units (default: '10000000' = 10 USDC). */
   initialDeposit?: string;
+  /**
+   * ROLLING mode (swap#153). The ILP address this sender is reachable at.
+   *
+   * Setting it does three things the legacy path never needed:
+   *
+   * 1. it becomes the connector's `nodeId`, and therefore the peer id its BTP
+   *    greeting authenticates under (connector `btp/btp-client.ts` sends
+   *    `peerId: nodeId`). The maker refuses to mint a session whose RFQ
+   *    advertises a `senderIlpAddress` other than the one its arrival session
+   *    authenticated with — `leg-b-return-path.ts`, the swap#148 `F02` fix —
+   *    so the two strings have to be the same string;
+   * 2. it installs a SELF-ROUTE, so the maker's leg-B PREPARE (addressed to
+   *    this address, arriving back down the same socket) resolves to local
+   *    delivery instead of `F02 no route found`;
+   * 3. it zeroes this connector's forwarding fee, so the δ the maker prices
+   *    the fill at is the δ the test asked for and not δ minus a shave.
+   */
+  senderIlpAddress?: string;
+  /**
+   * ROLLING mode. Answers inbound leg-B PREPAREs — the sender daemon's
+   * verify-before-reveal seam (spec R5). Build one with
+   * `rolling-driver.ts`'s `createLegBDaemon()`.
+   */
+  localDeliveryHandler?: LocalDeliveryHandler;
 }
 
 /**
@@ -71,9 +101,11 @@ export async function buildLiveSender(
   );
 
   const connectorLogger = createLogger(opts.loggerName, 'warn');
+  const nodeId =
+    opts.senderIlpAddress ?? `${opts.nodeIdPrefix}-${senderPubkey.slice(0, 8)}`;
   const connector = new ConnectorNode(
     {
-      nodeId: `${opts.nodeIdPrefix}-${senderPubkey.slice(0, 8)}`,
+      nodeId,
       btpServerPort: opts.btpServerPort,
       healthCheckPort: opts.healthCheckPort,
       environment: 'development' as const,
@@ -91,8 +123,21 @@ export async function buildLiveSender(
           chain: `evm:${CHAIN_ID}`,
         },
       ],
-      routes: [],
+      // Rolling: the self-route that makes leg B deliverable back into this
+      // process. Legacy: none, exactly as before.
+      routes: opts.senderIlpAddress
+        ? [
+            {
+              prefix: opts.senderIlpAddress,
+              nextHop: nodeId,
+              priority: 100,
+            },
+          ]
+        : [],
       localDelivery: { enabled: false },
+      ...(opts.senderIlpAddress
+        ? { settlement: { connectorFeePercentage: 0 } }
+        : {}),
       chainProviders: [
         {
           chainType: 'evm' as const,
@@ -106,6 +151,12 @@ export async function buildLiveSender(
     },
     connectorLogger
   );
+
+  // Leg-B terminator. Installed BEFORE `start()` so a leg-B PREPARE can never
+  // race an unwired handler.
+  if (opts.localDeliveryHandler) {
+    connector.setLocalDeliveryHandler(opts.localDeliveryHandler);
+  }
 
   await connector.start();
 
@@ -147,10 +198,7 @@ export async function buildLiveSender(
     });
     channelId = r.channelId;
   } catch (err) {
-    if (
-      err instanceof Error &&
-      /Channel already exists/i.test(err.message)
-    ) {
+    if (err instanceof Error && /Channel already exists/i.test(err.message)) {
       // Auto-channel created by start() — recover its id by listing channels.
       // ConnectorNode does not expose a public channel-by-peer lookup, so we
       // fall back to a synthetic placeholder. The settlement assertion in
@@ -235,6 +283,7 @@ export async function buildLiveSender(
     senderSecretKey,
     senderPubkey,
     channelId,
+    ...(opts.senderIlpAddress && { senderIlpAddress: opts.senderIlpAddress }),
     close: async () => {
       try {
         await connector.stop();

--- a/packages/swap/tests/e2e/helpers/infra-gate.ts
+++ b/packages/swap/tests/e2e/helpers/infra-gate.ts
@@ -29,6 +29,7 @@ import {
   USDC_TOKEN_ADDRESS,
   TOKEN_NETWORK_REGISTRY_ADDRESS,
   TOKEN_NETWORK_ADDRESS as ROLLING_TOKEN_NETWORK_ADDRESS,
+  ROLLING_SWAP_CHANNEL_ADDRESS,
   SENDER_EVM_PRIVATE_KEY,
   SENDER_EVM_ADDRESS,
   MAKER_EVM_ADDRESS,
@@ -36,21 +37,25 @@ import {
 import {
   ANVIL_CHAIN_ID,
   ANVIL_RPC,
+  ANVIL_B_CHAIN_ID,
+  ANVIL_B_RPC,
   EVM_CHAIN_PREFIX,
   RELAY_URL,
   PEER1_BTP_URL,
   PEER1_BLS_URL,
   PEER1_NOSTR_PUBKEY,
+  PEER1_ILP_ADDRESS,
 } from './topology.js';
 
 // ---------------------------------------------------------------------------
 // Endpoints
 // ---------------------------------------------------------------------------
 
-export { ANVIL_RPC };
+export { ANVIL_RPC, ANVIL_B_RPC };
 export const PEER1_RELAY_URL = RELAY_URL;
 export { PEER1_BTP_URL };
 export { PEER1_NOSTR_PUBKEY };
+export { PEER1_ILP_ADDRESS };
 export const PEER1_EVM_ADDRESS = MAKER_EVM_ADDRESS;
 
 /**
@@ -78,6 +83,9 @@ export const TOKEN_ADDRESS = USDC_TOKEN_ADDRESS;
 export const TOKEN_NETWORK_ADDRESS = ROLLING_TOKEN_NETWORK_ADDRESS;
 export const REGISTRY_ADDRESS = TOKEN_NETWORK_REGISTRY_ADDRESS;
 export const CHAIN_ID = ANVIL_CHAIN_ID;
+export const CHAIN_B_ID = ANVIL_B_CHAIN_ID;
+/** Leg-B settlement contract — the same deterministic deployment on both anvils. */
+export const ROLLING_CHANNEL_ADDRESS = ROLLING_SWAP_CHANNEL_ADDRESS;
 
 const anvilChain: Chain = {
   id: CHAIN_ID,
@@ -95,7 +103,8 @@ export function createViemClient() {
 // for the full account allocation: #0 is peer1's settlement key)
 // ---------------------------------------------------------------------------
 
-export const SWAP_E2E_EVM_SENDER_PRIVATE_KEY = SENDER_EVM_PRIVATE_KEY as `0x${string}`;
+export const SWAP_E2E_EVM_SENDER_PRIVATE_KEY =
+  SENDER_EVM_PRIVATE_KEY as `0x${string}`;
 export const SWAP_E2E_EVM_SENDER_ADDRESS = SENDER_EVM_ADDRESS as `0x${string}`;
 
 /**
@@ -116,6 +125,13 @@ export async function publicModeSettlementKey(
 // ---------------------------------------------------------------------------
 
 export const DOCKER_CHAIN_EVM = `${EVM_CHAIN_PREFIX}${CHAIN_ID}` as const;
+/**
+ * The SECOND EVM chain (swap#153) — a distinct chain id on a distinct anvil
+ * with its own `RollingSwapChannel` deployment and therefore its own EIP-712
+ * domain. `DOCKER_CHAIN_EVM → DOCKER_CHAIN_EVM_B` is the only pair in this
+ * harness that crosses a chain boundary without operator-supplied infra.
+ */
+export const DOCKER_CHAIN_EVM_B = `${EVM_CHAIN_PREFIX}${CHAIN_B_ID}` as const;
 export const DOCKER_CHAIN_SOLANA = 'solana:devnet' as const;
 export const DOCKER_CHAIN_MINA = 'mina:devnet' as const;
 
@@ -134,6 +150,47 @@ export const DOCKER_PAIR_MATRIX: readonly {
 }[] = Object.freeze(
   DOCKER_CHAINS.flatMap((from) => DOCKER_CHAINS.map((to) => ({ from, to })))
 );
+
+// ---------------------------------------------------------------------------
+// The ROLLING matrix (swap#153)
+// ---------------------------------------------------------------------------
+
+/**
+ * The rolling matrix adds the second EVM chain, so it is 4 chains and 16
+ * ordered pairs rather than the legacy 3 and 9. That is deliberate: the extra
+ * chain is the one pair in this harness that crosses a chain boundary WITHOUT
+ * operator-supplied infra, so it is the one that actually executes in CI.
+ */
+export const ROLLING_CHAINS = [
+  DOCKER_CHAIN_EVM,
+  DOCKER_CHAIN_EVM_B,
+  DOCKER_CHAIN_SOLANA,
+  DOCKER_CHAIN_MINA,
+] as const;
+
+export type RollingChain = (typeof ROLLING_CHAINS)[number];
+
+export const ROLLING_PAIR_MATRIX: readonly {
+  from: RollingChain;
+  to: RollingChain;
+}[] = Object.freeze(
+  ROLLING_CHAINS.flatMap((from) => ROLLING_CHAINS.map((to) => ({ from, to })))
+);
+
+/**
+ * The pairs peer1 actually advertises (`peer-node.ts`). A rolling RFQ for a
+ * pair outside this set is REFUSED — `unsupported_pair` — which is a stronger
+ * statement than "skipped": the maker is asserted to say no rather than
+ * quietly quoting something it cannot deliver.
+ */
+export const PEER1_ADVERTISED_PAIRS: ReadonlySet<string> = new Set([
+  `${DOCKER_CHAIN_EVM}->${DOCKER_CHAIN_EVM}`,
+  `${DOCKER_CHAIN_EVM}->${DOCKER_CHAIN_EVM_B}`,
+]);
+
+export function peer1AdvertisesPair(from: string, to: string): boolean {
+  return PEER1_ADVERTISED_PAIRS.has(`${from}->${to}`);
+}
 
 // ---------------------------------------------------------------------------
 // Readiness probes
@@ -190,14 +247,18 @@ async function probeMinaGraphql(
   return typeof json?.data?.syncStatus === 'string';
 }
 
-async function probeAnvil(timeoutMs: number): Promise<boolean> {
+async function probeAnvilAt(
+  rpcUrl: string,
+  chainId: number,
+  timeoutMs: number
+): Promise<boolean> {
   const json = await postJson<{ result?: string }>(
-    ANVIL_RPC,
+    rpcUrl,
     { jsonrpc: '2.0', id: 1, method: 'eth_chainId', params: [] },
     timeoutMs
   );
   if (!json) return false;
-  return parseInt(json.result ?? '0x0', 16) === ANVIL_CHAIN_ID;
+  return parseInt(json.result ?? '0x0', 16) === chainId;
 }
 
 function probeRelay(timeoutMs: number): Promise<boolean> {
@@ -255,12 +316,13 @@ let cachedCoreReady: Promise<boolean> | null = null;
 let lastCoreReady = true;
 
 async function probeCore(): Promise<boolean> {
-  const [anvilOk, relayOk, peer1Ok] = await Promise.all([
-    probeAnvil(3000),
+  const [anvilOk, anvilBOk, relayOk, peer1Ok] = await Promise.all([
+    probeAnvilAt(ANVIL_RPC, ANVIL_CHAIN_ID, 3000),
+    probeAnvilAt(ANVIL_B_RPC, ANVIL_B_CHAIN_ID, 3000),
     probeRelay(3000),
     probePeer1(3000),
   ]);
-  const ready = anvilOk && relayOk && peer1Ok;
+  const ready = anvilOk && anvilBOk && relayOk && peer1Ok;
   lastCoreReady = ready;
   return ready;
 }
@@ -278,7 +340,9 @@ export function checkAllServicesReady(): Promise<boolean> {
  * peer, so this is an alias for the same core-readiness check rather than a
  * second boot.
  */
-export async function waitForPeer2Bootstrap(_timeoutMs: number): Promise<boolean> {
+export async function waitForPeer2Bootstrap(
+  _timeoutMs: number
+): Promise<boolean> {
   return checkAllServicesReady();
 }
 
@@ -316,7 +380,10 @@ export async function waitForMinaHealth(timeoutMs: number): Promise<boolean> {
   return probeMinaGraphql(MINA_GRAPHQL, timeoutMs);
 }
 
-export async function acquireMinaAccount(): Promise<{ pk: string; sk: string } | null> {
+export async function acquireMinaAccount(): Promise<{
+  pk: string;
+  sk: string;
+} | null> {
   if (!MINA_ACCOUNTS_MANAGER) return null;
   try {
     const res = await fetch(`${MINA_ACCOUNTS_MANAGER}/acquire-account`, {
@@ -360,7 +427,7 @@ export function skipIfNotReady(ready: boolean): boolean {
   if (process.env['CI'] && !lastCoreReady) {
     throw new Error(
       '[swap e2e] Self-contained EVM infra (Anvil + relay + peer1) did not ' +
-        'come up under CI — this is this harness\'s own responsibility ' +
+        "come up under CI — this is this harness's own responsibility " +
         '(devbox pins `anvil`). Check the global-setup logs rather than ' +
         'silently skipping. See tests/e2e/README.md.'
     );

--- a/packages/swap/tests/e2e/helpers/peer-node.ts
+++ b/packages/swap/tests/e2e/helpers/peer-node.ts
@@ -8,13 +8,18 @@
  * Docker required: identity, chain wiring and relay publishing are all
  * in-process, callable from `global-setup.ts`.
  *
- * Only the EVM leg is wired to live chain infra (the vendored Anvil fixture
+ * Only EVM legs are wired to live chain infra (the vendored Anvil fixture
  * from `tests/integration/helpers/rolling-e2e-harness.ts`). Solana and Mina
  * swap pairs are NOT advertised by this boot helper — those chains need
  * real external infra (`solana-test-validator`, Mina lightnet) this repo
  * does not vendor; see `tests/e2e/README.md`. The suites correctly gate on
  * `waitForSolanaHealth()` / `waitForMinaHealth()` before touching those
  * chains, so their absence here is a graceful skip, not a failure.
+ *
+ * swap#153: `evmB` adds a SECOND EVM chain, so peer1 advertises a pair whose
+ * `from.chain !== to.chain` and the rolling suites can cross a real chain
+ * boundary in CI without any infra this repo does not already vendor. See
+ * `topology.ts`'s `ANVIL_B_CHAIN_ID` for why that mattered.
  */
 
 import { startSwapNode } from '../../../src/swap-node.js';
@@ -28,6 +33,27 @@ export interface PeerNodeHandle {
   instance: SwapNodeInstance;
   pubkey: string;
   stop: () => Promise<void>;
+}
+
+/** One deployed EVM surface peer1 can price and settle against. */
+export interface PeerNodeEvmChain {
+  chainId: number;
+  rpcUrl: string;
+  registryAddress: string;
+  tokenAddress: string;
+  /**
+   * Leg A — deployed `TokenNetwork` address, the contract a client opens its
+   * payment channel against and the value the kind:10032 `tokenNetworks`
+   * entry carries (issue #133).
+   */
+  tokenNetworkAddress: string;
+  /**
+   * Leg B — deployed `RollingSwapChannel` address, the EIP-712
+   * `verifyingContract` `startSwapNode()` binds into its v2 balance-proof
+   * signer (issue #101). `validateConfig()` refuses to boot a pair targeting
+   * this chain without it (PR #106 review finding #2).
+   */
+  channelAddress: string;
 }
 
 export interface StartPeerNodeOptions {
@@ -45,25 +71,13 @@ export interface StartPeerNodeOptions {
   relayUrls: readonly string[];
   ilpAddress: string;
   /** EVM chain-provider wiring. Omit to boot without any live chain (identity/relay only). */
-  evm?: {
-    chainId: number;
-    rpcUrl: string;
-    registryAddress: string;
-    tokenAddress: string;
-    /**
-     * Leg A — deployed `TokenNetwork` address, the contract a client opens its
-     * payment channel against and the value the kind:10032 `tokenNetworks`
-     * entry carries (issue #133).
-     */
-    tokenNetworkAddress: string;
-    /**
-     * Leg B — deployed `RollingSwapChannel` address, the EIP-712
-     * `verifyingContract` `startSwapNode()` binds into its v2 balance-proof
-     * signer (issue #101). `validateConfig()` refuses to boot a pair targeting
-     * this chain without it (PR #106 review finding #2).
-     */
-    channelAddress: string;
-  };
+  evm?: PeerNodeEvmChain;
+  /**
+   * A second EVM chain (swap#153). When present, peer1 additionally advertises
+   * the CROSS-chain pair `evm → evmB` and can issue leg-B claims on it.
+   * Ignored without `evm` — leg A has to land somewhere.
+   */
+  evmB?: PeerNodeEvmChain;
   loggerName?: string;
 }
 
@@ -77,40 +91,78 @@ export interface StartPeerNodeOptions {
  * file). Today that's 2 (the EVM suite's own sender + the pair-matrix
  * suite's shared sender); sized to 8 for headroom against future suites.
  */
-const SEED_CHANNEL_COUNT = 8;
-function seedChannelId(i: number): string {
-  return '0x' + 'e2'.repeat(31) + i.toString(16).padStart(2, '0');
+const SEED_CHANNEL_COUNT = 24;
+function seedChannelId(chainOrdinal: number, i: number): string {
+  return (
+    '0x' +
+    'e2'.repeat(30) +
+    chainOrdinal.toString(16).padStart(2, '0') +
+    i.toString(16).padStart(2, '0')
+  );
+}
+
+function seedChannels(chainOrdinal: number): {
+  channelId: string;
+  cumulativeAmount: bigint;
+  nonce: bigint;
+  updatedAt: number;
+}[] {
+  return Array.from({ length: SEED_CHANNEL_COUNT }, (_, i) => ({
+    channelId: seedChannelId(chainOrdinal, i),
+    cumulativeAmount: 0n,
+    nonce: 0n,
+    updatedAt: 0,
+  }));
 }
 
 export async function startPeerNode(
   opts: StartPeerNodeOptions
 ): Promise<PeerNodeHandle> {
   const evm = opts.evm;
+  const evmB = evm ? opts.evmB : undefined;
   const chain = evm ? `${EVM_CHAIN_PREFIX}${evm.chainId}` : undefined;
+  const chainB = evmB ? `${EVM_CHAIN_PREFIX}${evmB.chainId}` : undefined;
+
+  const asset = { assetCode: 'USD', assetScale: 6 } as const;
 
   const config: SwapNodeConfig = {
     mnemonic: opts.mnemonic,
     swapPairs: chain
       ? [
+          // Same-chain pair — what peer1 has always advertised, and what the
+          // legacy suites still drive. Also the shape the live devnet maker
+          // advertises today (a USDC-at-parity placeholder).
           {
-            from: { assetCode: 'USD', assetScale: 6, chain },
-            to: { assetCode: 'USD', assetScale: 6, chain },
+            from: { ...asset, chain },
+            to: { ...asset, chain },
             rate: '1',
           },
+          // Cross-chain pair (swap#153) — a real chain boundary: leg A on
+          // `chain`, leg-B claim signed for `chainB`'s own EIP-712 domain.
+          ...(chainB
+            ? [
+                {
+                  from: { ...asset, chain },
+                  to: { ...asset, chain: chainB },
+                  rate: '1',
+                },
+              ]
+            : []),
         ]
       : [],
     chains: evm ? ['evm'] : [],
     channels: chain
       ? {
-          [chain]: Array.from({ length: SEED_CHANNEL_COUNT }, (_, i) => ({
-            channelId: seedChannelId(i),
-            cumulativeAmount: 0n,
-            nonce: 0n,
-            updatedAt: 0,
-          })),
+          [chain]: seedChannels(0),
+          ...(chainB ? { [chainB]: seedChannels(1) } : {}),
         }
       : {},
-    inventory: chain ? { [chain]: 100_000_000_000n } : {},
+    inventory: chain
+      ? {
+          [chain]: 100_000_000_000n,
+          ...(chainB ? { [chainB]: 100_000_000_000n } : {}),
+        }
+      : {},
     logger: {
       debug: () => undefined,
       info: () => undefined,
@@ -124,20 +176,35 @@ export async function startPeerNode(
     btpEndpoint: `ws://127.0.0.1:${opts.btpServerPort}`,
     advertisedAsset: { assetCode: 'USD', assetScale: 6 },
     settlementPrivateKey: opts.evmPrivateKey,
-    chainProviders: evm && chain
-      ? [
-          {
-            chainType: 'evm' as const,
-            chainId: chain,
-            rpcUrl: evm.rpcUrl,
-            registryAddress: evm.registryAddress,
-            tokenAddress: evm.tokenAddress,
-            tokenNetworkAddress: evm.tokenNetworkAddress,
-            channelAddress: evm.channelAddress,
-            keyId: opts.evmPrivateKey,
-          },
-        ]
-      : [],
+    chainProviders:
+      evm && chain
+        ? [
+            {
+              chainType: 'evm' as const,
+              chainId: chain,
+              rpcUrl: evm.rpcUrl,
+              registryAddress: evm.registryAddress,
+              tokenAddress: evm.tokenAddress,
+              tokenNetworkAddress: evm.tokenNetworkAddress,
+              channelAddress: evm.channelAddress,
+              keyId: opts.evmPrivateKey,
+            },
+            ...(evmB && chainB
+              ? [
+                  {
+                    chainType: 'evm' as const,
+                    chainId: chainB,
+                    rpcUrl: evmB.rpcUrl,
+                    registryAddress: evmB.registryAddress,
+                    tokenAddress: evmB.tokenAddress,
+                    tokenNetworkAddress: evmB.tokenNetworkAddress,
+                    channelAddress: evmB.channelAddress,
+                    keyId: opts.evmPrivateKey,
+                  },
+                ]
+              : []),
+          ]
+        : [],
   };
 
   const instance = await startSwapNode(config);

--- a/packages/swap/tests/e2e/helpers/present.ts
+++ b/packages/swap/tests/e2e/helpers/present.ts
@@ -1,0 +1,23 @@
+/**
+ * A narrowing guard for E2E fixtures built in `beforeAll`.
+ *
+ * These suites build their sender, session and swap result once in
+ * `beforeAll` and read them from several `it()` bodies, which in TypeScript
+ * means `T | null` at every use site. The obvious spelling is `fixture!`, and
+ * the repo's lint gate counts every one of those (`@typescript-eslint/
+ * no-non-null-assertion`) — a frozen ceiling exists precisely so a growing
+ * pile of `!` cannot creep in unnoticed.
+ *
+ * `present()` narrows for real: it throws a named error naming the fixture,
+ * which is also a better failure than `Cannot read properties of null` when a
+ * `beforeAll` silently failed.
+ */
+export function present<T>(value: T | null | undefined, what: string): T {
+  if (value === null || value === undefined) {
+    throw new Error(
+      `${what} is missing — its beforeAll almost certainly failed; check the ` +
+        'console output above for the boot error.'
+    );
+  }
+  return value;
+}

--- a/packages/swap/tests/e2e/helpers/rolling-driver.ts
+++ b/packages/swap/tests/e2e/helpers/rolling-driver.ts
@@ -1,0 +1,563 @@
+/**
+ * swap#153 — the ROLLING sender, for the Docker cross-chain E2E harness.
+ *
+ * This is the replacement for `streamSwap()` in `tests/e2e/`: the four suites
+ * there drove the legacy zero-condition sender, which ADR 0003 removes. What
+ * they get instead is the coupled-leg protocol, driven over the same real BTP
+ * socket against the same real `startSwapNode()` peer1:
+ *
+ * ```
+ *  sender connector (peerId == its own ILP address)
+ *     │  leg 0  PREPARE amount=0, kind:20033 RFQ gift wrap ──▶ peer1
+ *     │  ◀──────────────── FULFILL kind:20034 quote
+ *     │  leg A  PREPARE δ + sender-minted condition Cᵢ ──────▶ peer1
+ *     │             (+ a REAL chain-A per-packet claim, attached
+ *     │              by this connector's PerPacketClaimService)
+ *     │                                     peer1 issues the chain-B claim …
+ *     │  ◀── leg B  PREPARE(advance, Cᵢ)    … back down THIS session
+ *     │  ────────────────── FULFILL(Pᵢ) ──▶   (verify-before-reveal, R5)
+ *     │  ◀──────────────── FULFILL(Pᵢ) for leg A
+ * ```
+ *
+ * ## Why the sender is a `ConnectorNode` and not a `BtpRuntimeClient`
+ *
+ * `src/swap-node.leg-b-wire.test.ts` drives the maker from a raw
+ * `BtpRuntimeClient` because it only needs leg 0 (amount 0) and a synthetic
+ * leg B. These suites need a leg A that is genuinely PAID: δ > 0 means the
+ * maker's `InboundClaimValidator` demands a payment-channel claim it can
+ * verify against a real on-chain channel. The `ConnectorNode` the legacy
+ * suites already built (`build-live-sender.ts`) opens that channel on the
+ * harness Anvil and signs those claims, so it is what the rolling port keeps —
+ * with two additions that the legacy path never needed and that
+ * `build-live-sender.ts` documents: the connector's `nodeId` IS its ILP
+ * address (the maker will not mint a session it cannot answer), and a
+ * local-delivery handler terminates leg B.
+ *
+ * ## What the daemon verifies, and what it deliberately does not
+ *
+ * The leg-B daemon here enforces the structural half of spec R5 —
+ * recipient equality, a strictly monotone (nonce, cumulativeAmount)
+ * watermark, Δcumulative covering the advance's `targetAmount`, and the
+ * `swapSignerAddress` the quote promised. It does NOT re-verify the v2
+ * EIP-712 balance-proof signature: `tests/integration/
+ * rolling-settlement.integration.test.ts` already runs the real client
+ * pipeline (`ingestReceivedClaims`) for that, against a chain it also
+ * settles on. Duplicating it here would add a second copy of the digest's
+ * domain wiring without covering anything the routing-shaped defects this
+ * harness exists to catch (`F02`, `T00`) live in.
+ */
+
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
+import type { UnsignedEvent } from 'nostr-tools';
+import type {
+  LocalDeliveryHandler,
+  LocalDeliveryRequest,
+  LocalDeliveryResponse,
+} from '@toon-protocol/connector';
+import { wrapSwapPacketToToon, unwrapSwapPacket } from '@toon-protocol/sdk';
+import type { AccumulatedClaim } from '@toon-protocol/sdk';
+import type { SwapPair } from '@toon-protocol/core';
+import {
+  ROLLING_PROTOCOL,
+  ROLLING_RFQ_REQUEST_KIND,
+  ROLLING_RFQ_RESPONSE_KIND,
+} from '@toon-protocol/swap';
+import type {
+  RollingAcceptRecord,
+  RollingAdvancePayload,
+  RollingRfqResponse,
+} from '@toon-protocol/swap';
+
+import type { LiveSender } from './build-live-sender.js';
+
+/** ILP FULFILL / REJECT discriminants (`@toon-protocol/shared` PacketType). */
+const PACKET_TYPE_FULFILL = 13;
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+/** A fresh 16-byte session id, lowercase hex (spec §2.1). */
+export function randomStreamNonce(): string {
+  const bytes = new Uint8Array(16);
+  globalThis.crypto.getRandomValues(bytes);
+  return bytesToHex(bytes);
+}
+
+function decodeUtf8(data: Buffer | Uint8Array | string | undefined): string {
+  if (data === undefined) return '';
+  if (typeof data === 'string')
+    return Buffer.from(data, 'base64').toString('utf8');
+  return Buffer.from(data).toString('utf8');
+}
+
+/** `data.reason` off a rolling reject body, whatever encoding it arrived in. */
+export function rejectReason(
+  data: Buffer | Uint8Array | string | undefined
+): string | undefined {
+  const text = decodeUtf8(data);
+  if (!text) return undefined;
+  try {
+    return (JSON.parse(text) as { reason?: string }).reason;
+  } catch {
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The leg-B daemon (the sender's half of the coupling)
+// ---------------------------------------------------------------------------
+
+export interface LegBRefusal {
+  seq: number;
+  reason: string;
+}
+
+export interface LegBDaemon {
+  /** Hand this to `buildLiveSender({ localDeliveryHandler })`. */
+  handler: LocalDeliveryHandler;
+  /** Mint a fresh `(Pᵢ, Cᵢ)` pair for the next fill. */
+  mint(): { preimage: Uint8Array; conditionB64: string };
+  /** Every leg-B advance that crossed the socket, in arrival order. */
+  advances: RollingAdvancePayload[];
+  /** One `AccumulatedClaim` per advance the daemon actually revealed for. */
+  claims: AccumulatedClaim[];
+  /** Advances refused by the R5 checks (never revealed for). */
+  refusals: LegBRefusal[];
+  /** Flip to `false` to withhold the preimage (spec R5/R8 withhold case). */
+  reveal: boolean;
+  /** Set by `openRollingSession()` once the quote is in hand. */
+  session: {
+    pair: SwapPair;
+    chainRecipient: string;
+    swapSignerAddress?: string;
+  } | null;
+}
+
+export function createLegBDaemon(): LegBDaemon {
+  const preimages = new Map<string, Uint8Array>();
+  /** Per-channel watermark, so a multi-fill session is checked as a stream. */
+  const watermark = new Map<string, { nonce: bigint; cumulative: bigint }>();
+
+  const daemon: LegBDaemon = {
+    reveal: true,
+    advances: [],
+    claims: [],
+    refusals: [],
+    session: null,
+    mint() {
+      const preimage = new Uint8Array(32);
+      globalThis.crypto.getRandomValues(preimage);
+      const conditionB64 = Buffer.from(sha256(preimage)).toString('base64');
+      preimages.set(conditionB64, preimage);
+      return { preimage, conditionB64 };
+    },
+    handler: async (
+      request: LocalDeliveryRequest
+    ): Promise<LocalDeliveryResponse> => {
+      let advance: RollingAdvancePayload;
+      try {
+        advance = JSON.parse(
+          Buffer.from(request.data, 'base64').toString('utf8')
+        ) as RollingAdvancePayload;
+      } catch {
+        return { reject: { code: 'F99', message: 'leg B was not JSON' } };
+      }
+      if (advance.proto !== ROLLING_PROTOCOL || advance.type !== 'advance') {
+        return { reject: { code: 'F99', message: 'not a rolling advance' } };
+      }
+      daemon.advances.push(advance);
+
+      const refuse = (reason: string): LocalDeliveryResponse => {
+        daemon.refusals.push({ seq: advance.seq, reason });
+        return { reject: { code: 'F99', message: reason } };
+      };
+
+      const expected = daemon.session;
+      if (!expected) return refuse('no session armed on the daemon');
+      if (advance.recipient !== expected.chainRecipient) {
+        return refuse(
+          `recipient mismatch: ${String(advance.recipient)} != ${expected.chainRecipient}`
+        );
+      }
+      if (
+        expected.swapSignerAddress !== undefined &&
+        advance.swapSignerAddress !== expected.swapSignerAddress
+      ) {
+        return refuse(
+          `signer mismatch: ${String(advance.swapSignerAddress)} != ${expected.swapSignerAddress}`
+        );
+      }
+      if (!advance.claim || advance.claim.length === 0) {
+        return refuse('advance carried no signed claim');
+      }
+      const channelId = advance.channelId;
+      if (!channelId) return refuse('advance carried no channelId');
+      if (
+        advance.nonce === undefined ||
+        advance.cumulativeAmount === undefined
+      ) {
+        return refuse('advance carried no balance-proof watermark');
+      }
+
+      const nonce = BigInt(advance.nonce);
+      const cumulative = BigInt(advance.cumulativeAmount);
+      const target = BigInt(advance.targetAmount);
+      const prev = watermark.get(channelId) ?? { nonce: -1n, cumulative: 0n };
+      if (nonce <= prev.nonce) {
+        return refuse(`nonce not monotone: ${nonce} <= ${prev.nonce}`);
+      }
+      if (cumulative - prev.cumulative < target) {
+        return refuse(
+          `Δcumulative ${cumulative - prev.cumulative} does not cover targetAmount ${target}`
+        );
+      }
+
+      if (!daemon.reveal) {
+        // Withhold. Per R8 the claim is void, so the watermark is NOT
+        // advanced — the maker rolls its own back and reuses the nonce.
+        return { reject: { code: 'T00', message: 'reveal withheld (test)' } };
+      }
+
+      const preimage = preimages.get(request.executionCondition ?? '');
+      if (!preimage) {
+        return refuse('no preimage for this execution condition');
+      }
+
+      watermark.set(channelId, { nonce, cumulative });
+      daemon.claims.push({
+        packetIndex: advance.seq,
+        sourceAmount: BigInt(advance.sourceAmount),
+        targetAmount: target,
+        claimBytes: new Uint8Array(Buffer.from(advance.claim, 'base64')),
+        swapEphemeralPubkey: '0'.repeat(64),
+        pair: expected.pair,
+        receivedAt: Date.now(),
+        channelId,
+        nonce: advance.nonce,
+        cumulativeAmount: advance.cumulativeAmount,
+        ...(advance.recipient !== undefined && {
+          recipient: advance.recipient,
+        }),
+        ...(advance.swapSignerAddress !== undefined && {
+          swapSignerAddress: advance.swapSignerAddress,
+        }),
+        rate: advance.rate,
+        rateTimestamp: advance.rateTimestamp,
+      });
+
+      return {
+        fulfill: {
+          fulfillment: Buffer.from(preimage).toString('base64'),
+          data: Buffer.from('{}', 'utf8').toString('base64'),
+        },
+      };
+    },
+  };
+  return daemon;
+}
+
+// ---------------------------------------------------------------------------
+// Leg 0 — the RFQ
+// ---------------------------------------------------------------------------
+
+export interface OpenRollingSessionParams {
+  sender: LiveSender;
+  /** peer1's Nostr pubkey — the gift wrap's recipient. */
+  makerPubkey: string;
+  /** peer1's ILP address — every leg of the session is addressed here. */
+  makerIlpAddress: string;
+  pair: SwapPair;
+  /** The sender's payout address on `pair.to.chain`. */
+  chainRecipient: string;
+  daemon: LegBDaemon;
+  streamNonce?: string;
+  sizeHint?: string;
+  /**
+   * Override the `senderIlpAddress` the RFQ advertises. Defaults to the
+   * sender's real one; a test passes something else to prove the maker
+   * refuses a session it could not answer (swap#148 `F02`).
+   */
+  advertiseIlpAddress?: string;
+}
+
+export type OpenRollingSessionResult =
+  | { ok: true; session: RollingSession }
+  | { ok: false; code: string; reason?: string; message?: string };
+
+export interface RollingSession {
+  streamNonce: string;
+  quote: RollingRfqResponse;
+  pair: SwapPair;
+  chainRecipient: string;
+  daemon: LegBDaemon;
+  /** Send one coupled fill. */
+  fill(params: { seq: number; amount: bigint }): Promise<FillOutcome>;
+}
+
+export type FillOutcome =
+  | {
+      accepted: true;
+      seq: number;
+      accept: RollingAcceptRecord;
+      /** The preimage the maker relayed back — proof of the coupling (R6). */
+      fulfillment: Uint8Array;
+      preimage: Uint8Array;
+    }
+  | {
+      accepted: false;
+      seq: number;
+      code: string;
+      message: string;
+      reason?: string;
+    };
+
+function rfqGiftWrapData(params: {
+  content: string;
+  senderSecretKey: Uint8Array;
+  makerPubkey: string;
+  makerIlpAddress: string;
+}): Buffer {
+  const rumor = {
+    kind: ROLLING_RFQ_REQUEST_KIND,
+    content: params.content,
+    tags: [],
+    created_at: Math.floor(Date.now() / 1000),
+    pubkey: '',
+  } as unknown as UnsignedEvent;
+  const { ilpPrepare } = wrapSwapPacketToToon({
+    rumor,
+    senderSecretKey: params.senderSecretKey,
+    recipientPubkey: params.makerPubkey,
+    destination: params.makerIlpAddress,
+    amount: 1000n,
+  });
+  return Buffer.from(ilpPrepare.data, 'base64');
+}
+
+/**
+ * Run leg 0 and, on a quote, hand back a session that can send fills.
+ *
+ * The RFQ is deliberately sent through the SAME connector the fills go out
+ * on: the maker binds this session's leg-B return path off the BTP session
+ * the RFQ arrived on, so an RFQ that took a different path would mint a
+ * session whose leg B could not be delivered — the exact defect swap#148 fixed.
+ */
+export async function openRollingSession(
+  params: OpenRollingSessionParams
+): Promise<OpenRollingSessionResult> {
+  const { sender, makerPubkey, makerIlpAddress, pair, chainRecipient, daemon } =
+    params;
+  const streamNonce = params.streamNonce ?? randomStreamNonce();
+  const senderIlpAddress =
+    params.advertiseIlpAddress ?? sender.senderIlpAddress;
+  if (!senderIlpAddress) {
+    throw new Error(
+      'openRollingSession requires a sender built with `senderIlpAddress` — ' +
+        'the maker refuses a session whose RFQ address is not the peer id its ' +
+        'BTP session authenticated under (leg-b-return-path.ts).'
+    );
+  }
+
+  const content = JSON.stringify({
+    proto: ROLLING_PROTOCOL,
+    type: 'rfq',
+    streamNonce,
+    pair: { from: pair.from, to: pair.to },
+    chainRecipient,
+    senderIlpAddress,
+    ...(params.sizeHint !== undefined && { sizeHint: params.sizeHint }),
+  });
+
+  const result = await sender.connector.sendPacket({
+    destination: makerIlpAddress,
+    // Leg 0 is free: quoting must never cost the sender anything (spec §2.2),
+    // and a zero-amount PREPARE also skips the maker's inbound claim gate.
+    amount: 0n,
+    expiresAt: new Date(Date.now() + 20_000),
+    data: rfqGiftWrapData({
+      content,
+      senderSecretKey: sender.senderSecretKey,
+      makerPubkey,
+      makerIlpAddress,
+    }),
+  });
+
+  if ((result.type as number) !== PACKET_TYPE_FULFILL) {
+    const rejected = result as {
+      code?: string;
+      message?: string;
+      data?: Buffer;
+    };
+    const reason = rejectReason(rejected.data);
+    return {
+      ok: false,
+      code: rejected.code ?? 'F00',
+      ...(reason !== undefined && { reason }),
+      ...(rejected.message !== undefined && { message: rejected.message }),
+    };
+  }
+
+  const fulfilled = result as { data?: Buffer };
+  const giftWrap = JSON.parse(decodeUtf8(fulfilled.data));
+  const { rumor } = unwrapSwapPacket({
+    giftWrap,
+    recipientSecretKey: sender.senderSecretKey,
+  });
+  if (rumor.kind !== ROLLING_RFQ_RESPONSE_KIND) {
+    throw new Error(
+      `RFQ answered with rumor kind ${rumor.kind}, expected ${ROLLING_RFQ_RESPONSE_KIND}`
+    );
+  }
+  const quote = JSON.parse(rumor.content) as RollingRfqResponse;
+
+  daemon.session = {
+    pair,
+    chainRecipient,
+    ...(quote.swapSignerAddress !== undefined && {
+      swapSignerAddress: quote.swapSignerAddress,
+    }),
+  };
+
+  const session: RollingSession = {
+    streamNonce,
+    quote,
+    pair,
+    chainRecipient,
+    daemon,
+    async fill({ seq, amount }): Promise<FillOutcome> {
+      const { preimage, conditionB64 } = daemon.mint();
+      const outcome = await sender.connector.sendPacket({
+        destination: makerIlpAddress,
+        amount,
+        expiresAt: new Date(Date.now() + 30_000),
+        data: Buffer.from(
+          JSON.stringify({
+            proto: ROLLING_PROTOCOL,
+            type: 'fill',
+            streamNonce,
+            seq,
+          }),
+          'utf8'
+        ),
+        executionCondition: conditionB64,
+      });
+
+      if ((outcome.type as number) !== PACKET_TYPE_FULFILL) {
+        const rejected = outcome as {
+          code?: string;
+          message?: string;
+          data?: Buffer;
+        };
+        const reason = rejectReason(rejected.data);
+        return {
+          accepted: false,
+          seq,
+          code: rejected.code ?? 'F00',
+          message: rejected.message ?? 'fill rejected',
+          ...(reason !== undefined && { reason }),
+        };
+      }
+
+      const fulfill = outcome as { fulfillment?: Uint8Array; data?: Buffer };
+      const accept = JSON.parse(
+        decodeUtf8(fulfill.data)
+      ) as RollingAcceptRecord;
+      return {
+        accepted: true,
+        seq,
+        accept,
+        fulfillment: new Uint8Array(fulfill.fulfillment ?? new Uint8Array()),
+        preimage,
+      };
+    },
+  };
+
+  return { ok: true, session };
+}
+
+// ---------------------------------------------------------------------------
+// The whole swap, in one call — the `streamSwap()`-shaped convenience
+// ---------------------------------------------------------------------------
+
+export interface RollingSwapResult {
+  /** `'completed'` iff every fill was accepted and every leg B was answered. */
+  state: 'completed' | 'failed';
+  /** Claims the daemon accepted on LEG B — where the value now travels. */
+  claims: AccumulatedClaim[];
+  accepts: RollingAcceptRecord[];
+  advances: RollingAdvancePayload[];
+  rejections: { seq: number; code: string; message: string; reason?: string }[];
+  streamNonce: string;
+  quote: RollingRfqResponse | null;
+  /** Set when leg 0 itself was refused (no session was ever minted). */
+  rfqReject?: { code: string; reason?: string; message?: string };
+}
+
+export interface RunRollingSwapParams extends Omit<
+  OpenRollingSessionParams,
+  'daemon'
+> {
+  daemon?: LegBDaemon;
+  /** Total source-asset notional, split evenly across `packetCount` fills. */
+  totalAmount: bigint;
+  packetCount: number;
+}
+
+/**
+ * RFQ + N coupled fills, shaped so a ported suite reads like the
+ * `streamSwap()` one it replaces (`state`, `claims`, `rejections`).
+ */
+export async function runRollingSwap(
+  params: RunRollingSwapParams
+): Promise<RollingSwapResult> {
+  const daemon = params.daemon ?? createLegBDaemon();
+  const opened = await openRollingSession({ ...params, daemon });
+  if (!opened.ok) {
+    return {
+      state: 'failed',
+      claims: [],
+      accepts: [],
+      advances: daemon.advances,
+      rejections: [],
+      streamNonce: params.streamNonce ?? '',
+      quote: null,
+      rfqReject: {
+        code: opened.code,
+        ...(opened.reason !== undefined && { reason: opened.reason }),
+        ...(opened.message !== undefined && { message: opened.message }),
+      },
+    };
+  }
+
+  const { session } = opened;
+  const packetCount = Math.max(1, params.packetCount);
+  const delta = params.totalAmount / BigInt(packetCount);
+  const accepts: RollingAcceptRecord[] = [];
+  const rejections: RollingSwapResult['rejections'] = [];
+
+  for (let seq = 1; seq <= packetCount; seq++) {
+    const outcome = await session.fill({ seq, amount: delta });
+    if (outcome.accepted) {
+      accepts.push(outcome.accept);
+    } else {
+      rejections.push({
+        seq,
+        code: outcome.code,
+        message: outcome.message,
+        ...(outcome.reason !== undefined && { reason: outcome.reason }),
+      });
+    }
+  }
+
+  return {
+    state: rejections.length === 0 ? 'completed' : 'failed',
+    claims: daemon.claims,
+    accepts,
+    advances: daemon.advances,
+    rejections,
+    streamNonce: session.streamNonce,
+    quote: session.quote,
+  };
+}

--- a/packages/swap/tests/e2e/helpers/topology.ts
+++ b/packages/swap/tests/e2e/helpers/topology.ts
@@ -33,6 +33,27 @@ export const ANVIL_CHAIN_ID = 31337;
 export const ANVIL_RPC = `http://127.0.0.1:${ANVIL_PORT}`;
 
 /**
+ * Chain **B** — a SECOND anvil, loaded with the same vendored state blob at a
+ * different chain id (swap#153).
+ *
+ * Why it exists: before this, every suite in `tests/e2e/` that actually
+ * EXECUTED ran `evm:base:31337 → evm:base:31337`. The Solana and Mina suites,
+ * and 8 of the pair matrix's 9 pairs, skip for want of infra this repo does not
+ * vendor — so the "multi-chain E2E harness" never once crossed a chain boundary
+ * in CI. `tests/integration/rolling-settlement.integration.test.ts` (swap#50)
+ * had already shown a chain boundary can be crossed with nothing but a second
+ * `anvil`, so the rolling port takes the same route: leg A settles on
+ * {@link ANVIL_CHAIN_ID}, leg-B claims are signed for {@link ANVIL_B_CHAIN_ID}.
+ *
+ * This is a genuinely different chain — different chain id, different RPC,
+ * different `RollingSwapChannel` deployment, its own EIP-712 domain — not a
+ * relabelling of the same one.
+ */
+export const ANVIL_B_PORT = 18546;
+export const ANVIL_B_CHAIN_ID = 31338;
+export const ANVIL_B_RPC = `http://127.0.0.1:${ANVIL_B_PORT}`;
+
+/**
  * Prefix of the EVM chain string peer1 advertises and the suites gate on.
  * Shared so `peer-node.ts` (which builds peer1's swapPairs) and
  * `infra-gate.ts` (which builds `DOCKER_CHAIN_EVM`) can never disagree —
@@ -49,3 +70,31 @@ export const PEER1_BTP_PORT = 18902;
 export const PEER1_BTP_URL = `ws://127.0.0.1:${PEER1_BTP_PORT}`;
 export const PEER1_BLS_PORT = 18903;
 export const PEER1_BLS_URL = `http://127.0.0.1:${PEER1_BLS_PORT}`;
+
+/** Peer1's own ILP address — the destination every RFQ and leg-A fill targets. */
+export const PEER1_ILP_ADDRESS = 'g.toon.peer1';
+
+/**
+ * ILP addresses the ROLLING senders authenticate their BTP sessions under.
+ *
+ * On the rolling path this string is load-bearing in a way it never was on the
+ * legacy path: the maker will only mint a session it can answer, and it decides
+ * that by comparing the RFQ's `senderIlpAddress` against the peer id the
+ * arriving BTP session authenticated with (`leg-b-return-path.ts` —
+ * `sourcePeer === senderIlpAddress`). A `ConnectorNode` greets with its
+ * `nodeId` verbatim (connector `btp/btp-client.ts`), so for a rolling sender
+ * the nodeId IS its ILP address, and `build-live-sender.ts` installs the
+ * matching self-route so leg B lands on its local-delivery handler.
+ *
+ * One per suite: peer1 is shared across every suite file in the run
+ * (`vitest.e2e.config.ts` — `singleFork`, `isolate: false`), and two live BTP
+ * sessions may not claim the same peer id.
+ */
+export const ROLLING_SENDER_ILP = {
+  evm: 'g.toon.client.e2erollevm',
+  crossChain: 'g.toon.client.e2erollxc',
+  solana: 'g.toon.client.e2erollsol',
+  mina: 'g.toon.client.e2erollmina',
+  matrix: 'g.toon.client.e2erollmtx',
+  routing: 'g.toon.client.e2erollroute',
+} as const;


### PR DESCRIPTION
Stage 2c of [toon-meta#411](https://github.com/toon-protocol/toon-meta/issues/411). **Removes nothing.** The four legacy `streamSwap` suites stay exactly as they are and still run — Stage 5 is what deletes the maker's legacy intake, and until the rolling suites are proven these are the only multi-chain end-to-end swap coverage the project has.

## Six rolling suites, on the real wire seam

kind:20033 RFQ → kind:20034 quote → coupled fills with a real 32-byte sender-minted execution condition, over the same real BTP socket against the same real `startSwapNode()` peer1. Leg A is genuinely **paid** — δ > 0 means the maker's `InboundClaimValidator` demands a chain-A payment-channel claim it can verify on chain — and leg B comes back down the same session into a sender daemon that verifies before it reveals (spec R5).

That is why the sender stays a `ConnectorNode` (it opens the channel and signs the claims) rather than the bare `BtpRuntimeClient` that `src/swap-node.leg-b-wire.test.ts` uses, with two additions the legacy path never needed:

- **its `nodeId` IS its ILP address** — the maker refuses to mint a session whose RFQ advertises an address other than the peer id its arrival session authenticated under (`leg-b-return-path.ts`, the swap#148 `F02` fix), so the two have to be one string;
- **a local-delivery handler terminates leg B**, which is the seam a stock client installs its rolling leg-B router on.

## The harness had never actually crossed a chain boundary

`tests/e2e/` is the project's multi-chain E2E swap coverage on paper. In CI the Solana suite, the Mina suite and 8 of the 9 matrix pairs all skip for want of infra this repo does not vendor — so the only pair that has **ever executed** here is `evm:base:31337 → evm:base:31337`. A same-chain swap at parity.

A port that preserved that faithfully would have preserved nothing. So `global-setup.ts` now boots a **second anvil (31338)** with the same vendored state blob — exactly what `tests/integration/rolling-settlement.integration.test.ts` already did — and peer1 advertises `evm:base:31337 → evm:base:31338`: different chain id, different RPC, different `RollingSwapChannel` deployment, different EIP-712 domain. One extra process, no new dependency, and `from.chain !== to.chain` on every CI run.

`docker-rolling-swap-cross-chain-e2e.test.ts` asserts the claims are issued on the **target** chain, to the target chain's recipient (deliberately not the address the sender's chain-A key controls, so a mis-bound claim cannot pass by coincidence), and that N cross-chain fills net to one settlement bundle in chain B's own domain.

## Chain families: what is covered, and what is not

| family | rolling coverage | why |
| --- | --- | --- |
| EVM → EVM (same chain) | **executes** | peer1's advertised parity pair — the shape the live devnet maker runs |
| EVM → EVM (31337 → 31338) | **executes** | the second anvil; a real chain boundary with no operator infra |
| Solana | **skips**, suite retained | infra-blocked only, not code-blocked. A local `solana-test-validator` cloning the real devnet program (so PDAs match, as the toon-meta#394 T6 rig did) is enough; `peer-node.ts` is now multi-chain-shaped so wiring the pair is config, not a rewrite |
| Mina | **skips**, suite retained | needs a lightnet **and** the SDK's Mina settlement builder, still a stub (Story 12.6 AC-9). The suite asserts the honest thing: a Mina claim reaches the Mina builder and is refused there |

The live devnet maker is EVM-only and its announced pair is a same-chain USDC-at-parity placeholder, so real cross-chain is not exercisable against devnet today — the harness is where that coverage lives, and now it genuinely does.

## Routing shapes (swap#148)

Both failure modes are covered against a real connector, because both are invisible to a unit test — the addresses were right, the sessions registered, and what was missing was a routing-table entry and a peer relation:

- **`F02`** — an RFQ advertising an unreachable address is refused at leg 0, where failing is free, and no route is invented for it.
- **`T00`** — leg B is value-bearing, so a next hop that is not `child` is refused *"No payment channel available for peer"* **before** the packet reaches the wire. Demote the return peer and delivery stops; restore it and it resumes, carrying the sender-minted condition verbatim and returning the preimage.

`docker-rolling-leg-b-routing-e2e.test.ts` boots its own standalone maker because `global-setup.ts` runs peer1 in the Vitest globalSetup process, so a suite file cannot reach its routing table or peer relations — and those two things are the assertions.

## Collected tests, per suite

Suites that collect zero and still report a pass are this harness's own history (swap#106), so the counts are the claim, not the colour:

| suite | before | after |
| --- | --- | --- |
| `docker-swap-flow-evm-e2e` (legacy) | 4 | 4 |
| `docker-swap-flow-solana-e2e` (legacy) | 2 | 2 |
| `docker-swap-flow-mina-e2e` (legacy) | 2 | 2 |
| `docker-swap-flow-pair-matrix-e2e` (legacy) | 10 | 10 |
| `docker-rolling-swap-evm-e2e` | — | 5 |
| `docker-rolling-swap-cross-chain-e2e` | — | 3 |
| `docker-rolling-swap-pair-matrix-e2e` | — | 17 |
| `docker-rolling-swap-solana-e2e` | — | 2 |
| `docker-rolling-swap-mina-e2e` | — | 2 |
| `docker-rolling-leg-b-routing-e2e` | — | 3 |
| **total** | **18** (14 passed, 4 skipped) | **50** (42 passed, 8 skipped) |

The rolling matrix is 16 ordered pairs over 4 chains rather than 9 over 3, and a pair peer1 does **not** advertise is asserted to be refused `unsupported_pair` rather than skipped — the legacy matrix could only skip, so "the maker quotes a pair it cannot deliver" would have passed there. Four EVM pairs now execute where one did.

## Constraints honoured

- **No product code changed** — the diff is `packages/swap/tests/e2e/` only.
- **No new required config key** (swap#134 crash-looped the live maker on one). `peer-node.ts`'s `evmB` is an optional field on a test helper.
- Nothing deleted: both families coexist until Stage 5's exit criterion is met.
- `tests/integration/helpers/fixture-topology.ts` — which Stage 5 deletes — is imported by **no** suite in `tests/e2e/`, legacy or rolling.
- No devnet ssh, no paid or on-chain operation.

## Local gate

`pnpm run gate:correctness` → lint 0 errors / 352 warnings against the frozen 352 (the new suites use a `present()` narrowing guard rather than `!` so the ratchet did not need loosening), typecheck 4 errors against a frozen 25. `pnpm test` 517 passed. `test:integration` 34 passed / 1 skipped. `test:e2e:docker` 42 passed / 8 skipped across 10 files.

Closes #153
Part of toon-protocol/toon-meta#411

🤖 Generated with [Claude Code](https://claude.com/claude-code)
