### PR TITLE
@toon-protocol/swap is frozen at 2.1.0: 22 of 26 changesets bump nothing (#168)

### DIFF
--- a/.changeset/announce-nip40-expiration-and-refresh.md
+++ b/.changeset/announce-nip40-expiration-and-refresh.md
@@ -1,4 +1,5 @@
 ---
+'@toon-protocol/swap': minor
 ---
 
 The swap node's kind:10032 announce now carries a NIP-40 `["expiration", created_at + ttl]` tag and is republished on a refresh loop, instead of being published exactly once at boot with no expiry at all.

--- a/.changeset/issue-101-v2-eip712-balance-proof-digest.md
+++ b/.changeset/issue-101-v2-eip712-balance-proof-digest.md
@@ -1,4 +1,5 @@
 ---
+'@toon-protocol/swap': major
 ---
 
 The swap node now signs the v2 EIP-712 domain-separated balance-proof digest (via `@toon-protocol/settlement-digest`) instead of the v1 raw-packed digest, so claims recover correctly against the v2 verifiers across the ecosystem (client, sdk, connector and the on-chain `RollingSwapChannel`). Verifiers still on the v1 raw-packed digest — including the `@toon-protocol/sdk` 2.x pinned here — will NOT recover these claims; those repos migrate separately. `SwapNodeEvmChainProvider` gains a required `channelAddress` field (the deployed `RollingSwapChannel` address); a swap pair targeting an EVM chain with no matching `chainProviders` entry now refuses to boot instead of issuing unverifiable claims.

--- a/.changeset/issue-102-advertise-verifying-contract.md
+++ b/.changeset/issue-102-advertise-verifying-contract.md
@@ -1,4 +1,5 @@
 ---
+'@toon-protocol/swap': minor
 ---
 
 The swap node's kind:10032 peer-info now advertises `tokenNetworks[chain]` (the deployed `RollingSwapChannel` address, the EIP-712 `verifyingContract`) and `settlementAddresses[chain]` (the swap node's own payout address) for every chain a swap pair targets. Without this, a stock client that receives a v2-signed leg-B claim (#101) has no way to reconstruct the EIP-712 domain and rejects it with `MISSING_CHAIN_CONFIG`. Both maps are derived from the same per-chain walk that constructs the EVM signers, so the advertised chain key and contract address can never drift from the ones a claim is actually signed under.

--- a/.changeset/issue-112-checksummed-evm-recipient.md
+++ b/.changeset/issue-112-checksummed-evm-recipient.md
@@ -1,4 +1,5 @@
 ---
+'@toon-protocol/swap': minor
 ---
 
 Bumped `@toon-protocol/sdk` from `^2.2.0` to `^3.1.8` (toon#200): released clients send EIP-55 checksummed (mixed-case) EVM `chain-recipient` addresses, and the sdk's `createSwapHandler`/`streamSwap` shared `validateChainRecipient` was lowercase-only, rejecting every such packet as `missing_or_malformed_chain_recipient` with an opaque ILP `T00 Internal error`. sdk 3.1.8 fixes this and reclassifies the reject as `F01` (permanent, self-diagnosable) instead of `T00` (transient). The swap node's own third-tier defense-in-depth check in `MultiChainClaimIssuer` (`claim-issuer.ts`, guarding direct `issueClaim`/rolling-session callers that bypass the sdk handler) carried a byte-for-byte copy of the same lowercase-only bug — fixed the same way, and now normalizes the accepted recipient to lowercase before signing/echoing it, matching the sdk's own `findChainRecipient()` behavior.

--- a/.changeset/issue-114-advertise-supported-chains.md
+++ b/.changeset/issue-114-advertise-supported-chains.md
@@ -1,4 +1,5 @@
 ---
+'@toon-protocol/swap': minor
 ---
 
 The swap node's kind:10032 peer-info now advertises `supportedChains` (every chain a swap pair targets) and `preferredTokens[chain]` (the settlement-token address/mint/id, from the same `chainProviders` entry each chain's signer/`tokenNetworks` entry already reads). Without `supportedChains`, a stock client's apex onboarding hard-refuses the maker (`addApex`: "announced no supportedChains — cannot settle") — found during the toon-meta#394 T6 devnet proof (swap#105).

--- a/.changeset/issue-124-runtime-image-peer-info-ilp-config.md
+++ b/.changeset/issue-124-runtime-image-peer-info-ilp-config.md
@@ -1,4 +1,5 @@
 ---
+'@toon-protocol/swap': minor
 ---
 
 The `toon-swap` CLI now accepts `peerInfoIlpDestination` / `peerInfoPricePerByte` in the JSON config file, closing the last gap in the CLI's config surface versus the proven standalone-maker wiring (`scratchpad/t6/maker.mjs`) — these fields were already supported by `startSwapNode()` but never forwarded from `packages/swap/src/cli.ts`. Also adds a runtime container image (`deploy/swap/Dockerfile`, published to `ghcr.io/toon-protocol/swap` by `.github/workflows/publish-swap-image.yml`) that boots the maker via `toon-swap --config`; see `deploy/swap/README.md` for the full config-surface reference.

--- a/.changeset/issue-126-cli-autogen-identity-index2-settlement-key.md
+++ b/.changeset/issue-126-cli-autogen-identity-index2-settlement-key.md
@@ -1,4 +1,5 @@
 ---
+'@toon-protocol/swap': minor
 ---
 
 The `toon-swap` CLI now closes two gaps blocking a fully-autonomous, self-provisioning maker deploy (toon-meta#402):

--- a/.changeset/issue-133-announce-leg-a-token-network.md
+++ b/.changeset/issue-133-announce-leg-a-token-network.md
@@ -1,4 +1,5 @@
 ---
+'@toon-protocol/swap': major
 ---
 
 The swap node's kind:10032 `tokenNetworks` map now advertises **leg A** — the deployed `TokenNetwork` a client calls `openChannel(address participant2, uint256 settlementTimeout)` on to open the payment channel it pays this maker over — sourced from a new required `chainProviders[].tokenNetworkAddress`. The maker's own `RollingSwapChannel` (`chainProviders[].channelAddress`) moves to its own announce key, `swapVerifyingContracts`, which is **leg B**: the EIP-712 `verifyingContract` its v2 balance-proof claims are signed under.

--- a/.changeset/issue-136-silent-t00-and-inventory-leak.md
+++ b/.changeset/issue-136-silent-t00-and-inventory-leak.md
@@ -1,4 +1,5 @@
 ---
+'@toon-protocol/swap': major
 ---
 
 **A swap refusal is now logged and actionable, and a failed swap no longer leaks inventory.**

--- a/.changeset/issue-138-legacy-inventory-recycle.md
+++ b/.changeset/issue-138-legacy-inventory-recycle.md
@@ -1,4 +1,5 @@
 ---
+'@toon-protocol/swap': minor
 ---
 
 Inventory now recycles on the legacy swap path, so a maker no longer degrades to permanently unusable. Both claim paths share ONE capital model: `issueClaim` takes an in-flight window reservation and commits it to **unsettled channel liability** instead of permanently debiting `available`, exactly as the rolling path already did. Previously a *successful* legacy claim burned `available` for good — `recordSettlement`, the only recycler, shrank `unsettled`, which the legacy path never populated — so `available` ratcheted toward zero over the maker's lifetime and it then refused everything with T04 however faithfully its counterparties redeemed on chain.

--- a/.changeset/issue-141-solana-channel-reader.md
+++ b/.changeset/issue-141-solana-channel-reader.md
@@ -1,4 +1,5 @@
 ---
+'@toon-protocol/swap': minor
 ---
 
 Chain-truth inventory recycling is no longer EVM-only. `createEvmChannelOnChainReader` was the sole `ChannelOnChainReader`, so on a Solana target chain nothing ever observed a claim's redemption: `unsettled` liability only grew, `free` walked to zero, and the maker refused every swap however faithfully its counterparty redeemed — the exact defect #138 fixed, still live for a second chain family. A new `createSolanaChannelOnChainReader` reads the channel PDA's `transferred_amount_{a,b}` straight from `getAccountInfo` (hand-decoded from the canonical 178-byte `ChannelState` layout, no Solana SDK dependency, mirroring the EVM reader's raw-`eth_call` stance), and `createChannelOnChainReader` composes the readers behind the one seam both consumers already take — so this ALSO closes the same gap in the #113 channel-rebind precondition, which was likewise EVM-only.

--- a/.changeset/issue-164-solana-claim-signs-program-message.md
+++ b/.changeset/issue-164-solana-claim-signs-program-message.md
@@ -1,5 +1,5 @@
 ---
-'@toon-protocol/swap': minor
+'@toon-protocol/swap': major
 ---
 
 The maker's Solana balance proofs are now REDEEMABLE (swap#164, toon#214).

--- a/.changeset/issue-168-changeset-gate.md
+++ b/.changeset/issue-168-changeset-gate.md
@@ -1,0 +1,10 @@
+---
+---
+
+<!-- changeset:no-release — `.github/workflows/ci.yml` and `.sandcastle/scripts/` only. This change adds the gate and corrects OTHER changesets' frontmatter; it ships no code, no types and no wire change of its own, and its own release effect is entirely carried by the changesets it fixed. -->
+
+Add a changeset gate to CI, and correct the frontmatter of the 26 pending changesets (swap#168).
+
+Nothing in `.github/` read a changeset before merge — `changeset` appeared only in `release.yml`, which runs after merge where its failure gates nothing. 22 of the 26 pending changesets therefore had empty frontmatter, ~13 of them describing shipped behaviour of `@toon-protocol/swap`, so `@toon-protocol/swap` sat on npm at 2.1.0 while the Docker image moved.
+
+`CI OK` now requires a `Changeset check` job that (1) demands a changeset when `packages/swap/` changes, (2) runs the byte-identical `pnpm changeset version` that `release.yml` runs, and (3) requires a changeset that bumps nothing to say so with a `changeset:no-release` marker — this file being the first example.

--- a/.changeset/issue-28-fix-package-description.md
+++ b/.changeset/issue-28-fix-package-description.md
@@ -1,4 +1,6 @@
 ---
 ---
 
+<!-- changeset:no-release — packages/swap/package.json `description` only. The field ships as-is in whatever tarball is cut next, so it reaches npm without a version bump of its own; no code, no types, no wire. -->
+
 Clean up stale internal tracking reference ("Token Swap Primitive (Epic 12)") in packages/swap/package.json description.

--- a/.changeset/issue-31-align-pnpm-version.md
+++ b/.changeset/issue-31-align-pnpm-version.md
@@ -1,4 +1,6 @@
 ---
 ---
 
+<!-- changeset:no-release — `.github/workflows/ci.yml` + the private root `package.json` toolchain pin. Nothing in the published tarball (`files: ["dist"]`). -->
+
 Align pnpm patch version to 8.15.9 across ci.yml and package.json to match the devbox-pinned toolchain.

--- a/.changeset/issue-32-remove-stale-todo-12-7-comment.md
+++ b/.changeset/issue-32-remove-stale-todo-12-7-comment.md
@@ -1,4 +1,6 @@
 ---
 ---
 
+<!-- changeset:no-release — a source COMMENT in `claim-issuer.ts`. Comments are stripped from `dist`, so the published bytes are unchanged. -->
+
 Remove stale TODO(12.7) comment in claim-issuer.ts; startMill() already populates signerAddresses via buildSignerAddresses().

--- a/.changeset/issue-35-release-yml-pnpm-version.md
+++ b/.changeset/issue-35-release-yml-pnpm-version.md
@@ -1,4 +1,6 @@
 ---
 ---
 
+<!-- changeset:no-release — `.github/workflows/release.yml` toolchain pin only. Not shipped. -->
+
 Align the pnpm patch version pinned in `.github/workflows/release.yml` with `devbox.json` (8.15.0 → 8.15.9).

--- a/.changeset/issue-36-fix-cli-test-header-comment.md
+++ b/.changeset/issue-36-fix-cli-test-header-comment.md
@@ -1,4 +1,6 @@
 ---
 ---
 
+<!-- changeset:no-release — a header comment in `cli.test.ts`. Test files are not in `files: ["dist"]`. -->
+
 Fix stale header comment in cli.test.ts (no longer claims tests are .skip'd; fixes non-existent packages/mill path references).

--- a/.changeset/issue-40-add-license.md
+++ b/.changeset/issue-40-add-license.md
@@ -1,4 +1,6 @@
 ---
 ---
 
+<!-- changeset:no-release — a root `LICENSE` file. `packages/swap/package.json` already declared `"license": "MIT"`, and the root file sits outside the package dir so npm never packed it either way. -->
+
 Add a root LICENSE file (MIT) so the repo is no longer all-rights-reserved.

--- a/.changeset/issue-43-readme-epic-12-cleanup.md
+++ b/.changeset/issue-43-readme-epic-12-cleanup.md
@@ -1,4 +1,6 @@
 ---
 ---
 
+<!-- changeset:no-release — `packages/swap/README.md` prose only. npm always packs a package-dir README regardless of `files`, so it reaches the npm page with the next tarball without needing a bump of its own. -->
+
 Remove stale "Epic 12" internal tracking reference from packages/swap/README.md.

--- a/.changeset/issue-64-fix-root-vitest-config.md
+++ b/.changeset/issue-64-fix-root-vitest-config.md
@@ -1,4 +1,6 @@
 ---
 ---
 
+<!-- changeset:no-release — the root `vitest.config.ts`. Test harness, not shipped. -->
+
 Fix root vitest.config.ts, which aliased monorepo packages (core, relay, bls, sdk, client, town, townhouse-web) that no longer exist in this extracted single-package repo, breaking `pnpm test` / `devbox run test` at the root.

--- a/.changeset/issue-67-fix-claude-md-context-path.md
+++ b/.changeset/issue-67-fix-claude-md-context-path.md
@@ -1,4 +1,6 @@
 ---
 ---
 
+<!-- changeset:no-release — root `CLAUDE.md` agent guidance. Not shipped. -->
+
 Fix CLAUDE.md's canonical rules/decisions pointer to reference toon-meta's context/ docs instead of the removed _bmad-output/project-context.md path.

--- a/.changeset/leg-b-return-path.md
+++ b/.changeset/leg-b-return-path.md
@@ -1,4 +1,5 @@
 ---
+'@toon-protocol/swap': minor
 ---
 
 **A rolling fill can now actually be delivered: leg B goes back over the BTP session its RFQ arrived on.**

--- a/.changeset/rolling-rfq-wire-intake.md
+++ b/.changeset/rolling-rfq-wire-intake.md
@@ -1,4 +1,5 @@
 ---
+'@toon-protocol/swap': minor
 ---
 
 The maker now accepts a rolling-swap session **from the wire**: an inbound kind:20033 RFQ (NIP-59 gift wrap, rolling-swap spec §2.2) registers the session and is answered with a gift-wrapped kind:20034 quote carrying `R₀`, `rateTimestamp`, quote expiry, `spread`, `maxRateAge`, `minAmount`/`maxAmount` and the leg-B `swapSignerAddress`.

--- a/.changeset/solana-balance-proof-from-published-leaf.md
+++ b/.changeset/solana-balance-proof-from-published-leaf.md
@@ -1,5 +1,5 @@
 ---
-'@toon-protocol/swap': patch
+'@toon-protocol/swap': minor
 ---
 
 The Solana balance-proof bytes now come from the published shared leaf, not a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,122 @@ on:
     branches: [main]
 
 jobs:
+  # Changeset gate (swap#168), ported from toon-client#612 / rig#110 plus a
+  # third step this repo needs and neither of those has.
+  #
+  # Until now NOTHING in `.github/` read a changeset except `release.yml`, which
+  # runs after merge where its failure gates nothing. What that cost is swap#168:
+  # 22 of the 26 pending changesets on `main` had EMPTY frontmatter, ~13 of them
+  # describing shipped behaviour of the published package — the v2 EIP-712
+  # digest, the leg-B return path, the `cli.ts` fix that made every log line in
+  # the released image a no-op — and `@toon-protocol/swap` sat on npm at 2.1.0
+  # for five weeks while `swap:release` moved. The Docker image is a separate
+  # artifact and did carry all of it; only npm consumers were short-changed.
+  #
+  # `if: github.event_name == 'pull_request'` is a real skip, not an oversight —
+  # a push to `main` happens after merge, where there is nothing left to gate —
+  # and `ci-ok` therefore accepts `skipped` from THIS job on push events ONLY.
+  # A bare `needs:` would block nothing (toon-meta#279, toon#216): a skipped
+  # required check reads as a pass, so the skip has to be paired with the reason
+  # it is legitimate. Every other job in this workflow is unconditional, which is
+  # why `ci-ok` can keep checking those against a flat `!= success`.
+  changeset:
+    name: Changeset check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require a changeset when the publishable package changes
+        run: |
+          # `@toon-protocol/swap` is the only publishable package in the repo
+          # (`packages/swap`, not `private`, and `.changeset/config.json` has an
+          # empty `ignore`). deploy/, infra and .sandcastle publish nothing.
+          PUBLISHABLE="packages/swap"
+          changed=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          needs_changeset=false
+          for pkg in $PUBLISHABLE; do
+            if echo "$changed" | grep -q "^${pkg}/"; then
+              needs_changeset=true
+              break
+            fi
+          done
+          if [ "$needs_changeset" = "true" ]; then
+            new_changesets=$(echo "$changed" | grep -c "^\.changeset/.*\.md$" || true)
+            if [ "$new_changesets" -eq 0 ]; then
+              echo "::error::This PR modifies a publishable package but includes no changeset."
+              echo "Run 'pnpm changeset' and commit the generated .changeset/*.md file."
+              exit 1
+            fi
+          fi
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: pnpm
+
+      - run: pnpm install --no-frozen-lockfile
+
+      # Neither of the steps around this one would have caught swap#168.
+      # `changeset version` accepts an empty changeset without complaint — it is
+      # what `changeset add --empty` produces and the right shape for a CI-only
+      # change — and the file-exists step above is satisfied by one. So "empty"
+      # carried no signal, and 22 files accumulated over five weeks.
+      #
+      # This step does not ban empty; 9 of those 26 genuinely release nothing.
+      # It requires empty to be SAID, with a `changeset:no-release` marker in the
+      # body naming what does not ship. An author can still mark a behavioural
+      # change no-release and be wrong — no static check reads prose — but they
+      # can no longer do it by leaving a template untouched, which is how all 22
+      # happened.
+      #
+      # Runs BEFORE `changeset version`, which consumes and deletes every
+      # changeset file: after it there would be nothing left to read, and a
+      # malformed frontmatter gets a message naming the file here rather than a
+      # changesets stack trace there.
+      #
+      # Rationale and the rule itself: .sandcastle/scripts/changeset-lib.ts. Unit
+      # tested in changeset-lib.test.ts, which `pnpm test` runs in the `build`
+      # job — including an assertion that this repo's own pending changesets
+      # satisfy the rule, so the regression stays caught even if this job is
+      # edited away.
+      - name: Every changeset must release something, or say why not
+        run: npx tsx .sandcastle/scripts/changeset-check.ts .changeset
+
+      # `changeset version` rather than `changeset status`: it is the
+      # byte-identical command `release.yml` hands `changesets/action` as its
+      # `version:` input (release.yml line ~68), so green here means the release
+      # gets past versioning, with no second implementation to drift. `status`
+      # additionally resolves `baseBranch` through git and errors when IT decides
+      # packages changed with no changeset — duplicating the step above with a
+      # different definition of "changed".
+      #
+      # Mutating the tree is free: this is a throwaway checkout that commits,
+      # pushes and publishes nothing, and has no step after the next one. The
+      # bumps it writes are PRINTED rather than discarded, because "what version
+      # would this release cut" is the useful half of the output — and it is
+      # exactly the number swap#168 was about.
+      #
+      # Unlike toon-client and rig, this repo's `.changeset/config.json` has
+      # `"ignore": []`, so the specific toon-client#611 failure (a changeset
+      # naming both an ignored and a non-ignored package) cannot occur here yet.
+      # This step still catches an unknown package name, unparseable YAML, and an
+      # `ignore` list the day someone adds one.
+      - name: Assert the changesets form a valid release plan
+        run: |
+          set -euo pipefail
+          pnpm changeset version
+          echo "--- the release plan this PR would produce ---"
+          git --no-pager diff --stat
+          git --no-pager diff -- '**/package.json' | grep -E '^[+-]  "version"' || true
+          echo "✅ changeset version succeeds — release.yml can get past versioning"
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -440,15 +556,18 @@ jobs:
   ci-ok:
     name: CI OK
     runs-on: ubuntu-latest
-    needs: [build, devbox-validate, solana-e2e, swap-image-build, no-op-merge]
+    needs:
+      [changeset, build, devbox-validate, solana-e2e, swap-image-build, no-op-merge]
     if: always()
     steps:
       # Fleet-wide aggregate required check (toon-meta#279): this job is the
       # single required status for the repo. It must fail unless every gating
       # job actually SUCCEEDED — a skipped or cancelled gating job must never
       # read as a pass. `build`, `devbox-validate`, `solana-e2e` and
-      # `swap-image-build` are expected on every run; there are no
-      # legitimately-skippable jobs in this workflow.
+      # `swap-image-build` carry no `if:` of their own, so for them a `skipped`
+      # cannot mean "correctly not required" — only cancelled-upstream or a
+      # workflow edit that stopped them running, and both must fail. That is why
+      # a flat `!= success` is a complete gate for these four.
       - name: Check all gating jobs succeeded
         run: |
           echo "build: ${{ needs.build.result }}"
@@ -460,4 +579,47 @@ jobs:
             echo "One or more gating jobs did not succeed (failure, cancelled, and skipped all fail)."
             exit 1
           fi
+
+      # The conditional half (swap#168, pattern from toon#217/#216). `changeset`
+      # is the one job here with an `if:` of its own, so a bare `needs:` on it
+      # would block NOTHING: a job skipped by its own `if:` reports `skipped`,
+      # and a required check that reads a skip as a pass is not a gate. The skip
+      # is therefore only accepted against the reason it exists — the event type,
+      # which is not a judgement call and not something a broken step can lie
+      # about.
+      #
+      # Three outcomes, no fourth:
+      #   pull_request -> the check must have SUCCEEDED. failure, cancelled and
+      #                   skipped all fail the aggregate. This is the one that
+      #                   matters: it is the merge path.
+      #   push         -> `skipped` is the expected result (the job's `if:`), and
+      #                   `success` is fine too if someone re-ran it by hand.
+      #   anything else (workflow_dispatch, a future trigger) -> treated as push:
+      #                   permissive, because this workflow gates merges via
+      #                   pull_request and a hand-fired run must not be able to
+      #                   turn `CI OK` red for a job that was never meant to run.
+      - name: The changeset check must have run and passed on a PR
+        env:
+          CHANGESET_RESULT: ${{ needs.changeset.result }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          echo "event: $EVENT_NAME"
+          echo "changeset: $CHANGESET_RESULT"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            if [ "$CHANGESET_RESULT" != "success" ]; then
+              echo "::error::changeset result is '$CHANGESET_RESULT' on a pull_request (expected 'success'; skipped and cancelled both count as failure — the job's own 'if:' runs it on every PR, so a skip means it stopped running, not that it was unnecessary)"
+              exit 1
+            fi
+            echo "CI OK: the changeset check ran and passed on this PR."
+            exit 0
+          fi
+          case "$CHANGESET_RESULT" in
+            success|skipped)
+              echo "CI OK: changeset was '$CHANGESET_RESULT' on a '$EVENT_NAME' event, which is legitimate."
+              ;;
+            *)
+              echo "::error::changeset result is '$CHANGESET_RESULT' on a '$EVENT_NAME' event (only 'success' or 'skipped' are legitimate off a pull_request)"
+              exit 1
+              ;;
+          esac
           echo "All gating jobs succeeded."

--- a/.sandcastle/scripts/changeset-check.ts
+++ b/.sandcastle/scripts/changeset-check.ts
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * CLI wiring for the empty-changeset rule (swap#168). See ./changeset-lib.ts
+ * for what the rule is and why it is a marker rather than a ban.
+ *
+ * usage: changeset-check.ts [changesetDir]
+ *
+ * Exits 1 with a job summary when a changeset releases nothing without saying
+ * so. Runs against the WHOLE `.changeset/` directory, not just the files a PR
+ * touched: swap#168 was 22 files accumulated over five weeks, and a diff-scoped
+ * check would have gone green on every one of the PRs that added them and green
+ * again on every PR after. Whole-tree also means a rebase that drops a marker
+ * line cannot slip through on a later PR that never touches the file.
+ */
+
+import { appendFileSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  findChangesetProblems,
+  highestBumpFor,
+  NO_RELEASE_MARKER,
+  parseChangeset,
+  type ParsedChangeset,
+} from './changeset-lib.ts';
+
+const PUBLISHABLE_PACKAGE = '@toon-protocol/swap';
+
+// `config.json` is the changesets config and `README.md` is its shipped
+// boilerplate; neither is a changeset.
+const NOT_A_CHANGESET = new Set(['README.md']);
+
+function readChangesets(dir: string): readonly ParsedChangeset[] {
+  return readdirSync(dir)
+    .filter((name) => name.endsWith('.md') && !NOT_A_CHANGESET.has(name))
+    .sort()
+    .map((name) => parseChangeset(name, readFileSync(join(dir, name), 'utf8')));
+}
+
+function writeSummary(lines: readonly string[]): void {
+  const summaryPath = process.env['GITHUB_STEP_SUMMARY'];
+  if (summaryPath === undefined || summaryPath === '') {
+    return;
+  }
+  appendFileSync(summaryPath, `${lines.join('\n')}\n`);
+}
+
+function main(): void {
+  const dir = process.argv[2] ?? '.changeset';
+  const parsed = readChangesets(dir);
+
+  console.log(`[changeset-check] ${String(parsed.length)} changeset(s) in ${dir}`);
+  for (const entry of parsed) {
+    const plan =
+      entry.releases.length > 0
+        ? entry.releases.map((r) => `${r.packageName}:${r.bump}`).join(', ')
+        : entry.declaredNoRelease
+          ? `no release (declared: ${NO_RELEASE_MARKER})`
+          : 'no release (UNDECLARED)';
+    console.log(`[changeset-check]   ${entry.file} — ${plan}`);
+  }
+
+  const bump = highestBumpFor(parsed, PUBLISHABLE_PACKAGE);
+  console.log(
+    `[changeset-check] ${PUBLISHABLE_PACKAGE} would take a ${bump ?? 'NO'} bump from these changesets`,
+  );
+
+  const problems = findChangesetProblems(parsed);
+  if (problems.length === 0) {
+    console.log('[changeset-check] every changeset either names a package or declares no-release');
+    return;
+  }
+
+  const summary: string[] = [
+    '## ❌ A changeset releases nothing without saying so',
+    '',
+    'A changeset with no package in its frontmatter bumps nothing, and its description',
+    'never reaches a CHANGELOG — the reader of the npm package is told nothing. That is',
+    'CORRECT for a CI-only or docs-only change and wrong for everything else, and the two',
+    'look identical, which is how swap#168 happened: 22 of 26 pending changesets were',
+    'empty, ~13 of them describing shipped behaviour, and `@toon-protocol/swap` sat at',
+    '2.1.0 for five weeks.',
+    '',
+    '| changeset | problem |',
+    '| --- | --- |',
+  ];
+
+  for (const problem of problems) {
+    console.error(`::error::${problem.file}: ${problem.detail}`);
+    summary.push(`| \`${problem.file}\` | ${problem.detail} |`);
+  }
+
+  summary.push(
+    '',
+    '**If the change reaches a consumer of `@toon-protocol/swap`** — source, types, the',
+    'wire, the `toon-swap` CLI, a dependency floor — name the package and pick a level:',
+    '',
+    '```',
+    '---',
+    `'${PUBLISHABLE_PACKAGE}': patch | minor | major`,
+    '---',
+    '```',
+    '',
+    '**If it genuinely ships nothing to npm** — CI, agent tooling, a test, a comment, root',
+    `docs — keep the frontmatter empty and add a \`${NO_RELEASE_MARKER}\` marker to the body`,
+    'saying which, e.g.:',
+    '',
+    '```',
+    '---',
+    '---',
+    '',
+    `<!-- ${NO_RELEASE_MARKER} — .github/workflows only; nothing in the published tarball -->`,
+    '```',
+    '',
+    'The marker is the whole point: empty has to be a sentence someone wrote, not a',
+    'template left untouched.',
+  );
+
+  writeSummary(summary);
+  process.exit(1);
+}
+
+main();

--- a/.sandcastle/scripts/changeset-lib.test.ts
+++ b/.sandcastle/scripts/changeset-lib.test.ts
@@ -1,0 +1,179 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  findChangesetProblems,
+  highestBumpFor,
+  NO_RELEASE_MARKER,
+  parseChangeset,
+} from "./changeset-lib.ts";
+
+const CHANGESET_DIR = join(import.meta.dirname, "..", "..", ".changeset");
+
+describe("parseChangeset", () => {
+  it("reads a single quoted release", () => {
+    const parsed = parseChangeset(
+      "a.md",
+      "---\n'@toon-protocol/swap': minor\n---\n\nbody\n",
+    );
+    expect(parsed.releases).toEqual([
+      { packageName: "@toon-protocol/swap", bump: "minor" },
+    ]);
+    expect(parsed.malformedLines).toEqual([]);
+    expect(parsed.missingFrontmatter).toBe(false);
+  });
+
+  it("reads unquoted and double-quoted names, and every bump level", () => {
+    const parsed = parseChangeset(
+      "a.md",
+      '---\n@toon-protocol/swap: major\n"other": patch\n---\n',
+    );
+    expect(parsed.releases).toEqual([
+      { packageName: "@toon-protocol/swap", bump: "major" },
+      { packageName: "other", bump: "patch" },
+    ]);
+  });
+
+  it("treats an empty frontmatter block as a valid parse with no releases", () => {
+    const parsed = parseChangeset("a.md", "---\n---\n\nbody\n");
+    expect(parsed.releases).toEqual([]);
+    expect(parsed.missingFrontmatter).toBe(false);
+    expect(parsed.declaredNoRelease).toBe(false);
+  });
+
+  it("reports a missing frontmatter block distinctly from an empty one", () => {
+    const parsed = parseChangeset("a.md", "just some prose\n");
+    expect(parsed.missingFrontmatter).toBe(true);
+  });
+
+  it("reports an unterminated frontmatter block as missing", () => {
+    const parsed = parseChangeset("a.md", "---\n'@toon-protocol/swap': minor\n");
+    expect(parsed.missingFrontmatter).toBe(true);
+  });
+
+  it("reports an unknown bump level as malformed rather than accepting it", () => {
+    const parsed = parseChangeset(
+      "a.md",
+      "---\n'@toon-protocol/swap': breaking\n---\n",
+    );
+    expect(parsed.releases).toEqual([]);
+    expect(parsed.malformedLines).toEqual(["'@toon-protocol/swap': breaking"]);
+  });
+
+  it("finds the no-release marker in the body", () => {
+    const parsed = parseChangeset(
+      "a.md",
+      `---\n---\n\n<!-- ${NO_RELEASE_MARKER} — CI only -->\n\nbody\n`,
+    );
+    expect(parsed.declaredNoRelease).toBe(true);
+  });
+
+  it("does not read a marker out of the frontmatter block", () => {
+    const parsed = parseChangeset(
+      "a.md",
+      `---\n# ${NO_RELEASE_MARKER}\n---\n\nbody\n`,
+    );
+    expect(parsed.declaredNoRelease).toBe(false);
+  });
+});
+
+describe("findChangesetProblems", () => {
+  it("passes a changeset that names a package", () => {
+    const parsed = [
+      parseChangeset("a.md", "---\n'@toon-protocol/swap': minor\n---\n\nbody\n"),
+    ];
+    expect(findChangesetProblems(parsed)).toEqual([]);
+  });
+
+  it("passes an empty changeset that declares no-release", () => {
+    const parsed = [
+      parseChangeset("a.md", `---\n---\n\n<!-- ${NO_RELEASE_MARKER} — CI -->\n`),
+    ];
+    expect(findChangesetProblems(parsed)).toEqual([]);
+  });
+
+  // This is swap#168 itself: the shape of all 22 offenders on `main`. The
+  // changeset is valid YAML, `changeset version` accepts it, and it bumps
+  // nothing — so this assertion is the whole reason the gate exists.
+  it("BLOCKS an empty changeset that does not declare no-release", () => {
+    const parsed = [
+      parseChangeset(
+        "issue-101-v2-eip712-balance-proof-digest.md",
+        "---\n---\n\nThe swap node now signs the v2 EIP-712 digest.\n",
+      ),
+    ];
+    const problems = findChangesetProblems(parsed);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]?.kind).toBe("undeclared-empty");
+    expect(problems[0]?.file).toBe(
+      "issue-101-v2-eip712-balance-proof-digest.md",
+    );
+  });
+
+  it("blocks a malformed frontmatter line", () => {
+    const parsed = [
+      parseChangeset("a.md", "---\n'@toon-protocol/swap': breaking\n---\n"),
+    ];
+    expect(findChangesetProblems(parsed)[0]?.kind).toBe("malformed-frontmatter");
+  });
+
+  it("blocks a file with no frontmatter block", () => {
+    const parsed = [parseChangeset("a.md", "prose only\n")];
+    expect(findChangesetProblems(parsed)[0]?.kind).toBe("missing-frontmatter");
+  });
+
+  it("reports every offender, not just the first", () => {
+    const parsed = [
+      parseChangeset("a.md", "---\n---\n\nbody\n"),
+      parseChangeset("b.md", "---\n'@toon-protocol/swap': minor\n---\n"),
+      parseChangeset("c.md", "---\n---\n\nbody\n"),
+    ];
+    expect(findChangesetProblems(parsed).map((p) => p.file)).toEqual([
+      "a.md",
+      "c.md",
+    ]);
+  });
+});
+
+describe("highestBumpFor", () => {
+  it("picks the highest level across changesets", () => {
+    const parsed = [
+      parseChangeset("a.md", "---\n'@toon-protocol/swap': patch\n---\n"),
+      parseChangeset("b.md", "---\n'@toon-protocol/swap': major\n---\n"),
+      parseChangeset("c.md", "---\n'@toon-protocol/swap': minor\n---\n"),
+    ];
+    expect(highestBumpFor(parsed, "@toon-protocol/swap")).toBe("major");
+  });
+
+  it("ignores other packages and returns undefined when none match", () => {
+    const parsed = [parseChangeset("a.md", "---\n'other': major\n---\n")];
+    expect(highestBumpFor(parsed, "@toon-protocol/swap")).toBeUndefined();
+  });
+});
+
+// The rule is only worth anything if the repo's own pending changesets satisfy
+// it. This is the regression half of swap#168: it fails the moment a changeset
+// is added that bumps nothing without saying so, whether or not CI runs the CLI.
+describe("this repo's pending changesets", () => {
+  const parsed = readdirSync(CHANGESET_DIR)
+    .filter((name) => name.endsWith(".md") && name !== "README.md")
+    .sort()
+    .map((name) =>
+      parseChangeset(name, readFileSync(join(CHANGESET_DIR, name), "utf8")),
+    );
+
+  it("all satisfy the rule", () => {
+    expect(findChangesetProblems(parsed)).toEqual([]);
+  });
+
+  it("every declared release names @toon-protocol/swap (the only publishable package)", () => {
+    const names = new Set(
+      parsed.flatMap((entry) => entry.releases.map((r) => r.packageName)),
+    );
+    expect([...names].filter((name) => name !== "@toon-protocol/swap")).toEqual(
+      [],
+    );
+  });
+});

--- a/.sandcastle/scripts/changeset-lib.ts
+++ b/.sandcastle/scripts/changeset-lib.ts
@@ -1,0 +1,214 @@
+/**
+ * Changeset frontmatter inspection (swap#168).
+ *
+ * `changeset version` answers "is this a VALID release plan". It cannot answer
+ * "is this the release plan the author MEANT", because a changeset that names
+ * no package is perfectly valid — it is what `changeset add --empty` produces,
+ * and it is the right shape for a CI-only or docs-only change. It is also what
+ * you get by accident, and the two are byte-indistinguishable.
+ *
+ * swap#168 is what that costs: 22 of 26 pending changesets on `main` had empty
+ * frontmatter, ~13 of them describing shipped behaviour of the published
+ * `@toon-protocol/swap` — the v2 EIP-712 digest, the leg-B return path, the
+ * `cli.ts` fix that made every log line in the released image a no-op. Each one
+ * documented a real change, satisfied the "a changeset file exists" check, and
+ * bumped nothing, so the npm package sat at 2.1.0 for five weeks while the
+ * Docker image moved. Nothing was wrong with any individual file; the failure
+ * was that "empty" carried no signal.
+ *
+ * So this module does not forbid empty. It requires empty to be SAID: an
+ * explicit `changeset:no-release` marker in the body, which an author has to
+ * type and a reviewer can see. An author can still mark a behavioural change
+ * no-release and be wrong — no static check can tell prose from truth — but
+ * they can no longer do it by leaving a template untouched, which is how all 22
+ * happened.
+ */
+
+/** The marker that makes an empty changeset a decision instead of a default. */
+export const NO_RELEASE_MARKER = 'changeset:no-release';
+
+export type ChangesetBump = 'major' | 'minor' | 'patch';
+
+export interface ChangesetRelease {
+  readonly packageName: string;
+  readonly bump: ChangesetBump;
+}
+
+export interface ParsedChangeset {
+  readonly file: string;
+  /** Package releases declared in the frontmatter, in file order. */
+  readonly releases: readonly ChangesetRelease[];
+  /** Frontmatter lines this parser could not read as a release. */
+  readonly malformedLines: readonly string[];
+  /** True when the body carries {@link NO_RELEASE_MARKER}. */
+  readonly declaredNoRelease: boolean;
+  /** True when the file has no `---` delimited frontmatter block at all. */
+  readonly missingFrontmatter: boolean;
+}
+
+export type ChangesetProblemKind =
+  | 'missing-frontmatter'
+  | 'malformed-frontmatter'
+  | 'undeclared-empty';
+
+export interface ChangesetProblem {
+  readonly file: string;
+  readonly kind: ChangesetProblemKind;
+  readonly detail: string;
+}
+
+const FRONTMATTER_DELIMITER = '---';
+
+// `'@toon-protocol/swap': minor`, with the quotes optional because changesets
+// accepts either. The bump alternatives are spelled out rather than captured
+// loosely so an unknown level is reported here, next to the file name, instead
+// of surfacing later as a changesets stack trace.
+const RELEASE_LINE = /^\s*(['"]?)(?<name>[^'":]+)\1\s*:\s*(?<bump>major|minor|patch)\s*$/u;
+
+/**
+ * Split a changeset into its frontmatter lines and its body.
+ *
+ * Returns `undefined` when there is no frontmatter block, which is a distinct
+ * condition from an EMPTY one: an empty block is a legitimate no-release
+ * changeset, whereas a missing block means the file is not a changeset at all.
+ */
+function splitFrontmatter(
+  source: string,
+): { readonly frontmatter: readonly string[]; readonly body: string } | undefined {
+  const lines = source.split('\n');
+  if (lines[0]?.trim() !== FRONTMATTER_DELIMITER) {
+    return undefined;
+  }
+
+  for (let i = 1; i < lines.length; i += 1) {
+    if (lines[i]?.trim() === FRONTMATTER_DELIMITER) {
+      return {
+        frontmatter: lines.slice(1, i),
+        body: lines.slice(i + 1).join('\n'),
+      };
+    }
+  }
+
+  return undefined;
+}
+
+export function parseChangeset(file: string, source: string): ParsedChangeset {
+  const split = splitFrontmatter(source);
+  if (split === undefined) {
+    return {
+      file,
+      releases: [],
+      malformedLines: [],
+      // The marker is read from the whole file here: a changeset with no
+      // frontmatter is already failing, and looking for the marker in a body we
+      // could not delimit would only add a second, confusing complaint.
+      declaredNoRelease: source.includes(NO_RELEASE_MARKER),
+      missingFrontmatter: true,
+    };
+  }
+
+  const releases: ChangesetRelease[] = [];
+  const malformedLines: string[] = [];
+
+  for (const line of split.frontmatter) {
+    if (line.trim() === '') {
+      continue;
+    }
+    const match = RELEASE_LINE.exec(line);
+    const groups = match?.groups;
+    if (groups === undefined) {
+      malformedLines.push(line.trim());
+      continue;
+    }
+    const name = groups['name'];
+    const bump = groups['bump'];
+    // Both groups are non-optional in the pattern, so this is unreachable —
+    // written as a guard rather than a `!` because the frozen lint baseline
+    // forbids the assertion, and a narrowing guard costs nothing.
+    if (name === undefined || bump === undefined) {
+      malformedLines.push(line.trim());
+      continue;
+    }
+    releases.push({
+      packageName: name.trim(),
+      bump: bump as ChangesetBump,
+    });
+  }
+
+  return {
+    file,
+    releases,
+    malformedLines,
+    declaredNoRelease: split.body.includes(NO_RELEASE_MARKER),
+    missingFrontmatter: false,
+  };
+}
+
+/**
+ * The rule: a changeset that releases nothing must say so on purpose.
+ *
+ * Deliberately NOT a rule about which packages a changeset ought to name. That
+ * question needs the diff, the prose and a reviewer; this only removes the
+ * silent default.
+ */
+export function findChangesetProblems(
+  parsed: readonly ParsedChangeset[],
+): readonly ChangesetProblem[] {
+  const problems: ChangesetProblem[] = [];
+
+  for (const entry of parsed) {
+    if (entry.missingFrontmatter) {
+      problems.push({
+        file: entry.file,
+        kind: 'missing-frontmatter',
+        detail:
+          'no `---` delimited frontmatter block. A changeset must open with one, even when it is empty.',
+      });
+      continue;
+    }
+
+    if (entry.malformedLines.length > 0) {
+      problems.push({
+        file: entry.file,
+        kind: 'malformed-frontmatter',
+        detail: `frontmatter line(s) that are not \`'<package>': major|minor|patch\`: ${entry.malformedLines
+          .map((line) => JSON.stringify(line))
+          .join(', ')}`,
+      });
+      continue;
+    }
+
+    if (entry.releases.length === 0 && !entry.declaredNoRelease) {
+      problems.push({
+        file: entry.file,
+        kind: 'undeclared-empty',
+        detail:
+          'names no package, so it bumps nothing and its description will never reach a CHANGELOG.',
+      });
+    }
+  }
+
+  return problems;
+}
+
+/** The version bump a set of parsed changesets implies for one package. */
+export function highestBumpFor(
+  parsed: readonly ParsedChangeset[],
+  packageName: string,
+): ChangesetBump | undefined {
+  const order: readonly ChangesetBump[] = ['patch', 'minor', 'major'];
+  let highest: ChangesetBump | undefined;
+
+  for (const entry of parsed) {
+    for (const release of entry.releases) {
+      if (release.packageName !== packageName) {
+        continue;
+      }
+      if (highest === undefined || order.indexOf(release.bump) > order.indexOf(highest)) {
+        highest = release.bump;
+      }
+    }
+  }
+
+  return highest;
+}


### PR DESCRIPTION
Closes #168.

22 of the 26 pending changesets on `main` had empty frontmatter. A changeset that names no package is *valid* — it is what `changeset add --empty` produces, and it is the right shape for a CI-only change — so each of the 22 documented a real change, satisfied every check that existed (there were none: `changeset` appeared in `.github/` only inside `release.yml`, which runs *after* merge where its failure gates nothing), and bumped nothing.

`@toon-protocol/swap` has sat on npm at **2.1.0 since 2026-07-12**. Every changeset in this repo was added after that date, so the newest thing the package's CHANGELOG tells a consumer predates all of it.

**Scope: this is an npm-consumer problem, not a fleet outage.** `swap:release` is built by `publish-swap-image.yml` from source, not from the npm tarball, so the live devnet maker has carried all of these fixes all along and was verified end-to-end today. Nothing about the running maker changes here, and nothing is published by this PR.

---

## The triage — all 26

Verified against each changeset's own text and the commit that added it. Bump levels are set from content, not uniformly.

### Major — 4

| changeset | why major |
|---|---|
| `issue-101-v2-eip712-balance-proof-digest.md` | Two independent breaks. `SwapNodeEvmChainProvider` gains a **required** `channelAddress`, and a pair targeting an EVM chain with no matching entry now **refuses to boot** — a config that worked on 2.1.0 does not boot on this. And the signed digest moves v1 raw-packed → v2 EIP-712, so a verifier still on v1 (including the sdk 2.x that 2.1.0 pinned) will not recover these claims. |
| `issue-133-announce-leg-a-token-network.md` | A second **required, defaultless** field: `chainProviders[].tokenNetworkAddress`. Deliberately no default (defaulting it to `channelAddress` is the invisible failure this fixed). Also re-points a published announce key — `tokenNetworks` stops meaning `RollingSwapChannel` and starts meaning the leg-A `TokenNetwork`; the old value moves to a new `swapVerifyingContracts`. A reader of the old key gets a different contract than before. |
| `issue-136-silent-t00-and-inventory-leak.md` | Reclassifies a blanket `T00` into `T04`/`insufficient_funds` and `F99`/`application_error`. `T00 → F99` crosses the ILP **T-class → F-class** boundary, which is exactly the bit a released counterparty branches on to decide whether to retry: a client that retried before will now give up. That is a behaviour change a consumer must be told about, and the MAJOR section is where they will read it. |
| `issue-164-solana-claim-signs-program-message.md` | **Was `minor`; corrected.** `SolanaPaymentChannelSigner` is a 2.1.0 export, and this changes the bytes it signs (to the 48-byte program message the deployed program actually verifies) *and* makes it throw on a `channelId` that is not a 32-byte base58 PDA. Input that 2.1.0 accepted now raises, and signatures 2.1.0 produced do not match. Its own text says "Synthetic Solana channel ids in callers' tests must become real PDAs" — that is a migration instruction. |

### Minor — 13

| changeset | level | note |
|---|---|---|
| `issue-102-advertise-verifying-contract.md` | minor | Additive announce keys (`tokenNetworks`, `settlementAddresses`). |
| `issue-112-checksummed-evm-recipient.md` | minor | Fixes a lowercase-only recipient check (input that was rejected now works) and moves the `@toon-protocol/sdk` floor `^2.2.0 → ^3.1.8`. Repo precedent: 2.1.0 shipped "Dependency floors: connector ^3.30.0, sdk ^2.2.0" as a **minor**, so a floor move alone is minor here. |
| `issue-114-advertise-supported-chains.md` | minor | Additive announce keys (`supportedChains`, `preferredTokens`). |
| `issue-124-runtime-image-peer-info-ilp-config.md` | minor | New **optional** CLI config keys. The `toon-swap` bin is part of the published package (`bin.toon-swap → dist/cli.js`), so the CLI's config surface is public API. The Dockerfile half ships nothing to npm. |
| `issue-126-cli-autogen-identity-index2-settlement-key.md` | minor | New opt-in CLI features; nothing required, nothing removed. ⚠️ Does change a *derived default*: a mnemonic boot that omits `settlementPrivateKey` now derives the index-2 EVM key instead of falling back to the (unrelated) Nostr key. Levelled minor because the old fallback signed with the wrong key — it is a fix on a broken path, and no surface tightens. Flagged here rather than buried. |
| `issue-138-legacy-inventory-recycle.md` | minor | Additive: `SwapInventory.refundDebit`/`recordChainRedemption`, `SwapInventoryReconciler`, `/admin/inventory*` routes, two **optional** env vars. `SwapInventory` is an exported **class**, not an interface, so new methods are additive — unlike 2.0.0's `SwapNodeInstance`, which was an interface and correctly went major for the same shape of change. |
| `issue-141-solana-channel-reader.md` | minor | New `createSolanaChannelOnChainReader` + a composing dispatcher; the existing EVM reader keeps its name and signature. No new config key (deliberately — a required key is what crash-looped the maker in #134). |
| `issue-142-operator-route-new-capital.md` | minor | **Already correct, unchanged.** New admin route + optional reader capability. |
| `leg-b-return-path.md` | minor | New `leg-b-return-path.ts`, no config key. Refusing at leg 0 with `F02`/`no_return_path` is a *new* refusal on a path that previously always failed later (`F99`, nothing delivered), so nothing that worked stops working. |
| `rolling-rfq-wire-intake.md` | minor | New kind:20033 intake, all knobs optional. Intake defaults **on**, but anything not positively identified as an RFQ falls through to the legacy path byte-for-byte, so the new default cannot change an existing flow. |
| `announce-nip40-expiration-and-refresh.md` | minor | Additive NIP-40 tag + a refresh loop; both knobs optional with fleet-convention defaults. |
| `sdk-3.2.0-on-failure-seam.md` | minor | **Already `minor`; deliberately kept, and this is the one worth reading.** It *does* remove public exports (`createClaimRefusalDiagnostics`, `ClaimRefusalDiagnostics` — confirmed in `e3cad0e`'s `index.ts` diff). But those were added by `issue-136` in this same unreleased batch: they never existed in 2.1.0, so relative to the last published version there is nothing to remove. A consumer cannot break on the disappearance of something they were never able to import. Its own text is right that there is no wire change. |
| `solana-balance-proof-from-published-leaf.md` | patch → **minor** | Moves three dependency floors — `settlement-digest ^1.0.0 → ^1.1.0`, `sdk ^3.2.0 → ^3.3.0`, and `core ^2.1.0 → ^3.5.0`, the last retiring a two-major-old copy of core from the consumer's tree. Same precedent as `issue-112`: a floor move is minor in this repo, not patch. |

### No bump — 9, and correctly so

Kept empty. Each now carries a `changeset:no-release` marker naming what does not ship, so the decision is on the record and the new gate can tell it apart from an accident. Verified against `files: ["dist"]` and each one's commit diff.

| changeset | what it actually touched | why nothing ships |
|---|---|---|
| `issue-31-align-pnpm-version.md` | `.github/workflows/ci.yml`, private root `package.json` | toolchain pin |
| `issue-35-release-yml-pnpm-version.md` | `.github/workflows/release.yml` | toolchain pin |
| `issue-64-fix-root-vitest-config.md` | root `vitest.config.ts` | test harness |
| `issue-67-fix-claude-md-context-path.md` | root `CLAUDE.md` | agent guidance |
| `issue-36-fix-cli-test-header-comment.md` | `packages/swap/src/cli.test.ts` | test file, outside `dist` |
| `issue-32-remove-stale-todo-12-7-comment.md` | `packages/swap/src/claim-issuer.ts` | **comment only** — stripped from `dist`, so the published bytes are identical |
| `issue-40-add-license.md` | root `LICENSE` | `packages/swap/package.json` already declared `"license": "MIT"`; the root file is outside the package dir, so npm never packed it either way |
| `issue-28-fix-package-description.md` | `packages/swap/package.json` `description` | **does** reach the npm page — but as *metadata*, carried by whatever tarball is cut next regardless of whether this changeset bumps. No code, no types, no wire. |
| `issue-43-readme-epic-12-cleanup.md` | `packages/swap/README.md` | same: npm always packs a package-dir README regardless of `files`, so the prose reaches the npm page with the next tarball without needing a bump of its own |

The last two are the genuinely arguable ones and are called out rather than waved through. Levelling them `patch` would have been defensible; it would also have added two CHANGELOG entries saying nothing a consumer can act on, and the fix reaches npm either way.

### Categories the audit asked about, resolved

- **Already released / duplicates: none.** 2.1.0 was cut on 2026-07-12 (`packages/swap/CHANGELOG.md`'s last touch, `136f0c4`); the earliest pending changeset was added 2026-07-13. Every one of the 26 is genuinely unreleased, and no two describe the same change.
- **Deliberately image-only: none.** No changeset describes something that ships in the Docker image but not on npm. The image and the package are built from the same source; the divergence was purely that the package never got published.

---

## Result: 2.1.0 → 3.0.0

Verified by running `pnpm changeset version` in a throwaway copy of this branch:

```
version: 3.0.0
marker leaked into CHANGELOG: 0
leftover changesets: 0
```

For comparison, the same command on `origin/main` today produces **2.2.0** — a minor, from the four changesets that happened to have frontmatter.

### Yes, it is a major. What breaks

`2.x → 3.0.0` has a real cost, so concretely, for someone on 2.1.0:

1. **A working config stops booting.** `chainProviders[]` entries need `channelAddress` (#101) and `tokenNetworkAddress` (#133). Neither has a default, both refuse to boot, and that refusal is intentional — defaulting either one reintroduces a failure with no diagnostic.
2. **EVM claims are signed under a different digest** (#101): v2 EIP-712 via `@toon-protocol/settlement-digest`, not v1 raw-packed. A verifier still on v1 will not recover them. Both sides must move.
3. **Solana claims are signed under a different message** (#164): the 48-byte `channel_pda(32) || nonce(8 LE) || transferred_amount(8 LE)` the deployed program verifies. Everything 2.1.0 signed was unredeemable, so there is no working deployment to break — but the bytes did change.
4. **`SolanaPaymentChannelSigner` throws on a non-PDA `channelId`** (#164). Callers with synthetic Solana channel ids in tests must use real PDAs.
5. **One announce key changes meaning** (#133): `tokenNetworks` is now leg A (the `TokenNetwork` to `openChannel` on); the `RollingSwapChannel` moved to `swapVerifyingContracts`. A client reading `tokenNetworks` and calling the rolling-channel ABI is what reverted before this fix, so the new meaning is the working one.
6. **Refusal codes change class** (#136): a blanket `T00` becomes `T04`/`insufficient_funds` (unredeemed channel) or `F99`/`application_error` (no channel). `T00 → F99` flips T-class to F-class, so a counterparty that retried will now stop retrying — which is correct, the condition is permanent, but it is a behaviour change.
7. **Dependency floors move**, including `@toon-protocol/core ^2.1.0 → ^3.5.0`, which drops a two-major-old core from the tree.

A migration note for 3.0.0 needs to say, in this order: add `channelAddress` and `tokenNetworkAddress` to every `chainProviders` entry before upgrading; upgrade EVM and Solana verifiers to the v2 digest / 48-byte message in step with the maker; re-read `tokenNetworks` as leg A and `swapVerifyingContracts` as leg B; and stop treating a swap refusal as uniformly retryable.

I have written no such note and cut no release — #168 asked for the changesets to be correct, and cutting 3.0.0 is your call. The release PR regenerates on merge.

---

## The gate

swap had **no changeset CI job at all**. Ported from toon-client#612 and rig#110, wired into the `CI OK` aggregate, plus a third step neither sibling has.

**1. A PR touching `packages/swap/` must add a changeset.** Verbatim from rig#110, with `PUBLISHABLE="packages/swap"` — the only publishable package here (`packages/swap`, not `private`, and `.changeset/config.json` has an empty `ignore`).

**2. `pnpm changeset version` must succeed.** Byte-identical to what `release.yml` hands `changesets/action` as its `version:` input (`release.yml` ~line 68), so green here means the release gets past versioning with no second implementation to drift. Throwaway the same way the siblings are: a fresh `actions/checkout` on a disposable runner, no step after it, and the bumps it writes are **printed** rather than discarded, because "what version would this release cut" is the useful half of the output — and it is precisely the number #168 was about.

One difference from the ported rationale, stated in the comment rather than copied over: this repo's `ignore` list is empty, so the specific toon-client#611 failure (a changeset naming both an ignored and a non-ignored package) cannot happen here yet. The step still catches an unknown package name, unparseable YAML, and an `ignore` list the day someone adds one.

**3. A changeset that bumps nothing must say so.** This is new, and it is the step that matters, because **neither ported step would have caught #168** — `changeset version` accepts an empty changeset without complaint, and the file-exists check is satisfied by one.

### Is failing on empty frontmatter safe? No — so it doesn't

9 of these 26 legitimately release nothing. A hard "empty is an error" rule would block every CI-only, docs-only and test-only PR in the repo and would have been wrong about a third of the audit. So the rule is not *don't be empty*, it is **empty must be said**: a `changeset:no-release` marker in the body.

```
---
---

<!-- changeset:no-release — .github/workflows only; nothing in the published tarball -->
```

An HTML comment, in the body, so it is invisible where it ends up — and it never ends up anywhere: an empty changeset produces no CHANGELOG entry at all, verified above (`marker leaked into CHANGELOG: 0`).

The honest limit, stated rather than glossed: an author can still mark a behavioural change no-release and be wrong. No static check reads prose. What it removes is the *silent default* — empty now has to be a sentence someone typed, next to a reason, in a diff a reviewer sees. All 22 offenders got there by leaving a template untouched, and that specific route is now closed.

All 9 legitimately-empty changesets are retro-marked in this PR, which is also what lets the check scan the **whole** `.changeset/` directory rather than only the PR's diff. Diff-scoping would have gone green on every one of the PRs that added the 22, and green again on every PR since; whole-tree also means a rebase that drops a marker cannot slip through on a later PR that never touches the file.

### A bare `needs:` blocks nothing

`changeset` is the only job in this workflow with an `if:` of its own (`pull_request` — a push to `main` happens after merge, where there is nothing left to gate). A job skipped by its own `if:` reports `skipped`, and a required check that reads a skip as a pass is not a gate (toon-meta#279, toon#216). So `ci-ok` pairs the result with the reason the skip would be legitimate — the event type, which is not a judgement call and which a broken step cannot lie about:

- `pull_request` → must be `success`. `failure`, `cancelled` **and `skipped`** all fail. This is the merge path.
- anything else → `skipped` (expected) or `success` (someone re-ran it) are both fine.

The other five jobs keep their flat `!= success` chain, and that is complete for them precisely *because* they carry no `if:` — for those, `skipped` cannot mean "correctly not required", only cancelled-upstream or a workflow edit that stopped them running, and both must fail.

### Proof it blocks

Against `origin/main`'s `.changeset` — the 26 files as they are today:

```
$ npx tsx .sandcastle/scripts/changeset-check.ts <origin/main .changeset>
22
exit=1
```

22 `::error::` annotations, exit 1 — the exact 22 the audit found, found independently by the check rather than from a hardcoded list. Against this branch: exit 0, and it reports the release plan it read (`@toon-protocol/swap would take a major bump from these changesets`).

The rule lives in `.sandcastle/scripts/changeset-lib.ts` as a tested module rather than inline YAML, following the `gate-lib.ts` / toon#217 precedent. `changeset-lib.test.ts` — **18 tests, inside the root `pnpm test` include, so the `build` job runs them** — covers the blocking case directly (`BLOCKS an empty changeset that does not declare no-release`, using #101's real text), the malformed and missing-frontmatter cases, that the marker is not read out of the frontmatter block, and that an unknown bump level is reported rather than accepted.

Two of those tests assert against **this repo's own `.changeset/` directory**: that every pending changeset satisfies the rule, and that every declared release names `@toon-protocol/swap`. That is the part that survives someone deleting the CI job — the regression stays caught by `pnpm test`.

---

## Verification

- `pnpm run gate:correctness` — **PASS**: lint 0 errors / 349 warnings (frozen 0/352), typecheck 4 errors (frozen 25). No new violations; the frozen baseline is untouched and the new module uses narrowing guards rather than `!` (there is a comment at the one place that would have been tempting).
- `pnpm test` — **46 files, 558 passed, 2 skipped**, including the 18 new ones.
- `pnpm changeset version` in a throwaway copy — 3.0.0, all 26 changesets consumed, marker text absent from the generated CHANGELOG.
- `ci.yml` parses; job graph and `ci-ok` `needs:` confirmed.

Not run and not touched, per the constraints: no publish, no ssh to any box, no paid or on-chain operation. The `swap-image-build` fleet-config gate is unaffected — this PR changes no config key, adds no required field, and touches nothing under `packages/swap/src/`.

## Prose

No changeset's description was reworded, shortened or deleted. Every edit is frontmatter, plus a marker comment on the 9 no-release files. Those descriptions are the CHANGELOG that never got written, and merging this is what finally lets them be written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
