### PR TITLE
docs: the README is a guide, and how-it-works explains the swap and the δ lever

### DIFF
--- a/.changeset/readme-guide.md
+++ b/.changeset/readme-guide.md
@@ -1,0 +1,9 @@
+---
+'@toon-protocol/swap': patch
+---
+
+The README is now a guide (what this is, try it on the devnet in 60 seconds, run a maker,
+choose δ, CLI reference, what is verified, state & resume), and `docs/how-it-works.md`
+explains the swap sequence and the δ lever in plain language, with the devnet measurements.
+A maker config may now omit `channels` for a chain whose `chainProviders[].channelDeposit`
+opens channels on demand (previously that was refused as `INVALID_CONFIG`).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,22 @@
 # swap
 
-TOON Protocol multi-chain swap node — @toon-protocol/swap (issues signed target-chain payment-channel claims; EVM/Solana/Mina).
+`@toon-protocol/swap` — swap USDC across chains through a TOON relay, with no server in
+between. A maker publishes an order; a taker streams it small fills; each side verifies the
+other's signed payment-channel claim; the newest claim is redeemed on chain once.
 
-In the TOON stack this is both sides of a **relay-mediated rolling swap**. A maker publishes an order on a TOON relay; a taker accepts it and streams fills — each fill a NIP-59 gift wrap carrying the taker's cumulative leg-A payment-channel claim, answered by one carrying the maker's cumulative leg-B claim on the target chain. Each party verifies the other's claim itself; the relay's [Rust connector](https://github.com/toon-protocol/connector) only charges carriage for the writes. The wire is `rolling/3` — see [`docs/relay-swap.md`](docs/relay-swap.md) for the design, `toon-swap make|orders|take|resume|redeem` for the CLI, and [`packages/swap/tests/e2e`](packages/swap/tests/e2e) for the cross-chain proof through a real relay (EVM↔Solana, redeemed on chain). toon-meta [`docs/rolling-swap.md`](https://github.com/toon-protocol/toon-meta/blob/main/docs/rolling-swap.md) is the protocol's history (`rolling/1`).
+| Start here | |
+| --- | --- |
+| **Guide** — install, try it on the devnet, run a maker, the CLI | [packages/swap/README.md](packages/swap/README.md) |
+| **How it works** — the sequence, and the one number you turn (δ) | [docs/how-it-works.md](docs/how-it-works.md) |
+| Design record — why the swap is relay-mediated, what does not change | [docs/relay-swap.md](docs/relay-swap.md) |
+| Operator & config reference | [deploy/swap/README.md](deploy/swap/README.md) |
+| The proof — EVM↔Solana through a real relay, redeemed on chain | [packages/swap/tests/e2e](packages/swap/tests/e2e) |
+| History — `rolling/1`, the protocol's first shape | toon-meta [docs/rolling-swap.md](https://github.com/toon-protocol/toon-meta/blob/main/docs/rolling-swap.md) |
 
-> Extracted from the TOON monorepo with full git history preserved. npm publishing is done by CI (changesets + `pnpm`, authed by the org `NPM_TOKEN` secret).
+Published on npm as [`@toon-protocol/swap`](https://www.npmjs.com/package/@toon-protocol/swap)
+by CI (changesets + `pnpm`, authed by the org `NPM_TOKEN` secret). The relay's
+[Rust connector](https://github.com/toon-protocol/connector) charges for each write and never
+opens a message.
 
 ## Getting started with Devbox
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,116 @@
+# How a swap works, and the one number you turn
+
+Two people trade USDC across two chains without a server between them. They pass signed
+claims through a mailbox, one small step at a time. This page shows the steps, and the one
+number you turn: **δ**, the size of one fill.
+
+> An interactive version of this page, with a slider for δ:
+> <https://claude.ai/code/artifact/c89ba851-e4d7-40cf-ada1-90299577b7e0>
+
+## The cast
+
+| Who | Role | What they hold |
+| --- | --- | --- |
+| **Taker** | Wants to swap. Reads orders, picks one, and sends the first claim in every step. | USDC on chain A |
+| **Maker** | Offers a price. Publishes an order. Answers each claim it receives with a claim of its own. | USDC on chain B |
+| **Relay** | A mailbox. Stores messages. Never opens them. Each write costs 1 µUSDC, paid by whoever writes. | — |
+| **Chain A · Chain B** | One payment channel each, between the two parties. A claim is a signed IOU against that channel. | the deposits |
+
+Nobody runs a server. The maker and the taker are both ordinary clients. Either one can close
+the laptop and come back later.
+
+## The sequence
+
+One swap of three fills. Every message after the order is sealed, so only the two parties can
+read it. The relay stores each message and charges 1 µUSDC to write it. The chains are touched
+only at the end.
+
+```mermaid
+sequenceDiagram
+    participant T as Taker
+    participant R as Relay (mailbox)
+    participant M as Maker
+    M->>R: 1 · order (public): pair, price, fill size min–max
+    Note over R: stored; the taker reads it here
+    T->>M: 2 · accept (sealed to the maker)
+    M->>T: 3 · quote: live price, fill bounds, chain facts
+    loop for fills 1, 2, 3 … (each fill is δ)
+        T->>M: 4 · fill i: the taker's claim on chain A, total so far = i × δ
+        Note over M: maker checks the claim itself
+        M->>T: 5 · advance i: the maker's claim on chain B, total so far = i × δ × price
+        Note over T: taker checks the claim itself
+    end
+    T->>M: 6 · done
+    Note over T: 7 · redeem once, on chain B, with the newest advance
+```
+
+1. **Maker** publishes an **order**. It is public. It says: which pair, what price, and how
+   small or large one fill may be.
+2. **Taker** sends an **accept**. It names the order and the taker's addresses on both chains.
+3. **Maker** answers with a **quote**: the live price and the facts the taker needs to check
+   every later claim.
+4. **Taker** sends **fill 1**: a signed claim on chain A for δ. The maker checks the signature,
+   the channel, and the deposit behind it before it counts.
+5. **Maker** answers with **advance 1**: a signed claim on chain B for δ × price. The taker
+   checks it the same way.
+6. Fill 2, advance 2, fill 3, advance 3 … Each claim is a **running total**, not a new amount.
+   The newest claim replaces the last. Only the newest one matters.
+7. When the total is reached, the taker sends **done** and takes its newest claim to chain B.
+   One transaction. The maker does the same on chain A whenever it likes.
+
+## What if someone stops?
+
+| Case | What happens |
+| --- | --- |
+| **The maker goes silent** | The taker moves first in every fill. So the most it can have paid for and not received is one fill: **δ**. Never more. |
+| **Someone goes offline** | The relay keeps every message. Either party can come back later, read what it missed, and continue from the last fill. |
+| **An answer is lost** | The taker re-sends the same fill. The maker recognises it and returns the same advance. Nothing is paid twice. |
+| **A state file is lost** | The taker's next claim is too low. The maker refuses it and says where the total stands. The taker adopts that and continues. |
+
+## The lever: δ
+
+δ is the size of one fill. It is the only number the taker turns. It sets three things at
+once, and you cannot move one without the others.
+
+For a swap of total size **S**, with **N = ⌈S / δ⌉** fills:
+
+| | Formula | Why |
+| --- | --- | --- |
+| **Exposure** | δ | The most you can lose if the maker stops: one fill. |
+| **Relay cost** | (2N + 3) µUSDC, i.e. ≈ (2 + 3/N) / δ of S | 2 writes per fill (fill, advance) + 3 per swap (accept, quote, done), 1 µUSDC each. |
+| **Time** | ≈ N × 0.37 s | One fill takes about 0.35 s on the devnet, whatever δ is. |
+
+**Small δ: safe, expensive, slow. Large δ: risky, cheap, fast.**
+
+That is the swap's slippage. The taker picks it per swap with `toon-swap take --delta`. The
+maker sets the floor in its order with `order.fill.min`, so nobody can make it sign thousands
+of near-zero claims at two writes each.
+
+### Measured on the TOON devnet
+
+10 fills per δ, price 0.99, Base Sepolia → Solana devnet, through the live relay.
+
+| δ (µUSDC) | per fill | fills / s | relay cost | cost as % of swap |
+| --- | --- | --- | --- | --- |
+| 2 | ~350 ms | 2.7 | 23 µUSDC | 115 % |
+| 100 | ~400 ms | 2.1 | 23 µUSDC | 2.3 % |
+| 1 000 | ~350 ms | 2.8 | 23 µUSDC | 0.23 % |
+| 10 000 | ~350 ms | 2.5 | 23 µUSDC | 0.023 % |
+| 100 000 | ~330 ms | 3.0 | 23 µUSDC | 0.002 % |
+
+Speed does not change with δ. Only the count of fills changes. δ = 1 is refused: at price
+0.99 it rounds to zero. Below about 100 µUSDC the relay cost is larger than the fill is worth.
+**The sweet spot is 1 000 – 10 000 µUSDC** (0.001 – 0.01 USDC): one fill of exposure you can
+afford to lose, under 0.25 % relay cost, and a 1 USDC swap in 40 seconds to 6 minutes.
+
+## What δ does not change
+
+Every claim is checked by the other party before it counts, at any δ. Only the newest claim is
+redeemed on chain, once, for the whole swap. δ sets only how much value is in flight between
+one fill and the next.
+
+---
+
+Under the hood: each sealed message is a NIP-59 gift wrap on a Nostr relay, and each write is
+paid over TOON's connector. The design record is [`relay-swap.md`](./relay-swap.md); the
+user guide is the [package README](../packages/swap/README.md).

--- a/docs/relay-swap.md
+++ b/docs/relay-swap.md
@@ -1,6 +1,7 @@
 # The swap is a relay-mediated client
 
-**Status:** decided and built in this repository (swap 3.0.0, 2026-08-28). Supersedes
+**Status:** decided and built in this repository (swap 3.0.0, 2026-08-28). New here? Read
+[How it works](./how-it-works.md) first, then the [guide](../packages/swap/README.md). Supersedes
 [`rust-connector-migration.md`](./rust-connector-migration.md) (the maker as an HTTP app behind a
 Rust connector), which never shipped.
 

--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -1,20 +1,190 @@
 # @toon-protocol/swap
 
-The TOON **swap maker**: quotes a pair, takes paid fills on one chain, and answers each fill
-with a cumulative payment-channel claim on the other (EVM / Solana / Mina leg B).
+**Swap USDC across chains through a relay, with no server in between.** A maker publishes an
+order; a taker streams it small fills. Each fill is a pair of signed payment-channel claims —
+the taker's on chain A, the maker's on chain B — passed through a TOON relay that stores
+messages but never opens them. Each side verifies the other's claim itself. Nothing touches a
+chain until the end, when the newest claim is redeemed once.
 
-It is a relay-mediated swap client — see [`docs/relay-swap.md`](../../docs/relay-swap.md) for the
-shape, the `rolling/3` wire it speaks (`src/wire.ts`), and how a maker and a taker find each
-other through a relay.
+Both roles live in this package: `toon-swap make` runs a maker, `toon-swap take` runs a taker.
+
+- **How it works** (the sequence, and the one number you turn) →
+  [docs/how-it-works.md](https://github.com/toon-protocol/swap/blob/main/docs/how-it-works.md)
+- Design record → [docs/relay-swap.md](https://github.com/toon-protocol/swap/blob/main/docs/relay-swap.md)
+- Operator & config reference → [deploy/swap/README.md](https://github.com/toon-protocol/swap/blob/main/deploy/swap/README.md)
+- Changelog → [packages/swap/CHANGELOG.md](https://github.com/toon-protocol/swap/blob/main/packages/swap/CHANGELOG.md)
+
+## Try it in 60 seconds (taker, TOON devnet)
+
+You need: **USDC on Base Sepolia and Solana devnet** (the
+[devnet faucet](https://faucet.devnet.toonprotocol.dev) drips it), and a little **native gas**
+on each chain (ETH on Base Sepolia, SOL on Solana devnet — the faucet does not drip gas).
 
 ```sh
-pnpm --filter @toon-protocol/swap test        # unit
-pnpm --filter @toon-protocol/swap test:e2e    # both chains, through a real relay and its connector
+npm i -g @toon-protocol/swap        # or: npx @toon-protocol/swap …
 ```
 
-The end-to-end suite (`tests/e2e/`) boots anvil, `solana-test-validator`, the `connector`
-binary or image, and `startSwapNode()` in-process, then swaps EVM→Solana and Solana→EVM and
-redeems every leg-B claim on chain. `tests/e2e/helpers` is the reference taker — what a client
-does to pay the maker's connector and verify what comes back.
+`swap.config.json`:
 
-Operator documentation: [`deploy/swap/README.md`](../../deploy/swap/README.md).
+```json
+{
+  "chains": ["evm", "solana"],
+  "chainProviders": [
+    {
+      "chainType": "evm",
+      "chainId": "evm:84532",
+      "rpcUrl": "https://base-sepolia-rpc.publicnode.com",
+      "registryAddress": "0x0c41D9D424d6B075A3cEa1068a694f7847a8CCa5",
+      "tokenAddress": "0x49beE1Bca5d15Fb0963117923403F9498119a9Ce",
+      "tokenNetworkAddress": "0xe9E05dfecfe165266C88d73e61D483612651952a"
+    },
+    {
+      "chainType": "solana",
+      "chainId": "solana:devnet",
+      "rpcUrl": "https://api.devnet.solana.com",
+      "programId": "2aEVJ8koKD8LTZrLRSGtAtU7LBt4e7QjjCgf1kzQ7Rip",
+      "tokenMint": "34eSxY7qxQ4GzyhDJ8GpUcTz1WWzruGbJbR8q6TtxfQU"
+    }
+  ],
+  "relay": {
+    "readUrl": "wss://relay-ws.devnet.toonprotocol.dev",
+    "connectorUrl": "https://proxy.relay.devnet.toonprotocol.dev/ilp",
+    "transport": "btp",
+    "payChain": "evm",
+    "deposit": "1000000"
+  },
+  "gasStation": {
+    "destination": "g.toon.relay.gas",
+    "connectorUrl": "https://proxy.gas.devnet.toonprotocol.dev/ilp"
+  },
+  "statePath": "./state/swap-state.json"
+}
+```
+
+Then:
+
+```sh
+# 1. Make an identity (written beside statePath, mode 600) and see the addresses to fund.
+SWAP_AUTOGEN_IDENTITY=1 toon-swap orders --config swap.config.json
+
+# 2. Pick an order from the list (printed as <makerPubkey>:<orderId>) and swap 1 USDC
+#    in fills of 0.005 USDC (amounts are base units: USDC has 6 decimals).
+SWAP_AUTOGEN_IDENTITY=1 toon-swap take --config swap.config.json \
+  --order <makerPubkey>:<orderId> --size 1000000 --delta 5000
+
+# 3. Take the newest claim to the target chain.
+SWAP_AUTOGEN_IDENTITY=1 toon-swap redeem --config swap.config.json --stream <streamNonce>
+```
+
+`take` prints the three numbers your δ implies before it starts — exposure, relay cost, ETA —
+and streams the fills. `redeem` pays out on EVM immediately; on Solana it records the claim,
+then `close` and (after the challenge window) `settle` pay out.
+
+> Instead of `SWAP_AUTOGEN_IDENTITY`, put `"mnemonic": "…"` in the config or set
+> `SWAP_MNEMONIC`. The same mnemonic yields the Nostr key that seals messages and the chain keys
+> that sign claims and pay for writes.
+
+## Run a maker
+
+A maker is the same program with an order to publish and capital to back it:
+
+```json
+{
+  "chains": ["evm", "solana"],
+  "swapPairs": [
+    {
+      "from": { "assetCode": "USDC", "assetScale": 6, "chain": "evm:84532" },
+      "to": { "assetCode": "USDC", "assetScale": 6, "chain": "solana:devnet" },
+      "rate": "0.99"
+    }
+  ],
+  "inventory": { "solana:devnet": "500000000" },
+  "channels": {},
+  "chainProviders": [ "…as above, plus \"channelDeposit\": \"50000000\" on each entry…" ],
+  "relay": { "…as above…" },
+  "order": { "fill": { "min": "1000", "max": "10000000" } },
+  "statePath": "./state/swap-state.json"
+}
+```
+
+```sh
+SWAP_AUTOGEN_IDENTITY=1 toon-swap make --config swap.config.json
+```
+
+| Key | What it does |
+| --- | --- |
+| `swapPairs`, `inventory` | What you sell, at what indicative rate, and how much target-chain capital you will issue against. |
+| `chainProviders[].channelDeposit` | Lets the maker open and fund its side of a channel with each taker **on demand**, at the taker's first verified fill, and top it up as needed. Without it, channels must be pre-opened under `channels`. |
+| `order.fill.min` / `max` | The smallest and largest fill a taker may send. The floor stops anyone making you sign thousands of near-zero claims. |
+| `relay` | Where orders and messages go. Without `relay.connectorUrl` the maker boots **offline** (health and admin only) and says so. |
+| `statePath` | Everything that must survive a restart: inventory, channel watermarks, sessions, orders. |
+
+`GET /health` on `appPort` (default 8080) shows the relay loop, published orders and per-taker
+watermarks. Full key list: [deploy/swap/README.md](https://github.com/toon-protocol/swap/blob/main/deploy/swap/README.md).
+
+## Choose δ (the lever)
+
+δ is the size of one fill. It sets three things at once. Small δ: safe, expensive, slow. Large
+δ: risky, cheap, fast.
+
+| | For a swap of size S with N = ⌈S/δ⌉ fills |
+| --- | --- |
+| **Exposure** | δ — the most you can lose if the maker stops: one fill. |
+| **Relay cost** | (2N + 3) µUSDC — two writes per fill, three per swap, 1 µUSDC each. |
+| **Time** | ≈ N × 0.37 s — ~350 ms per fill on the devnet, whatever δ is. |
+
+Sweet spot on the devnet: **δ = 1 000 – 10 000 µUSDC** (0.001 – 0.01 USDC): under 0.25 %
+relay cost and a 1 USDC swap in 40 s – 6 min. Measurements and the reasoning:
+[docs/how-it-works.md](https://github.com/toon-protocol/swap/blob/main/docs/how-it-works.md#the-lever-δ).
+
+## CLI
+
+Every command takes `--config <path>` (default `./swap.config.json`).
+
+| Command | Does |
+| --- | --- |
+| `toon-swap make` | Run a maker: publish orders, answer fills. (Also the default when no command is given.) |
+| `toon-swap orders [--json]` | List live orders on the relay. |
+| `toon-swap take --order <maker>:<orderId> --size <units> [--delta <units>] [--recipient <addr>] [--json]` | Accept an order and stream the fills. |
+| `toon-swap resume --stream <streamNonce> [--json]` | Continue a session from disk after a stop, crash, or lost answer. |
+| `toon-swap redeem --stream <streamNonce> [--via own\|gas-station] [--no-fallback]` | Redeem the newest claim on chain. `--via gas-station` asks the gas station to pay the fee; it falls back to your own gas unless `--no-fallback`. |
+| `toon-swap close --stream <streamNonce>` | Solana: start the channel's challenge window. |
+| `toon-swap settle --stream <streamNonce>` | Solana: pay out after the window. |
+| `toon-swap sessions [--json]` | Your sessions and channel watermarks. |
+
+Environment overrides: `SWAP_MNEMONIC`, `SWAP_AUTOGEN_IDENTITY`, `SWAP_IDENTITY_FILE`,
+`SWAP_STATE_PATH`, `SWAP_RELAY_READ_URL`, `SWAP_RELAY_CONNECTOR_URL`, `SWAP_FILL_MIN`,
+`SWAP_FILL_MAX`, `SWAP_LOG_LEVEL`.
+
+## What is verified
+
+Nobody verifies for you. Before a claim counts, the party receiving it checks:
+
+- **the signature**, against the counterparty bound when the session opened — before any chain read;
+- **the channel**, re-derived from the two participants, never taken from the message;
+- **the money**: the claim's total is above the last accepted total by at least the fill, and the
+  counterparty's on-chain deposit covers it. Chain reads are cached and budgeted per counterparty.
+
+The relay's connector only checks that each write was paid for. It never sees a swap claim.
+
+## State & resume
+
+The taker keeps `<statePath minus .json>.taker.json`: every session, and one watermark per
+channel so it never signs a claim below one it already sent. A fill is written to disk **before**
+it is published. The maker keeps `statePath`: inventory, channel watermarks, sessions, per-taker
+inbound watermarks, the relay cursor and its published orders.
+
+After any stop, `toon-swap resume --stream <nonce>` re-quotes, reads what the relay kept, and
+continues. A re-sent fill gets the same answer; a lost state file is re-synced from the maker's
+refusal. Your money is never in a message that can be replayed — only in the newest claim, which
+you redeem once.
+
+## Develop
+
+```sh
+pnpm --filter @toon-protocol/swap test        # unit (in-memory relay, real signatures)
+pnpm --filter @toon-protocol/swap test:e2e    # real relay + connector + anvil + solana-test-validator
+```
+
+The e2e suite swaps EVM→Solana and Solana→EVM through a real relay and redeems every claim on
+chain; `tests/e2e/devnet-swap.e2e.test.ts` (opt-in) does the same against the live devnet.

--- a/packages/swap/src/swap-node.ts
+++ b/packages/swap/src/swap-node.ts
@@ -596,7 +596,8 @@ export function validateConfig(config: SwapNodeConfig): void {
         `SwapNodeConfig.chains missing family "${fam}" required by pair.to.chain=${chain}`
       );
     }
-    const chanList = config.channels[chain];
+    // A chain with no `channels` entry means "none pre-opened" — fine when `channelDeposit` opens them on demand.
+    const chanList = config.channels[chain] ?? [];
     const onDemand =
       (fam === 'evm' &&
         findChainProvider(config.chainProviders, 'evm', chain)


### PR DESCRIPTION
The package README (what npm renders) becomes a guide — what this is, try it on the TOON devnet in 60 seconds with the real endpoints, run a maker, choose δ, the CLI reference, what is verified, state & resume — and a new `docs/how-it-works.md` explains the swap sequence and the δ lever in plain language with the devnet measurements (same content as the interactive page it links to). The root README is now a landing page.

One small code change so the guide's maker example is honest: a maker config may omit `channels` for a chain whose `channelDeposit` opens channels on demand; `validateConfig` refused that before.

Patch changeset → 3.0.1, so npm shows the new README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117t8EFQSwtbX7RASqMJkfH