### PR TITLE
The ADR 0003 removal gate cannot be satisfied: its evidence is deleted by every deploy, and its read pattern never matches

### DIFF
--- a/.changeset/issue-171-durable-intake-ledger.md
+++ b/.changeset/issue-171-durable-intake-ledger.md
@@ -1,0 +1,11 @@
+---
+'@toon-protocol/swap': minor
+---
+
+`GET /admin/intake` — a durable per-class intake ledger backing ADR 0003's removal gate.
+
+swap#152 made every arrival classifiable (`swap.intake.arrival`), but the gate that reads it — "no legacy intake observed for N consecutive days" — could not survive to N days: `swap:release` is auto-on-green, Watchtower recreates the container on every merge, and `docker logs` only ever holds the CURRENT container's stdout. Every recreate reset the observation window to zero. The documented read pattern was also false-green (`"event":"swap.intake"` never matches the real `swap.intake.arrival`), so the gate returned `0 legacy` unconditionally.
+
+A small ledger (per-class count, `firstSeenAt`, `lastSeenAt`, plus the ledger's own `since`) now persists beside the existing `statePath` snapshot — the same durable volume the maker's inventory and channel watermarks already survive a recreate on — and is read back at `GET /admin/intake`, next to the existing `GET /admin/inventory`. `since` distinguishes "this ledger just started" from "legacy has truly been silent"; without it a fresh ledger's `count: 0` is indistinguishable from 90 days of silence.
+
+No new required config key: `intakeLedgerPath` is optional and defaults to `intake-ledger.json` beside `statePath`; with neither set, the ledger still counts in-memory for the life of the process. Unlike `statePath`'s load-fails-loudly policy, a missing or corrupt ledger file starts empty rather than blocking boot, and a ledger write failure is logged and dropped rather than rejecting a swap — this is observability evidence, not a crash-consistency watermark.

--- a/deploy/swap/README.md
+++ b/deploy/swap/README.md
@@ -36,6 +36,7 @@ checked into this repo):
 | `blsPort` | no | `/health` HTTP port. |
 | `btpServerPort` | no | **Required for the proven standalone-maker wiring** — no `connectorUrl`/`connector` set + this present = auto-created embedded `ConnectorNode` with no parent, self-routed. |
 | `statePath` | no | Durable state snapshot path (issue #46) — mount a volume here to persist inventory/watermarks/bindings across restarts. The image pre-creates `/app/state`, owned by the runtime `swap` user (uid `10001`), as the intended mount point — see "Runtime user & filesystem" below. |
+| `intakeLedgerPath` | no | **Issue #171.** Durable per-class intake-ledger path (ADR 0003's removal gate — see "ADR 0003 removal gate" below). Defaults to `intake-ledger.json` beside `statePath`; without either, counts are in-memory only and reset on restart. |
 | `chainProviders` | yes for EVM settlement | Array of `{ chainType: "evm", chainId, rpcUrl, registryAddress, tokenAddress, tokenNetworkAddress, channelAddress, keyId? }` (or the `solana`/`mina` variants — see `SwapNodeChainProvider` in `swap-node.ts`). **Two different contracts, both required** for any EVM chain a `swapPair` targets — boot refuses otherwise: `tokenNetworkAddress` is **leg A**, the deployed `TokenNetwork` a *client* calls `openChannel(address,uint256)` on to open the channel it pays this maker over (this is what the kind:10032 `tokenNetworks` entry advertises, and it must be the same fleet-wide `TokenNetwork` deployment the relay/store/apex announce for this chain+token); `channelAddress` is **leg B**, the deployed `RollingSwapChannel` this maker signs v2 EIP-712 balance-proof claims against (advertised separately as `swapVerifyingContracts`). Never set them to the same address — see issue #133. `keyId` defaults to `settlementPrivateKey` (or the identity secret key) when omitted. |
 | `settlementPrivateKey` | no | Hex EVM private key for the claim signer / `chainProviders[].keyId` default. In the proven wiring this is the **same BIP-44 account-index-2 key** used as the connector `keyId`. **Issue #126:** when the identity is a mnemonic and this is unset (or a `0xdead…`-style placeholder), the CLI auto-derives it via `deriveSwapNodeKeys` (index-2) — a committed skeleton can ship a placeholder here and rely on the CLI to fill in the real key, whether or not `identityAutogen` is used. |
 | `identityAutogen` | no | **Issue #126.** When `true` (or `SWAP_AUTOGEN_IDENTITY=1`) and no identity is otherwise provided, self-generates a BIP-39 mnemonic and persists it to an identity file (mode 600, default beside `statePath`) so restarts reuse the same identity. No-op if `mnemonic`/`secretKey` is set. |
@@ -61,6 +62,7 @@ inject the secret from a mount rather than baking it into the config file.
 | `SWAP_BLS_PORT` | Overrides `blsPort`. |
 | `SWAP_RELAYS` | Comma-separated relay WS URLs, overrides `relayUrls`. |
 | `SWAP_STATE_PATH` | Overrides `statePath`. |
+| `SWAP_INTAKE_LEDGER_PATH` | **Issue #171.** Overrides `intakeLedgerPath`. |
 | `TOON_CONNECTOR_URL` | Parent BTP URL — activates embedded-with-parent mode instead of standalone. |
 | `TOON_PARENT_PEER_ID` | Parent peer id (default `apex`). |
 | `TOON_PARENT_AUTH_TOKEN` | BTP auth token for the parent peer. |
@@ -117,6 +119,7 @@ the chain key of the `chainProviders` entry you already have.
 | `POST /admin/inventory/reconcile` | token | Force a chain-truth pass now; returns what it recycled. |
 | `POST /admin/inventory/credit` | token | `{ assetCode, chain, amount? }` — recycle burned capital. Applies **only** what an on-chain redemption corroborates: an uncorroborated request (or one larger than the chain backs) is refused `409` with nothing applied. |
 | `POST /admin/inventory/deposit` | token | **swap#142.** `{ assetCode, chain, amount?, dryRun? }` — book genuinely NEW capital. Applies **only** what the pool's on-chain channel funding corroborates. |
+| `GET /admin/intake` | none | **Issue #171.** Per-class intake counts backing ADR 0003's removal gate — see below. |
 
 ### Adding capital (swap#142)
 
@@ -206,6 +209,46 @@ and it is deliberately **not** corrected by any live write path:
 If it must be exact sooner, do it with the node **down** — stop the maker,
 edit the persisted pool entry in `swap-node-state.json`, restart. That is a
 deliberate human action, not a route that can be fired by accident.
+
+## ADR 0003 removal gate (issue #171)
+
+ADR 0003's removal gate is *"no legacy intake observed on the deployed maker
+for N consecutive days"*. **Do not read this from `docker logs`.**
+`swap:release` is auto-on-green and Watchtower recreates the `swap-node`
+container on every merge to `main`; `docker logs` only ever holds the
+CURRENT container's stdout, so every recreate silently resets the
+observation window to zero and any `docker logs | grep swap.intake.arrival`
+count is a lie about how long legacy has actually been silent.
+
+Read the durable ledger instead — it survives a recreate because it lives
+beside `statePath` on the same persistent volume:
+
+```sh
+curl -s http://127.0.0.1:<blsPort>/admin/intake | jq .
+```
+
+```json
+{
+  "generatedAt": 1755450000000,
+  "since": 1754845200000,
+  "classes": [
+    { "class": "legacy", "count": 0 },
+    { "class": "rolling-rfq", "count": 812, "firstSeenAt": 1754845201000, "lastSeenAt": 1755449999000 },
+    { "class": "rolling-fill", "count": 799, "firstSeenAt": 1754845202000, "lastSeenAt": 1755449999500 },
+    { "class": "refused", "count": 3, "firstSeenAt": 1754900000000, "lastSeenAt": 1755000000000 }
+  ]
+}
+```
+
+The gate is satisfied only when **both** hold: `legacy.count === 0` (or, for
+a maker with prior legacy traffic, `Date.now() - legacy.lastSeenAt >= N
+days`) **and** `Date.now() - since >= N days`. The second check is what a
+`docker logs` grep could never give: without `since`, a ledger that just
+started reads identically to one that has genuinely observed N days of
+silence — a freshly-recreated container's `count: 0` is not evidence of
+anything yet. A class that has never fired at all omits `firstSeenAt`/
+`lastSeenAt` rather than reporting `0`, which would be indistinguishable
+from a real epoch-0 timestamp.
 
 ## Runtime user & filesystem
 

--- a/deploy/swap/README.md
+++ b/deploy/swap/README.md
@@ -250,6 +250,11 @@ anything yet. A class that has never fired at all omits `firstSeenAt`/
 `lastSeenAt` rather than reporting `0`, which would be indistinguishable
 from a real epoch-0 timestamp.
 
+The ledger file is written by the first arrival, not at boot, so a maker
+that has served *nothing at all* since the ledger shipped starts each
+restart with a fresh `since` — that fails the second check rather than
+passing it, which is the safe direction: no arrivals is no evidence.
+
 ## Runtime user & filesystem
 
 The container runs as a non-root `swap` user, uid/gid `10001`. Two paths are

--- a/packages/swap/src/admin-surface.ts
+++ b/packages/swap/src/admin-surface.ts
@@ -10,7 +10,7 @@
  * `nonce`/`cumulativeAmount` BELOW claims already issued and invites a
  * replay — see `state-store.ts`).
  *
- * Four routes, mounted on the existing BLS server under `/admin`:
+ * Five routes, mounted on the existing BLS server under `/admin`:
  *
  * - `GET  /admin/inventory`           — read: per-pool buckets, per-channel
  *   issued-vs-redeemed, and an explicit reason when issuance is blocked.
@@ -20,6 +20,11 @@
  * - `POST /admin/inventory/deposit`   — write (swap#142): book genuinely NEW
  *   capital, and ONLY the amount the pool's on-chain channel funding
  *   corroborates.
+ * - `GET  /admin/intake`              — read (issue #171): per-class
+ *   cumulative counts + first/last-seen timestamps from the durable intake
+ *   ledger, and the ledger's own `since` — the reading ADR 0003's removal
+ *   gate is actually taken from. See `intake-ledger.ts` for why this has to
+ *   be a persisted watermark rather than a `docker logs` grep.
  *
  * ## Recycling vs. new capital (swap#142)
  *
@@ -73,6 +78,9 @@ import type {
   ReconcileResult,
   SwapInventoryReconciler,
 } from './inventory-reconciler.js';
+import { SWAP_INTAKE_CLASSES } from './intake-event.js';
+import type { SwapIntakeClass } from './intake-event.js';
+import type { IntakeLedger } from './intake-ledger.js';
 
 export interface AdminChannelView {
   channelId: string;
@@ -127,6 +135,8 @@ export interface AdminInventoryReport {
 export interface AdminSurfaceDeps {
   inventory: SwapInventory;
   reconciler: SwapInventoryReconciler;
+  /** Issue #171 — backs `GET /admin/intake`. */
+  intakeLedger: IntakeLedger;
   /** Operator token; absent ⇒ writes disabled. */
   adminToken?: string;
   clock?: () => number;
@@ -299,6 +309,49 @@ export function buildInventoryReport(
   };
 }
 
+export interface AdminIntakeClassView {
+  class: SwapIntakeClass;
+  count: number;
+  /** Absent when this class has never been observed by this ledger. */
+  firstSeenAt?: number;
+  lastSeenAt?: number;
+}
+
+export interface AdminIntakeReport {
+  generatedAt: number;
+  /**
+   * ms-epoch this ledger started observing (issue #171). A class reading 0
+   * is only meaningful once `generatedAt - since` covers the gate's full
+   * window — a fresh ledger and 90 days of silence both read `count: 0`,
+   * and only `since` tells them apart.
+   */
+  since: number;
+  /** Always all four classes, in `SWAP_INTAKE_CLASSES` order — an absent
+   *  class would be indistinguishable from a class this build forgot. */
+  classes: AdminIntakeClassView[];
+}
+
+/** Build the operator read view backing `GET /admin/intake` (issue #171). */
+export function buildIntakeReport(deps: AdminSurfaceDeps): AdminIntakeReport {
+  const clock = deps.clock ?? Date.now;
+  const persisted = deps.intakeLedger.snapshot();
+  return {
+    generatedAt: clock(),
+    since: persisted.since,
+    classes: SWAP_INTAKE_CLASSES.map((intakeClass) => {
+      const entry = persisted.classes[intakeClass];
+      return {
+        class: intakeClass,
+        count: entry?.count ?? 0,
+        ...(entry !== undefined && {
+          firstSeenAt: entry.firstSeenAt,
+          lastSeenAt: entry.lastSeenAt,
+        }),
+      };
+    }),
+  };
+}
+
 /** JSON-safe projection of a reconcile pass. */
 function serializeReconcile(result: ReconcileResult): Record<string, unknown> {
   return {
@@ -414,6 +467,12 @@ export function registerAdminRoutes(app: Hono, deps: AdminSurfaceDeps): void {
   app.get('/admin/inventory', (c: Context) =>
     c.json(buildInventoryReport(deps))
   );
+
+  // Issue #171 — read-only, unauthenticated, same protection as
+  // /admin/inventory (box nginx `^~ /admin` 404 rule) and same reasoning:
+  // this discloses strictly less than an operator with shell access to the
+  // state volume could already read from intake-ledger.json.
+  app.get('/admin/intake', (c: Context) => c.json(buildIntakeReport(deps)));
 
   app.post('/admin/inventory/reconcile', async (c: Context) => {
     const denied = denyWrite(c);

--- a/packages/swap/src/cli.ts
+++ b/packages/swap/src/cli.ts
@@ -24,6 +24,13 @@
  *                            enables persistence of inventory, channel
  *                            watermarks, sticky bindings + replay
  *                            reservations across restarts
+ *   SWAP_INTAKE_LEDGER_PATH — durable per-class intake ledger path (issue
+ *                            #171, ADR 0003's removal gate — read at
+ *                            GET /admin/intake). OPTIONAL: defaults to
+ *                            `intake-ledger.json` beside SWAP_STATE_PATH
+ *                            when that is set; a missing/corrupt file
+ *                            starts empty rather than crash-looping the
+ *                            maker.
  *   TOON_CONNECTOR_URL     — parent BTP URL; activates embedded-with-parent mode
  *   TOON_PARENT_PEER_ID    — peer id for the parent (default: "apex")
  *   TOON_PARENT_AUTH_TOKEN — BTP auth token for the parent peer (default: "")
@@ -135,6 +142,8 @@ interface CliRawConfig {
   btpServerPort?: number;
   /** Durable swap-state snapshot path (issue #46). */
   statePath?: string;
+  /** Durable intake-ledger path (issue #171); defaults beside statePath. */
+  intakeLedgerPath?: string;
   passphrase?: string;
   knownPeers?: { ilpAddress: string; btpUrl?: string }[];
   // Story 12.7 Review Pass #1 additions — operator-surfaced kind:10032 fields.
@@ -270,6 +279,7 @@ function parseRawConfig(raw: CliRawConfig): SwapNodeConfig {
   if (raw.blsPort !== undefined) cfg.blsPort = raw.blsPort;
   if (raw.btpServerPort !== undefined) cfg.btpServerPort = raw.btpServerPort;
   if (raw.statePath) cfg.statePath = raw.statePath;
+  if (raw.intakeLedgerPath) cfg.intakeLedgerPath = raw.intakeLedgerPath;
   if (raw.passphrase) cfg.passphrase = raw.passphrase;
   if (raw.knownPeers) cfg.knownPeers = raw.knownPeers;
   if (raw.ilpAddress) cfg.ilpAddress = raw.ilpAddress;
@@ -342,6 +352,9 @@ function applyEnvOverlay(cfg: SwapNodeConfig): SwapNodeConfig {
       .filter(Boolean);
   }
   if (env['SWAP_STATE_PATH']) out.statePath = env['SWAP_STATE_PATH'];
+  if (env['SWAP_INTAKE_LEDGER_PATH']) {
+    out.intakeLedgerPath = env['SWAP_INTAKE_LEDGER_PATH'];
+  }
   // Embedded-with-parent connector wiring (TOON_* env vars). Setting
   // TOON_CONNECTOR_URL activates the embedded-with-parent path; the
   // remaining TOON_* vars are optional refinements.

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -127,11 +127,7 @@ export {
   formatPairLabel,
 } from './intake-event.js';
 export type { SwapIntakeClass } from './intake-event.js';
-export {
-  IntakeLedger,
-  JsonFileIntakeLedgerStore,
-  validatePersistedIntakeLedger,
-} from './intake-ledger.js';
+export { IntakeLedger, JsonFileIntakeLedgerStore } from './intake-ledger.js';
 export type {
   IntakeLedgerStore,
   IntakeLedgerInit,

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -41,12 +41,19 @@ export type {
   ChannelFundingObservation,
   PoolFundingReading,
 } from './inventory-reconciler.js';
-export { buildInventoryReport, registerAdminRoutes } from './admin-surface.js';
+export {
+  buildInventoryReport,
+  buildIntakeReport,
+  registerAdminRoutes,
+} from './admin-surface.js';
 export type {
   AdminInventoryReport,
   AdminPoolView,
   AdminChannelView,
   AdminSurfaceDeps,
+  // Issue #171 — the `GET /admin/intake` report shape.
+  AdminIntakeReport,
+  AdminIntakeClassView,
 } from './admin-surface.js';
 
 // Payment-channel signing (Story 12.4)
@@ -109,6 +116,28 @@ export type {
   PersistedChannelEntry,
   PersistedReservationEntry,
 } from './state-store.js';
+
+// Intake classification + durable ledger (swap#152, issue #171 — ADR 0003's
+// removal gate). `swap.intake.arrival` classifies every arrival; the ledger
+// is what makes "no legacy for N consecutive days" survive a Watchtower
+// recreate instead of resetting to zero on every deploy.
+export {
+  SWAP_INTAKE_EVENT,
+  SWAP_INTAKE_CLASSES,
+  formatPairLabel,
+} from './intake-event.js';
+export type { SwapIntakeClass } from './intake-event.js';
+export {
+  IntakeLedger,
+  JsonFileIntakeLedgerStore,
+  validatePersistedIntakeLedger,
+} from './intake-ledger.js';
+export type {
+  IntakeLedgerStore,
+  IntakeLedgerInit,
+  PersistedIntakeLedger,
+  IntakeLedgerClassEntry,
+} from './intake-ledger.js';
 
 // Errors (Story 12.4)
 export { SwapInventoryError, SwapWalletError } from './errors.js';

--- a/packages/swap/src/intake-event.ts
+++ b/packages/swap/src/intake-event.ts
@@ -23,12 +23,18 @@ export const SWAP_INTAKE_EVENT = 'swap.intake.arrival';
  * - `rolling-rfq` — inner rumor kind:20033;
  * - `rolling-fill` — a coupled fill under a sender-chosen condition;
  * - `refused` — rejected before dispatch, carrying the reject reason.
+ *
+ * Canonical list (issue #171's intake ledger validates/reports against this
+ * rather than a second, driftable copy of the four literals).
  */
-export type SwapIntakeClass =
-  | 'legacy'
-  | 'rolling-rfq'
-  | 'rolling-fill'
-  | 'refused';
+export const SWAP_INTAKE_CLASSES = [
+  'legacy',
+  'rolling-rfq',
+  'rolling-fill',
+  'refused',
+] as const;
+
+export type SwapIntakeClass = (typeof SWAP_INTAKE_CLASSES)[number];
 
 /** Minimal pair shape — satisfied by both `SwapPair` and an RFQ's requested pair. */
 interface PairLike {

--- a/packages/swap/src/intake-ledger.test.ts
+++ b/packages/swap/src/intake-ledger.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Issue #171 — durable intake ledger tests.
+ *
+ * Covers:
+ *   - `JsonFileIntakeLedgerStore` atomic save/load roundtrip
+ *   - tolerant load: missing/corrupt/invalid file starts empty, never throws
+ *   - `IntakeLedger` counting, `since` semantics, and best-effort persist
+ */
+import { mkdtempSync, existsSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+import {
+  JsonFileIntakeLedgerStore,
+  IntakeLedger,
+  validatePersistedIntakeLedger,
+} from './intake-ledger.js';
+import type {
+  IntakeLedgerStore,
+  PersistedIntakeLedger,
+} from './intake-ledger.js';
+
+const tmpDirs: string[] = [];
+function makeTmpDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'swap-intake-ledger-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe('JsonFileIntakeLedgerStore', () => {
+  it('[P0] save → load roundtrips the exact state', () => {
+    const dir = makeTmpDir();
+    const store = new JsonFileIntakeLedgerStore(
+      join(dir, 'intake-ledger.json')
+    );
+    const state: PersistedIntakeLedger = {
+      version: 1,
+      since: 1000,
+      classes: {
+        legacy: { count: 3, firstSeenAt: 1000, lastSeenAt: 5000 },
+        'rolling-rfq': { count: 1, firstSeenAt: 2000, lastSeenAt: 2000 },
+      },
+    };
+    store.save(state);
+    expect(store.load()).toEqual(state);
+  });
+
+  it('[P1] load() returns null when no file exists', () => {
+    const dir = makeTmpDir();
+    const store = new JsonFileIntakeLedgerStore(join(dir, 'nope.json'));
+    expect(store.load()).toBeNull();
+  });
+
+  it('[P0] corrupt JSON starts empty (load() returns null), never throws', () => {
+    const dir = makeTmpDir();
+    const path = join(dir, 'intake-ledger.json');
+    writeFileSync(path, '{ not json', 'utf-8');
+    const store = new JsonFileIntakeLedgerStore(path);
+    expect(store.load()).toBeNull();
+  });
+
+  it('[P0] a file with an unknown class returns null (start empty) rather than throwing', () => {
+    const dir = makeTmpDir();
+    const path = join(dir, 'intake-ledger.json');
+    writeFileSync(
+      path,
+      JSON.stringify({
+        version: 1,
+        since: 1,
+        classes: { bogus: { count: 1, firstSeenAt: 1, lastSeenAt: 1 } },
+      }),
+      'utf-8'
+    );
+    const store = new JsonFileIntakeLedgerStore(path);
+    expect(store.load()).toBeNull();
+  });
+
+  it('[P1] save() creates missing parent directories and leaves no .tmp behind', () => {
+    const dir = makeTmpDir();
+    const nested = join(dir, 'a', 'b', 'intake-ledger.json');
+    const store = new JsonFileIntakeLedgerStore(nested);
+    store.save({ version: 1, since: 1, classes: {} });
+    expect(existsSync(nested)).toBe(true);
+    expect(existsSync(`${nested}.tmp`)).toBe(false);
+  });
+
+  it('[P1] save() over an existing snapshot replaces it atomically (last write wins)', () => {
+    const dir = makeTmpDir();
+    const path = join(dir, 'intake-ledger.json');
+    const store = new JsonFileIntakeLedgerStore(path);
+    store.save({ version: 1, since: 1, classes: {} });
+    store.save({
+      version: 1,
+      since: 1,
+      classes: { legacy: { count: 1, firstSeenAt: 5, lastSeenAt: 5 } },
+    });
+    expect(store.load()).toEqual({
+      version: 1,
+      since: 1,
+      classes: { legacy: { count: 1, firstSeenAt: 5, lastSeenAt: 5 } },
+    });
+  });
+});
+
+describe('validatePersistedIntakeLedger', () => {
+  it('[P2] rejects a non-object, an unsupported version, and a non-finite since', () => {
+    expect(() => validatePersistedIntakeLedger(null)).toThrow();
+    expect(() =>
+      validatePersistedIntakeLedger({ version: 2, since: 1, classes: {} })
+    ).toThrow();
+    expect(() =>
+      validatePersistedIntakeLedger({ version: 1, since: 'nope', classes: {} })
+    ).toThrow();
+  });
+});
+
+describe('IntakeLedger', () => {
+  it('[P0] first record() sets both firstSeenAt and lastSeenAt; subsequent records advance only lastSeenAt', () => {
+    const ledger = new IntakeLedger();
+    ledger.record('legacy', 100);
+    ledger.record('legacy', 200);
+    ledger.record('legacy', 300);
+    const snap = ledger.snapshot();
+    expect(snap.classes['legacy']).toEqual({
+      count: 3,
+      firstSeenAt: 100,
+      lastSeenAt: 300,
+    });
+  });
+
+  it('[P0] classes are independent — recording one class never touches another', () => {
+    const ledger = new IntakeLedger();
+    ledger.record('legacy', 100);
+    ledger.record('rolling-rfq', 200);
+    const snap = ledger.snapshot();
+    expect(snap.classes['legacy']).toEqual({
+      count: 1,
+      firstSeenAt: 100,
+      lastSeenAt: 100,
+    });
+    expect(snap.classes['rolling-rfq']).toEqual({
+      count: 1,
+      firstSeenAt: 200,
+      lastSeenAt: 200,
+    });
+    expect(snap.classes['rolling-fill']).toBeUndefined();
+    expect(snap.classes['refused']).toBeUndefined();
+  });
+
+  it('[P0] `since` defaults to the clock at construction when nothing is persisted', () => {
+    const ledger = new IntakeLedger({ clock: () => 42_000 });
+    expect(ledger.snapshot().since).toBe(42_000);
+  });
+
+  it('[P0] `since` carries forward from a persisted ledger, even across a class that has never fired', () => {
+    const dir = makeTmpDir();
+    const store = new JsonFileIntakeLedgerStore(
+      join(dir, 'intake-ledger.json')
+    );
+    store.save({ version: 1, since: 1_000, classes: {} });
+
+    const ledger = new IntakeLedger({ store, clock: () => 999_999 });
+    expect(ledger.snapshot().since).toBe(1_000);
+    expect(ledger.snapshot().classes['legacy']).toBeUndefined();
+  });
+
+  it('[P0] restart rehydrates counts, and `since` never regresses — a fresh boot does not reset the observation window', () => {
+    const dir = makeTmpDir();
+    const path = join(dir, 'intake-ledger.json');
+
+    const first = new IntakeLedger({
+      store: new JsonFileIntakeLedgerStore(path),
+      clock: () => 1_000,
+    });
+    first.record('legacy', 1_000);
+    first.record('legacy', 2_000);
+
+    // Simulate a Watchtower recreate: fresh process, same durable path.
+    const second = new IntakeLedger({
+      store: new JsonFileIntakeLedgerStore(path),
+      clock: () => 50_000,
+    });
+    expect(second.snapshot()).toEqual({
+      version: 1,
+      since: 1_000,
+      classes: { legacy: { count: 2, firstSeenAt: 1_000, lastSeenAt: 2_000 } },
+    });
+
+    second.record('legacy', 60_000);
+    expect(second.snapshot().classes['legacy']).toEqual({
+      count: 3,
+      firstSeenAt: 1_000,
+      lastSeenAt: 60_000,
+    });
+  });
+
+  it('[P0] a save() failure is caught and dropped — record() never throws', () => {
+    const failing: IntakeLedgerStore = {
+      load: () => null,
+      save: () => {
+        throw new Error('disk full');
+      },
+    };
+    const warnings: { message: string; meta?: Record<string, unknown> }[] = [];
+    const ledger = new IntakeLedger({
+      store: failing,
+      logger: { warn: (message, meta) => warnings.push({ message, meta }) },
+    });
+    expect(() => ledger.record('legacy', 1)).not.toThrow();
+    expect(ledger.snapshot().classes['legacy']).toEqual({
+      count: 1,
+      firstSeenAt: 1,
+      lastSeenAt: 1,
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.message).toBe('swap.intake.ledger_persist_failed');
+  });
+
+  it('[P1] a load() failure at construction is caught and dropped — starts empty', () => {
+    const failing: IntakeLedgerStore = {
+      load: () => {
+        throw new Error('permission denied');
+      },
+      save: () => undefined,
+    };
+    const warnings: string[] = [];
+    const ledger = new IntakeLedger({
+      store: failing,
+      logger: { warn: (message) => warnings.push(message) },
+    });
+    expect(ledger.snapshot().classes).toEqual({});
+    expect(warnings).toContain('swap.intake.ledger_load_failed');
+  });
+
+  it('[P2] without a store, counts still accumulate in-memory (no persistence, no crash)', () => {
+    const ledger = new IntakeLedger();
+    ledger.record('refused', 1);
+    ledger.record('refused', 2);
+    expect(ledger.snapshot().classes['refused']).toEqual({
+      count: 2,
+      firstSeenAt: 1,
+      lastSeenAt: 2,
+    });
+  });
+});

--- a/packages/swap/src/intake-ledger.ts
+++ b/packages/swap/src/intake-ledger.ts
@@ -1,0 +1,257 @@
+/**
+ * Durable intake ledger — ADR 0003's removal gate, issue #171.
+ *
+ * swap#152 made every arrival classifiable (`swap.intake.arrival`, one line
+ * per packet), but the gate that reads it — "no legacy intake observed for N
+ * consecutive days" — cannot survive to N days from a log line alone:
+ * `swap:release` is auto-on-green, Watchtower recreates the container on
+ * every merge, and `docker logs` only ever holds the CURRENT container's
+ * stdout. Every recreate resets the observation window to zero.
+ *
+ * This module turns the reading into a watermark instead of a log-retention
+ * accident: a small per-class ledger (count / firstSeenAt / lastSeenAt),
+ * persisted on the same durable state volume the maker's inventory and
+ * channel watermarks already survive Watchtower recreates on. Exposed
+ * read-only at `GET /admin/intake` (`admin-surface.ts`).
+ *
+ * Deliberately NOT the crash-loud discipline of `JsonFileSwapStateStore`
+ * (state-store.ts): a corrupt or missing ledger file is observability
+ * evidence, not a crash-consistency watermark whose loss risks a double
+ * spend, so `JsonFileIntakeLedgerStore.load()` starts empty rather than
+ * throwing, and `IntakeLedger.record()` never lets a persist failure
+ * propagate — counting must never be able to fail an arrival.
+ *
+ * `since` is the ledger's own start time (first boot with no persisted
+ * file), carried forward across every subsequent restart even for classes
+ * that have never fired. Without it, a fresh ledger's "0 legacy, ever"
+ * reads identically to "legacy has been silent for 90 days" — the same
+ * false-green issue #171 exists to close.
+ */
+
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  writeSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+
+import { SWAP_INTAKE_CLASSES } from './intake-event.js';
+import type { SwapIntakeClass } from './intake-event.js';
+
+export interface IntakeLedgerClassEntry {
+  count: number;
+  /** ms-epoch of this class's first-ever recorded arrival. */
+  firstSeenAt: number;
+  /** ms-epoch of this class's most recent recorded arrival. */
+  lastSeenAt: number;
+}
+
+export interface PersistedIntakeLedger {
+  version: 1;
+  /** ms-epoch this ledger started observing (never regresses across restarts). */
+  since: number;
+  classes: Partial<Record<SwapIntakeClass, IntakeLedgerClassEntry>>;
+}
+
+/** Storage abstraction, mirroring `SwapStateStore` (state-store.ts). */
+export interface IntakeLedgerStore {
+  /** Returns `null` when nothing has ever been persisted OR the file is unreadable. */
+  load(): PersistedIntakeLedger | null;
+  save(state: PersistedIntakeLedger): void;
+}
+
+function isIntakeClass(v: unknown): v is SwapIntakeClass {
+  return (
+    typeof v === 'string' &&
+    (SWAP_INTAKE_CLASSES as readonly string[]).includes(v)
+  );
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v);
+}
+
+/** @internal — exported for direct testing of the validation surface. */
+export function validatePersistedIntakeLedger(
+  raw: unknown
+): PersistedIntakeLedger {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error('intake ledger state must be a JSON object');
+  }
+  const rec = raw as Record<string, unknown>;
+  if (rec['version'] !== 1) {
+    throw new Error(
+      `unsupported intake ledger schema version ${JSON.stringify(rec['version'])} (expected 1)`
+    );
+  }
+  if (!isFiniteNumber(rec['since'])) {
+    throw new Error('intake ledger state.since must be a finite number');
+  }
+  const classesRaw = rec['classes'];
+  if (
+    typeof classesRaw !== 'object' ||
+    classesRaw === null ||
+    Array.isArray(classesRaw)
+  ) {
+    throw new Error('intake ledger state.classes must be an object');
+  }
+  const classes: Partial<Record<SwapIntakeClass, IntakeLedgerClassEntry>> = {};
+  for (const [k, v] of Object.entries(classesRaw as Record<string, unknown>)) {
+    if (!isIntakeClass(k)) {
+      throw new Error(`intake ledger state.classes has unknown class "${k}"`);
+    }
+    const entry = v as Record<string, unknown>;
+    if (!isFiniteNumber(entry?.['count']) || entry['count'] < 0) {
+      throw new Error(
+        `intake ledger state.classes["${k}"].count must be a non-negative number`
+      );
+    }
+    if (!isFiniteNumber(entry?.['firstSeenAt'])) {
+      throw new Error(
+        `intake ledger state.classes["${k}"].firstSeenAt must be a finite number`
+      );
+    }
+    if (!isFiniteNumber(entry?.['lastSeenAt'])) {
+      throw new Error(
+        `intake ledger state.classes["${k}"].lastSeenAt must be a finite number`
+      );
+    }
+    classes[k] = {
+      count: entry['count'] as number,
+      firstSeenAt: entry['firstSeenAt'] as number,
+      lastSeenAt: entry['lastSeenAt'] as number,
+    };
+  }
+  return { version: 1, since: rec['since'] as number, classes };
+}
+
+/**
+ * File-backed {@link IntakeLedgerStore}. Same atomic-rename durability as
+ * `JsonFileSwapStateStore` (write `<path>.tmp`, `fsync`, `rename`), but with
+ * a tolerant load: a missing or corrupt file returns `null` (start empty)
+ * rather than throwing — this ledger is evidence, not a crash-consistency
+ * watermark, and must never be able to block boot or a swap.
+ */
+export class JsonFileIntakeLedgerStore implements IntakeLedgerStore {
+  private readonly filePath: string;
+
+  constructor(filePath: string) {
+    if (typeof filePath !== 'string' || filePath.length === 0) {
+      throw new Error(
+        'JsonFileIntakeLedgerStore requires a non-empty file path'
+      );
+    }
+    this.filePath = filePath;
+  }
+
+  load(): PersistedIntakeLedger | null {
+    if (!existsSync(this.filePath)) return null;
+    try {
+      const raw: unknown = JSON.parse(readFileSync(this.filePath, 'utf-8'));
+      return validatePersistedIntakeLedger(raw);
+    } catch {
+      // Corrupt/unreadable/invalid — start empty rather than crash the
+      // maker (issue #171): this is observability evidence, not a
+      // crash-consistency watermark.
+      return null;
+    }
+  }
+
+  save(state: PersistedIntakeLedger): void {
+    const tmpPath = `${this.filePath}.tmp`;
+    mkdirSync(dirname(this.filePath), { recursive: true });
+    const json = JSON.stringify(state, null, 2);
+    const fd = openSync(tmpPath, 'w');
+    try {
+      writeSync(fd, json, null, 'utf-8');
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+    renameSync(tmpPath, this.filePath);
+    try {
+      const dirFd = openSync(dirname(this.filePath), 'r');
+      try {
+        fsyncSync(dirFd);
+      } finally {
+        closeSync(dirFd);
+      }
+    } catch {
+      // Not supported on all platforms/filesystems — the file-level fsync
+      // above already guarantees snapshot integrity.
+    }
+  }
+}
+
+export interface IntakeLedgerInit {
+  /** Omitted → in-memory only; counts still accumulate but reset on restart. */
+  store?: IntakeLedgerStore;
+  clock?: () => number;
+  logger?: { warn?: (message: string, meta?: Record<string, unknown>) => void };
+}
+
+/**
+ * In-memory ledger, optionally backed by an {@link IntakeLedgerStore}.
+ * `record()` never throws — a write failure is logged and dropped so
+ * counting can never fail an arrival (issue #171 constraint).
+ */
+export class IntakeLedger {
+  private readonly store?: IntakeLedgerStore;
+  private readonly clock: () => number;
+  private readonly logger?: IntakeLedgerInit['logger'];
+  private readonly since: number;
+  private readonly classes: Partial<
+    Record<SwapIntakeClass, IntakeLedgerClassEntry>
+  >;
+
+  constructor(init: IntakeLedgerInit = {}) {
+    this.store = init.store;
+    this.clock = init.clock ?? Date.now;
+    this.logger = init.logger;
+
+    let persisted: PersistedIntakeLedger | null = null;
+    if (this.store) {
+      try {
+        persisted = this.store.load();
+      } catch (err) {
+        this.logger?.warn?.('swap.intake.ledger_load_failed', {
+          err: err instanceof Error ? err.message : String(err),
+        });
+        persisted = null;
+      }
+    }
+    this.since = persisted?.since ?? this.clock();
+    this.classes = persisted ? { ...persisted.classes } : {};
+  }
+
+  /** Update this class's counters and best-effort persist the new snapshot. */
+  record(intakeClass: SwapIntakeClass, at: number = this.clock()): void {
+    const existing = this.classes[intakeClass];
+    this.classes[intakeClass] = existing
+      ? {
+          count: existing.count + 1,
+          firstSeenAt: existing.firstSeenAt,
+          lastSeenAt: at,
+        }
+      : { count: 1, firstSeenAt: at, lastSeenAt: at };
+
+    if (!this.store) return;
+    try {
+      this.store.save(this.snapshot());
+    } catch (err) {
+      this.logger?.warn?.('swap.intake.ledger_persist_failed', {
+        class: intakeClass,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  snapshot(): PersistedIntakeLedger {
+    return { version: 1, since: this.since, classes: { ...this.classes } };
+  }
+}

--- a/packages/swap/src/intake-ledger.ts
+++ b/packages/swap/src/intake-ledger.ts
@@ -105,26 +105,26 @@ export function validatePersistedIntakeLedger(
     if (!isIntakeClass(k)) {
       throw new Error(`intake ledger state.classes has unknown class "${k}"`);
     }
-    const entry = v as Record<string, unknown>;
-    if (!isFiniteNumber(entry?.['count']) || entry['count'] < 0) {
+    const entry = v as Record<string, unknown> | null;
+    const numericField = (field: keyof IntakeLedgerClassEntry): number => {
+      const value = entry?.[field];
+      if (!isFiniteNumber(value)) {
+        throw new Error(
+          `intake ledger state.classes["${k}"].${field} must be a finite number`
+        );
+      }
+      return value;
+    };
+    const count = numericField('count');
+    if (count < 0) {
       throw new Error(
         `intake ledger state.classes["${k}"].count must be a non-negative number`
       );
     }
-    if (!isFiniteNumber(entry?.['firstSeenAt'])) {
-      throw new Error(
-        `intake ledger state.classes["${k}"].firstSeenAt must be a finite number`
-      );
-    }
-    if (!isFiniteNumber(entry?.['lastSeenAt'])) {
-      throw new Error(
-        `intake ledger state.classes["${k}"].lastSeenAt must be a finite number`
-      );
-    }
     classes[k] = {
-      count: entry['count'] as number,
-      firstSeenAt: entry['firstSeenAt'] as number,
-      lastSeenAt: entry['lastSeenAt'] as number,
+      count,
+      firstSeenAt: numericField('firstSeenAt'),
+      lastSeenAt: numericField('lastSeenAt'),
     };
   }
   return { version: 1, since: rec['since'] as number, classes };

--- a/packages/swap/src/inventory-deposit.test.ts
+++ b/packages/swap/src/inventory-deposit.test.ts
@@ -27,6 +27,7 @@ import type {
 } from './channel-state.js';
 import { SwapInventoryReconciler } from './inventory-reconciler.js';
 import { registerAdminRoutes } from './admin-surface.js';
+import { IntakeLedger } from './intake-ledger.js';
 import { createEvmChannelOnChainReader } from './evm-channel-reader.js';
 import { composeChannelOnChainReaders } from './channel-reader.js';
 
@@ -135,6 +136,7 @@ function makeAdminApp(p: {
   registerAdminRoutes(app, {
     inventory: p.inventory,
     reconciler: p.reconciler,
+    intakeLedger: new IntakeLedger(),
     ...(p.adminToken !== undefined && { adminToken: p.adminToken }),
   });
   return app;

--- a/packages/swap/src/inventory-reconciler.test.ts
+++ b/packages/swap/src/inventory-reconciler.test.ts
@@ -21,6 +21,7 @@ import type { ReconcileResult } from './inventory-reconciler.js';
 import type { ChannelOnChainReader } from './channel-state.js';
 import { registerAdminRoutes, buildInventoryReport } from './admin-surface.js';
 import type { AdminInventoryReport } from './admin-surface.js';
+import { IntakeLedger } from './intake-ledger.js';
 
 const ASSET = 'USDC';
 const CHAIN = 'evm:base:8453';
@@ -305,6 +306,7 @@ function makeAdminApp(p: {
   registerAdminRoutes(app, {
     inventory: p.inventory,
     reconciler: p.reconciler,
+    intakeLedger: new IntakeLedger(),
     ...(p.adminToken !== undefined && { adminToken: p.adminToken }),
   });
   return app;
@@ -352,7 +354,11 @@ describe('operator read surface — GET /admin/inventory', () => {
       reader: fakeReader({ redeemed: 0n }),
     });
 
-    const body = buildInventoryReport({ inventory, reconciler });
+    const body = buildInventoryReport({
+      inventory,
+      reconciler,
+      intakeLedger: new IntakeLedger(),
+    });
     expect(must(body.pools[0], 'pool view').issuanceBlocked).toBe(false);
     expect(must(body.pools[0], 'pool view').blockedReason).toBeUndefined();
     expect(body.writes.enabled).toBe(false);
@@ -370,7 +376,11 @@ describe('operator read surface — GET /admin/inventory', () => {
       channelState: makeChannelState(100n),
     });
 
-    const body = buildInventoryReport({ inventory, reconciler });
+    const body = buildInventoryReport({
+      inventory,
+      reconciler,
+      intakeLedger: new IntakeLedger(),
+    });
     expect(body.reconciler.enabled).toBe(false);
     expect(must(body.pools[0], 'pool view').blockedReason).toContain(
       'NO on-chain reader is configured'

--- a/packages/swap/src/rolling-rfq.ts
+++ b/packages/swap/src/rolling-rfq.ts
@@ -51,6 +51,7 @@ import {
 import type { LegBReturnPath } from './leg-b-return-path.js';
 import { SWAP_INTAKE_EVENT, formatPairLabel } from './intake-event.js';
 import type { SwapIntakeClass } from './intake-event.js';
+import type { IntakeLedger } from './intake-ledger.js';
 
 /** Inner rumor kind of an RFQ request (spec §2.2). */
 export const ROLLING_RFQ_REQUEST_KIND = 20033;
@@ -304,6 +305,12 @@ export interface RollingRfqIntakeConfig {
     /** swap#152 — carries the `rolling-rfq` intake classification event. */
     info?: (msg: string, meta?: Record<string, unknown>) => void;
   };
+  /**
+   * Issue #171 — the durable intake ledger. Recorded alongside the
+   * `swap.intake.arrival` log line below, from the same site, so the two
+   * can never diverge.
+   */
+  intakeLedger?: IntakeLedger;
 }
 
 /** Accept/reject shape the packet handler returns, structurally. */
@@ -398,6 +405,7 @@ export function createRollingRfqIntake(config: RollingRfqIntakeConfig): {
         sender: arrival?.sourcePeer,
         ...(requestedPair !== undefined && { pair: requestedPair }),
       });
+      config.intakeLedger?.record('rolling-rfq');
 
       if (parsed === null || parsed === 'malformed') {
         // Kind:20033 is unambiguously rolling traffic. Falling through would

--- a/packages/swap/src/swap-node.admin-intake.test.ts
+++ b/packages/swap/src/swap-node.admin-intake.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Issue #171 (ADR 0003's removal gate) — `GET /admin/intake` + durability
+ * across a restart.
+ *
+ * swap#152 emitted `swap.intake.arrival` log lines, but the gate reads
+ * "no legacy for N consecutive days" and a log line dies with the
+ * container on every `swap:release` Watchtower recreate. These tests boot
+ * a real `startSwapNode()`, drive real packets through the connector-facing
+ * handler (matching `swap-node.intake.test.ts`), and assert on the
+ * PERSISTED read surface rather than the log — including across a
+ * simulated restart, which is the whole point of the ledger.
+ */
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { wrapSwapPacketToToon } from '@toon-protocol/sdk';
+import type { UnsignedEvent } from 'nostr-tools';
+import { schnorr } from '@noble/curves/secp256k1.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
+
+import { startSwapNode } from './swap-node.js';
+import type { SwapNodeConfig, SwapNodeInstance } from './swap-node.js';
+import { ROLLING_RFQ_REQUEST_KIND } from './rolling-rfq.js';
+import type { AdminIntakeReport } from './admin-surface.js';
+
+const VALID_MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const CHAIN = 'evm:8453';
+const CHAIN_RECIPIENT = '0x' + '11'.repeat(20);
+
+const tmpDirs: string[] = [];
+function makeTmpDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'swap-intake-admin-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+interface PacketRequest {
+  amount: string;
+  destination: string;
+  data: string;
+}
+interface PacketResponse {
+  accept: boolean;
+}
+type PacketHandlerFn = (
+  request: PacketRequest,
+  sourcePeer?: string
+) => Promise<PacketResponse>;
+
+async function bootNode(overrides?: Partial<SwapNodeConfig>): Promise<{
+  instance: SwapNodeInstance;
+  handler: PacketHandlerFn;
+}> {
+  let captured: PacketHandlerFn | undefined;
+  const connector = {
+    sendPacket: async () => ({
+      type: 'reject' as const,
+      code: 'F02',
+      message: 'no route (fixture)',
+    }),
+    registerPeer: async () => undefined,
+    removePeer: async () => undefined,
+    setPacketHandler: (h: unknown) => {
+      captured = h as PacketHandlerFn;
+    },
+    close: async () => undefined,
+  } as unknown as SwapNodeConfig['connector'];
+
+  const instance = await startSwapNode({
+    mnemonic: VALID_MNEMONIC,
+    connector,
+    swapPairs: [
+      {
+        from: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+        to: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+        rate: '1.0',
+        minAmount: '1000',
+        maxAmount: '25000000',
+      },
+    ],
+    chains: ['evm'],
+    channels: {
+      [CHAIN]: [
+        {
+          channelId: '0x' + 'cd'.repeat(32),
+          cumulativeAmount: 0n,
+          nonce: 0n,
+          updatedAt: 0,
+        },
+      ],
+    },
+    inventory: { [CHAIN]: 1_000_000_000n },
+    chainProviders: [
+      {
+        chainType: 'evm',
+        chainId: CHAIN,
+        rpcUrl: 'http://127.0.0.1:1',
+        registryAddress: '0x' + '11'.repeat(20),
+        tokenAddress: '0x' + '22'.repeat(20),
+        tokenNetworkAddress: '0x' + '44'.repeat(20),
+        channelAddress: '0x' + '33'.repeat(20),
+      },
+    ],
+    relayUrls: ['ws://localhost:0'],
+    blsPort: 0,
+    publisher: { publish: async () => undefined },
+    ...overrides,
+  });
+  if (!captured) throw new Error('setPacketHandler was never called');
+  return { instance, handler: captured };
+}
+
+function senderKeys(): { secretKey: Uint8Array; pubkey: string } {
+  const secretKey = schnorr.utils.randomSecretKey();
+  return { secretKey, pubkey: bytesToHex(schnorr.getPublicKey(secretKey)) };
+}
+
+function legacySwapDataB64(
+  senderSecretKey: Uint8Array,
+  makerPubkey: string
+): string {
+  const rumor = {
+    kind: 20032,
+    content: '',
+    tags: [
+      ['swap-from', `USDC:${CHAIN}`],
+      ['swap-to', `USDC:${CHAIN}`],
+      ['chain-recipient', CHAIN_RECIPIENT],
+    ],
+    created_at: Math.floor(Date.now() / 1000),
+    pubkey: '',
+  } as unknown as UnsignedEvent;
+  const { ilpPrepare } = wrapSwapPacketToToon({
+    rumor,
+    senderSecretKey,
+    recipientPubkey: makerPubkey,
+    destination: 'g.toon.swap.x',
+    amount: 1000n,
+  });
+  return ilpPrepare.data;
+}
+
+function rfqDataB64(senderSecretKey: Uint8Array, makerPubkey: string): string {
+  const rumor = {
+    kind: ROLLING_RFQ_REQUEST_KIND,
+    content: JSON.stringify({
+      proto: 'rolling/1',
+      type: 'rfq',
+      streamNonce: '2a'.repeat(16),
+      pair: {
+        from: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+        to: { assetCode: 'USDC', assetScale: 6, chain: CHAIN },
+      },
+      chainRecipient: CHAIN_RECIPIENT,
+      senderIlpAddress: 'g.toon.client.sender01',
+    }),
+    tags: [],
+    created_at: Math.floor(Date.now() / 1000),
+    pubkey: '',
+  } as unknown as UnsignedEvent;
+  const { ilpPrepare } = wrapSwapPacketToToon({
+    rumor,
+    senderSecretKey,
+    recipientPubkey: makerPubkey,
+    destination: 'g.toon.swap.x',
+    amount: 1000n,
+  });
+  return ilpPrepare.data;
+}
+
+async function fetchIntake(instance: SwapNodeInstance): Promise<AdminIntakeReport> {
+  const res = await fetch(`http://127.0.0.1:${instance.blsPort}/admin/intake`);
+  expect(res.status).toBe(200);
+  return (await res.json()) as AdminIntakeReport;
+}
+
+describe('GET /admin/intake', () => {
+  it('[P0] a fresh boot reports all four classes at zero, with `since` set', async () => {
+    const { instance } = await bootNode();
+    try {
+      const report = await fetchIntake(instance);
+      expect(report.classes.map((c) => c.class).sort()).toEqual(
+        ['legacy', 'refused', 'rolling-fill', 'rolling-rfq'].sort()
+      );
+      for (const c of report.classes) {
+        expect(c.count).toBe(0);
+        expect(c.firstSeenAt).toBeUndefined();
+        expect(c.lastSeenAt).toBeUndefined();
+      }
+      expect(report.since).toBeLessThanOrEqual(report.generatedAt);
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('[P0] a legacy arrival is reflected in the read surface, not just the log', async () => {
+    const sender = senderKeys();
+    const { instance, handler } = await bootNode();
+    try {
+      await handler({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: legacySwapDataB64(sender.secretKey, instance.identity.pubkey),
+      });
+      const report = await fetchIntake(instance);
+      const legacy = report.classes.find((c) => c.class === 'legacy');
+      expect(legacy?.count).toBe(1);
+      expect(legacy?.firstSeenAt).toBe(legacy?.lastSeenAt);
+      const rfq = report.classes.find((c) => c.class === 'rolling-rfq');
+      expect(rfq?.count).toBe(0);
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('[P0] a rolling-rfq arrival (classified inside rolling-rfq.ts) also lands in the ledger', async () => {
+    const sender = senderKeys();
+    const { instance, handler } = await bootNode();
+    try {
+      const res = await handler({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: rfqDataB64(sender.secretKey, instance.identity.pubkey),
+      });
+      expect(res.accept).toBe(true);
+      const report = await fetchIntake(instance);
+      const rfq = report.classes.find((c) => c.class === 'rolling-rfq');
+      expect(rfq?.count).toBe(1);
+    } finally {
+      await instance.stop();
+    }
+  });
+});
+
+describe('issue #171 — intake ledger durability across a restart', () => {
+  it('[P0] defaults beside statePath, and counts + `since` survive a simulated Watchtower recreate', async () => {
+    const dir = makeTmpDir();
+    const statePath = join(dir, 'swap-state.json');
+    const sender = senderKeys();
+
+    const first = await bootNode({ statePath });
+    let firstReport: AdminIntakeReport;
+    try {
+      await first.handler({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: legacySwapDataB64(sender.secretKey, first.instance.identity.pubkey),
+      });
+      firstReport = await fetchIntake(first.instance);
+      expect(firstReport.classes.find((c) => c.class === 'legacy')?.count).toBe(1);
+    } finally {
+      await first.instance.stop();
+    }
+
+    // The default ledger path lands beside statePath, on the same durable
+    // volume — not a location a Watchtower recreate wipes.
+    expect(existsSync(join(dir, 'intake-ledger.json'))).toBe(true);
+
+    // A fresh process, same statePath — exactly what a container recreate is.
+    const second = await bootNode({ statePath });
+    try {
+      const secondReport = await fetchIntake(second.instance);
+      const legacy = secondReport.classes.find((c) => c.class === 'legacy');
+      expect(legacy?.count).toBe(1);
+      expect(legacy?.lastSeenAt).toBe(firstReport.classes.find((c) => c.class === 'legacy')?.lastSeenAt);
+      expect(secondReport.since).toBe(firstReport.since);
+
+      await second.handler({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: legacySwapDataB64(sender.secretKey, second.instance.identity.pubkey),
+      });
+      const thirdReport = await fetchIntake(second.instance);
+      expect(thirdReport.classes.find((c) => c.class === 'legacy')?.count).toBe(2);
+    } finally {
+      await second.instance.stop();
+    }
+  });
+
+  it('[P1] an explicit intakeLedgerPath overrides the statePath-relative default', async () => {
+    const dir = makeTmpDir();
+    const statePath = join(dir, 'swap-state.json');
+    const intakeLedgerPath = join(dir, 'custom', 'ledger.json');
+
+    const { instance } = await bootNode({ statePath, intakeLedgerPath });
+    try {
+      expect(existsSync(intakeLedgerPath)).toBe(false); // nothing recorded yet
+    } finally {
+      await instance.stop();
+    }
+
+    const sender = senderKeys();
+    const second = await bootNode({ statePath, intakeLedgerPath });
+    try {
+      await second.handler({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: legacySwapDataB64(sender.secretKey, second.instance.identity.pubkey),
+      });
+      expect(existsSync(intakeLedgerPath)).toBe(true);
+      expect(existsSync(join(dir, 'intake-ledger.json'))).toBe(false);
+    } finally {
+      await second.instance.stop();
+    }
+  });
+
+  it('[P0] a corrupt intake-ledger file starts empty rather than crash the maker (contrast statePath)', async () => {
+    const dir = makeTmpDir();
+    const statePath = join(dir, 'swap-state.json');
+    const ledgerPath = join(dir, 'intake-ledger.json');
+    writeFileSync(ledgerPath, '{ not json', 'utf-8');
+
+    const { instance } = await bootNode({ statePath });
+    try {
+      const report = await fetchIntake(instance);
+      expect(report.classes.every((c) => c.count === 0)).toBe(true);
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('[P1] a ledger write failure never rejects a swap (record() is best-effort)', async () => {
+    const dir = makeTmpDir();
+    // Point the ledger at a path whose parent cannot be created (a file
+    // occupying where a directory needs to go), forcing every save() to
+    // throw — the swap must still be accepted.
+    const blockerFile = join(dir, 'blocker');
+    writeFileSync(blockerFile, 'x', 'utf-8');
+    const intakeLedgerPath = join(blockerFile, 'intake-ledger.json');
+
+    const sender = senderKeys();
+    const { instance, handler } = await bootNode({ intakeLedgerPath });
+    try {
+      const res = await handler({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: legacySwapDataB64(sender.secretKey, instance.identity.pubkey),
+      });
+      expect(res.accept).toBe(true);
+    } finally {
+      await instance.stop();
+    }
+  });
+
+  it('[P1] with no statePath and no intakeLedgerPath, the ledger still counts in-memory', async () => {
+    const sender = senderKeys();
+    const { instance, handler } = await bootNode();
+    try {
+      await handler({
+        amount: '1000',
+        destination: 'g.toon.swap.x',
+        data: legacySwapDataB64(sender.secretKey, instance.identity.pubkey),
+      });
+      const report = await fetchIntake(instance);
+      expect(report.classes.find((c) => c.class === 'legacy')?.count).toBe(1);
+    } finally {
+      await instance.stop();
+    }
+  });
+});

--- a/packages/swap/src/swap-node.admin-intake.test.ts
+++ b/packages/swap/src/swap-node.admin-intake.test.ts
@@ -177,7 +177,9 @@ function rfqDataB64(senderSecretKey: Uint8Array, makerPubkey: string): string {
   return ilpPrepare.data;
 }
 
-async function fetchIntake(instance: SwapNodeInstance): Promise<AdminIntakeReport> {
+async function fetchIntake(
+  instance: SwapNodeInstance
+): Promise<AdminIntakeReport> {
   const res = await fetch(`http://127.0.0.1:${instance.blsPort}/admin/intake`);
   expect(res.status).toBe(200);
   return (await res.json()) as AdminIntakeReport;
@@ -253,10 +255,15 @@ describe('issue #171 — intake ledger durability across a restart', () => {
       await first.handler({
         amount: '1000',
         destination: 'g.toon.swap.x',
-        data: legacySwapDataB64(sender.secretKey, first.instance.identity.pubkey),
+        data: legacySwapDataB64(
+          sender.secretKey,
+          first.instance.identity.pubkey
+        ),
       });
       firstReport = await fetchIntake(first.instance);
-      expect(firstReport.classes.find((c) => c.class === 'legacy')?.count).toBe(1);
+      expect(firstReport.classes.find((c) => c.class === 'legacy')?.count).toBe(
+        1
+      );
     } finally {
       await first.instance.stop();
     }
@@ -271,16 +278,23 @@ describe('issue #171 — intake ledger durability across a restart', () => {
       const secondReport = await fetchIntake(second.instance);
       const legacy = secondReport.classes.find((c) => c.class === 'legacy');
       expect(legacy?.count).toBe(1);
-      expect(legacy?.lastSeenAt).toBe(firstReport.classes.find((c) => c.class === 'legacy')?.lastSeenAt);
+      expect(legacy?.lastSeenAt).toBe(
+        firstReport.classes.find((c) => c.class === 'legacy')?.lastSeenAt
+      );
       expect(secondReport.since).toBe(firstReport.since);
 
       await second.handler({
         amount: '1000',
         destination: 'g.toon.swap.x',
-        data: legacySwapDataB64(sender.secretKey, second.instance.identity.pubkey),
+        data: legacySwapDataB64(
+          sender.secretKey,
+          second.instance.identity.pubkey
+        ),
       });
       const thirdReport = await fetchIntake(second.instance);
-      expect(thirdReport.classes.find((c) => c.class === 'legacy')?.count).toBe(2);
+      expect(thirdReport.classes.find((c) => c.class === 'legacy')?.count).toBe(
+        2
+      );
     } finally {
       await second.instance.stop();
     }
@@ -304,7 +318,10 @@ describe('issue #171 — intake ledger durability across a restart', () => {
       await second.handler({
         amount: '1000',
         destination: 'g.toon.swap.x',
-        data: legacySwapDataB64(sender.secretKey, second.instance.identity.pubkey),
+        data: legacySwapDataB64(
+          sender.secretKey,
+          second.instance.identity.pubkey
+        ),
       });
       expect(existsSync(intakeLedgerPath)).toBe(true);
       expect(existsSync(join(dir, 'intake-ledger.json'))).toBe(false);

--- a/packages/swap/src/swap-node.ts
+++ b/packages/swap/src/swap-node.ts
@@ -21,6 +21,8 @@
  * `SwapNodeInstance.stop()` idempotence guarantees.
  */
 
+import { dirname, join } from 'node:path';
+
 import { serve, type ServerType } from '@hono/node-server';
 import { Hono, type Context } from 'hono';
 import { SimplePool } from 'nostr-tools/pool';
@@ -115,6 +117,7 @@ import { createLegBReturnRouteBinder } from './leg-b-return-path.js';
 import type { LegBReturnRouteBinder } from './leg-b-return-path.js';
 import { SWAP_INTAKE_EVENT, formatPairLabel } from './intake-event.js';
 import type { SwapIntakeClass } from './intake-event.js';
+import { IntakeLedger, JsonFileIntakeLedgerStore } from './intake-ledger.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -370,6 +373,19 @@ export interface SwapNodeConfig {
    * `statePath`.
    */
   stateStore?: SwapStateStore;
+  /**
+   * Issue #171 (ADR 0003's removal gate) — path to the durable per-class
+   * intake ledger (counts + first/last-seen timestamps), read at
+   * `GET /admin/intake`. Defaults to `intake-ledger.json` beside
+   * `statePath` when `statePath` is set, so it lands on the same durable
+   * volume without a second required config key. When neither this nor
+   * `statePath` is set, the ledger still counts in-memory (no persistence
+   * — counts reset on restart, same fallback `statePath` itself has).
+   * Corruption/write failures never crash the maker or fail a swap — this
+   * is observability evidence, not a crash-consistency watermark (contrast
+   * `statePath`'s load-fails-loudly policy).
+   */
+  intakeLedgerPath?: string;
 
   // --- Rolling coupled-leg engine (issue #47, rolling-swap §3) ---
   /**
@@ -924,6 +940,16 @@ export function validateConfig(config: SwapNodeConfig): void {
       'SwapNodeConfig.statePath MUST be a non-empty string when set'
     );
   }
+  if (
+    config.intakeLedgerPath !== undefined &&
+    (typeof config.intakeLedgerPath !== 'string' ||
+      config.intakeLedgerPath.length === 0)
+  ) {
+    throw new SwapNodeStartError(
+      'INVALID_CONFIG',
+      'SwapNodeConfig.intakeLedgerPath MUST be a non-empty string when set'
+    );
+  }
 
   if (!Array.isArray(config.swapPairs) || config.swapPairs.length === 0) {
     throw new SwapNodeStartError(
@@ -1348,6 +1374,27 @@ export async function startSwapNode(
       });
     }
   }
+
+  // 4c. Issue #171 (ADR 0003's removal gate) — durable intake ledger.
+  //
+  // Defaults beside `statePath` so it lands on the SAME durable volume the
+  // maker's inventory/channel watermarks already survive a Watchtower
+  // recreate on, with no second required config key (swap#134). Unlike the
+  // state store above, a corrupt/unreadable ledger file starts empty rather
+  // than failing boot — this is observability evidence, not a
+  // crash-consistency watermark, and counting must never be able to fail
+  // an arrival.
+  const intakeLedgerPath =
+    config.intakeLedgerPath ??
+    (config.statePath !== undefined
+      ? join(dirname(config.statePath), 'intake-ledger.json')
+      : undefined);
+  const intakeLedger = new IntakeLedger({
+    ...(intakeLedgerPath !== undefined && {
+      store: new JsonFileIntakeLedgerStore(intakeLedgerPath),
+    }),
+    logger: { warn: logger.warn },
+  });
 
   // 5. Inventory — map operator-supplied `Record<chain, bigint>` into the
   //    `SwapInventory` per-asset/per-chain shape. We key off pair.to.assetCode
@@ -1985,6 +2032,7 @@ export async function startSwapNode(
     },
     ...(config.rolling?.rfq && { rfq: config.rolling.rfq }),
     logger: { debug: logger.debug, warn: logger.warn, info: logger.info },
+    intakeLedger,
   });
 
   // 11a. Wire the HandlerRegistry to the connector's local-delivery path.
@@ -2084,6 +2132,9 @@ export async function startSwapNode(
         sender: intakeSender,
         ...extra,
       });
+      // Issue #171 — the durable watermark ADR 0003's removal gate is
+      // actually read from; the log line above dies with the container.
+      intakeLedger.record(intakeClass);
     };
     /** The pair a fill's session was minted for — absent once it has expired. */
     const sessionPairLabel = (streamNonce: string): string | undefined =>
@@ -2401,6 +2452,7 @@ export async function startSwapNode(
   registerAdminRoutes(app, {
     inventory,
     reconciler,
+    intakeLedger,
     ...(config.adminToken !== undefined && { adminToken: config.adminToken }),
   });
 


### PR DESCRIPTION
Closes #171.

Produced by the `agent:implement` runner (run 32046818532), reviewer verdict **CLEAN**, branch pushed. The runner then crashed opening this PR — `gh pr list --head …` hit GitHub's transient GraphQL 503 (`.sandcastle/agent-implement-issue.ts:343`), so the work landed on the branch with no PR. Opening it by hand; see toon-protocol/toon-meta#420, which now covers this second failure site as well as the guard's.

Diff verified against the branch before opening: 13 files, +1139/-9, including `intake-ledger.ts` (+257) with `intake-ledger.test.ts` (+253) and `swap-node.admin-intake.test.ts` (+386).

🤖 Generated with [Claude Code](https://claude.com/claude-code)